### PR TITLE
Avoid using make for building simdcomp

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,36 +1,49 @@
-#[cfg(feature= "simdcompression")]
+#[cfg(feature = "simdcompression")]
 mod build {
     extern crate gcc;
 
-    use std::process::Command;
-
     pub fn build() {
-        Command::new("make")
-            .current_dir("cpp/simdcomp")
-            .output()
-            .unwrap_or_else(|e| { panic!("Failed to make simdcomp: {}", e) });
-        gcc::Config::new()
-                    .flag("-O3")
-                    .flag("-mssse3")
-                    .include("./cpp/simdcomp/include")
-                    .object("cpp/simdcomp/avxbitpacking.o")
-                    .object("cpp/simdcomp/simdintegratedbitpacking.o")
-                    .object("cpp/simdcomp/simdbitpacking.o")
-                    .object("cpp/simdcomp/simdpackedsearch.o")
-                    .object("cpp/simdcomp/simdcomputil.o")
-                    .object("cpp/simdcomp/simdpackedselect.o")
-                    .object("cpp/simdcomp/simdfor.o")
-                    .file("cpp/simdcomp_wrapper.c")
-                    .compile("libsimdcomp.a");
+        let mut config = gcc::Config::new();
+        config.include("./cpp/simdcomp/include")
+            .file("cpp/simdcomp/src/avxbitpacking.c")
+            .file("cpp/simdcomp/src/simdintegratedbitpacking.c")
+            .file("cpp/simdcomp/src/simdbitpacking.c")
+            .file("cpp/simdcomp/src/simdpackedsearch.c")
+            .file("cpp/simdcomp/src/simdcomputil.c")
+            .file("cpp/simdcomp/src/simdpackedselect.c")
+            .file("cpp/simdcomp/src/simdfor.c")
+            .file("cpp/simdcomp_wrapper.c");
+
+        if !cfg!(debug_assertions) {
+            config.opt_level(3);
+
+            if cfg!(target_env = "msvc") {
+                config.define("NDEBUG", None)
+                    .flag("/Gm-")
+                    .flag("/GS-")
+                    .flag("/Gy")
+                    .flag("/Oi")
+                    .flag("/GL");
+            } else {
+                config.flag("-msse4.1")
+                    .flag("-march=native");
+            }
+        }
+
+        config.compile("libsimdcomp.a");
+
+        // Workaround for linking static libraries built with /GL
+        // https://github.com/rust-lang/rust/issues/26003
+        if !cfg!(debug_assertions) && cfg!(target_env = "msvc") {
+            println!("cargo:rustc-link-lib=dylib=simdcomp");
+        }
     }
 }
 
-#[cfg(not(feature= "simdcompression"))]
+#[cfg(not(feature = "simdcompression"))]
 mod build {
-    pub fn build() {
-    }
+    pub fn build() {}
 }
-
 
 fn main() {
     build::build();

--- a/src/compression/compression_simd.rs
+++ b/src/compression/compression_simd.rs
@@ -5,7 +5,6 @@ const COMPRESSED_BLOCK_MAX_SIZE: usize = NUM_DOCS_PER_BLOCK * 4 + 1;
 mod simdcomp {
     use libc::size_t;
 
-    #[link(name = "simdcomp")]
     extern {
         pub fn compress_sorted(
             data: *const u32,


### PR DESCRIPTION
Fixes #69 

I kept the aggressive optimizations, `-msse4.1` and `-march=native` from the `simdcomp` `Makefile`s. We might want to revisit this later.