### PR TITLE
Pretty print meta.json

### DIFF
--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -77,7 +77,7 @@ pub fn save_metas(segment_metas: Vec<SegmentMeta>,
         schema: schema,
         opstamp: opstamp,
     };
-    let mut w = try!(serde_json::to_vec(&metas));
+    let mut w = try!(serde_json::to_vec_pretty(&metas));
     try!(write!(&mut w, "\n"));
     let res = directory.atomic_write(&META_FILEPATH, &w[..])?;
     debug!("Saved metas {:?}", serde_json::to_string_pretty(&metas));


### PR DESCRIPTION
Pretty print the meta document, like it was in the `rustc_serialize` days.