### PR TITLE
FIXED inconsistent Term's field serialization.

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -27,20 +27,6 @@ pub trait HasLen {
     }
 }
 
-
-/// Creates an uninitialized Vec of a given usize
-///
-/// `allocate_vec` does an unsafe call to `set_len`
-/// as other solution are extremely slow in debug mode.
-pub fn allocate_vec<T>(capacity: usize) -> Vec<T> {
-    let mut v = Vec::with_capacity(capacity);
-    unsafe {
-        v.set_len(capacity);
-    }
-    v
-}
-
-
 const HIGHEST_BIT: u64 = 1 << 63;
 
 

--- a/src/core/term_iterator.rs
+++ b/src/core/term_iterator.rs
@@ -175,9 +175,7 @@ mod tests {
         let mut term_it = searcher.terms();
         let mut terms = String::new();
         while let Some(term) = term_it.next() {
-            unsafe {
-                terms.push_str(term.text());
-            }
+            terms.push_str(term.text());
         }
         assert_eq!(terms, "abcdef");
     }

--- a/src/datastruct/stacker/heap.rs
+++ b/src/datastruct/stacker/heap.rs
@@ -1,6 +1,5 @@
 use std::cell::UnsafeCell;
 use std::mem;
-use common::allocate_vec;
 use std::ptr;
 
 /// `BytesRef` refers to a slice in tantivy's custom `Heap`.
@@ -109,7 +108,7 @@ struct InnerHeap {
 impl InnerHeap {
 
     pub fn with_capacity(num_bytes: usize) -> InnerHeap {
-        let buffer: Vec<u8> = allocate_vec(num_bytes);
+        let buffer: Vec<u8> = vec![0u8; num_bytes];
         InnerHeap {
             buffer: buffer,
             buffer_len: num_bytes as u32,

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -17,7 +17,6 @@ use fastfield::FastFieldSerializer;
 use fastfield::FastFieldReader;
 use store::StoreWriter;
 use std::cmp::{min, max};
-use common::allocate_vec;
 
 pub struct IndexMerger {
     schema: Schema,
@@ -33,7 +32,7 @@ struct DeltaPositionComputer {
 impl DeltaPositionComputer {
     fn new() -> DeltaPositionComputer {
         DeltaPositionComputer { 
-            buffer: allocate_vec(512)
+            buffer: vec![0u32; 512]
         }
     }
 

--- a/src/postings/postings_writer.rs
+++ b/src/postings/postings_writer.rs
@@ -39,7 +39,8 @@ pub trait PostingsWriter {
                       -> u32 {
         let mut pos = 0u32;
         let mut num_tokens: u32 = 0u32;
-        let mut term = Term::allocate(field, 100);
+        let mut term = unsafe { Term::with_capacity(100) };
+        term.set_field(field);
         for field_value in field_values {
             let mut tokens = SimpleTokenizer.tokenize(field_value.value().text());
             // right now num_tokens and pos are redundant, but it should
@@ -118,7 +119,7 @@ impl<'a, Rec: Recorder + 'static> PostingsWriter for SpecializedPostingsWriter<'
             .iter()
             .collect();
         term_offsets.sort_by_key(|&(k, _v)| k);
-        let mut term = Term::allocate(Field(0), 100);
+        let mut term = unsafe { Term::with_capacity(100) };
         for (term_bytes, (addr, recorder)) in term_offsets {
             // sadly we are required to copy the data
             term.set_content(term_bytes);

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -99,8 +99,7 @@ impl Term {
     /// It is declared unsafe, as the term content
     /// is not initialized, and a call to `.field()`
     /// would panic.
-    #[doc(hidden)]
-    pub unsafe fn with_capacity(num_bytes: usize) -> Term {
+    pub(crate) unsafe fn with_capacity(num_bytes: usize) -> Term {
         Term(Vec::with_capacity(num_bytes))
     }
 


### PR DESCRIPTION
Also.

Cleaned up the code to make sure that the logic
is only in one place.
Removed allocate_vec

Closes #141
Closes #139
Closes #142
Closes #138