### PR TITLE
Use error-chain for root Error type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Cargo.lock
 benchmark
 .DS_Store
 cpp/simdcomp/bitpackingbenchmark
+*.bk

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ version = "2"
 crossbeam = "0.2"
 futures = "0.1.9"
 futures-cpupool = "0.1.2"
+error-chain = "0.8.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ uuid = { version = "0.5", features = ["v4", "serde"] }
 chan = "0.1"
 version = "2"
 crossbeam = "0.2"
-futures = "0.1.9"
-futures-cpupool = "0.1.2"
-error-chain = "0.8.1"
+futures = "0.1"
+futures-cpupool = "0.1"
+error-chain = "0.8"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2"

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -29,8 +29,7 @@ const NUM_SEARCHERS: usize = 12;
 fn load_metas(directory: &Directory) -> Result<IndexMeta> {
     let meta_data = directory.atomic_read(&META_FILEPATH)?;
     let meta_string = String::from_utf8_lossy(&meta_data);
-    serde_json::from_str(&meta_string)
-        .chain_err(|| ErrorKind::CorruptedFile(META_FILEPATH.clone()))
+    serde_json::from_str(&meta_string).chain_err(|| ErrorKind::CorruptedFile(META_FILEPATH.clone()))
 }
 
 /// Tantivy's Search Index

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -1,5 +1,5 @@
 use Result;
-use error::*;
+use error::{ErrorKind, ResultExt};
 use serde_json;
 use schema::Schema;
 use std::sync::Arc;

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -1,5 +1,5 @@
 use Result;
-use Error;
+use error::*;
 use serde_json;
 use schema::Schema;
 use std::sync::Arc;
@@ -30,7 +30,7 @@ fn load_metas(directory: &Directory) -> Result<IndexMeta> {
     let meta_data = directory.atomic_read(&META_FILEPATH)?;
     let meta_string = String::from_utf8_lossy(&meta_data);
     serde_json::from_str(&meta_string)
-        .map_err(|e| Error::CorruptedFile(META_FILEPATH.clone(), Box::new(e)))
+        .chain_err(|| ErrorKind::CorruptedFile(META_FILEPATH.clone()))
 }
 
 /// Tantivy's Search Index

--- a/src/directory/error.rs
+++ b/src/directory/error.rs
@@ -197,9 +197,7 @@ impl fmt::Display for DeleteError {
                 write!(f, "the file '{:?}' is protected and can't be deleted", path)
             }
             DeleteError::IOError(ref err) => {
-                write!(f,
-                       "an io error occurred while deleting a file: '{}'",
-                       err)
+                write!(f, "an io error occurred while deleting a file: '{}'", err)
             }
         }
     }

--- a/src/directory/error.rs
+++ b/src/directory/error.rs
@@ -30,10 +30,7 @@ impl StdError for IOError {
 }
 
 impl IOError {
-    pub(crate) fn with_path(
-                            path: PathBuf,
-                            err: io::Error)
-                            -> Self {
+    pub(crate) fn with_path(path: PathBuf, err: io::Error) -> Self {
         IOError {
             path: Some(path),
             err: err,
@@ -62,8 +59,12 @@ pub enum OpenDirectoryError {
 impl fmt::Display for OpenDirectoryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            OpenDirectoryError::DoesNotExist(ref path) => write!(f, "the underlying directory '{:?}' does not exist", path),
-            OpenDirectoryError::NotADirectory(ref path) => write!(f, "the path '{:?}' exists but is not a directory", path)
+            OpenDirectoryError::DoesNotExist(ref path) => {
+                write!(f, "the underlying directory '{:?}' does not exist", path)
+            }
+            OpenDirectoryError::NotADirectory(ref path) => {
+                write!(f, "the path '{:?}' exists but is not a directory", path)
+            }
         }
     }
 }
@@ -98,8 +99,14 @@ impl From<IOError> for OpenWriteError {
 impl fmt::Display for OpenWriteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            OpenWriteError::FileAlreadyExists(ref path) => write!(f, "the file '{:?}' already exists", path),
-            OpenWriteError::IOError(ref err) => write!(f, "an io error occurred while opening a file for writing: '{}'", err)
+            OpenWriteError::FileAlreadyExists(ref path) => {
+                write!(f, "the file '{:?}' already exists", path)
+            }
+            OpenWriteError::IOError(ref err) => {
+                write!(f,
+                       "an io error occurred while opening a file for writing: '{}'",
+                       err)
+            }
         }
     }
 }
@@ -112,7 +119,7 @@ impl StdError for OpenWriteError {
     fn cause(&self) -> Option<&StdError> {
         match *self {
             OpenWriteError::FileAlreadyExists(_) => None,
-            OpenWriteError::IOError(ref err) => Some(err)
+            OpenWriteError::IOError(ref err) => Some(err),
         }
     }
 }
@@ -136,8 +143,14 @@ impl From<IOError> for OpenReadError {
 impl fmt::Display for OpenReadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            OpenReadError::FileDoesNotExist(ref path) => write!(f, "the file '{:?}' does not exist", path),
-            OpenReadError::IOError(ref err) => write!(f, "an io error occurred while opening a file for reading: '{}'", err)
+            OpenReadError::FileDoesNotExist(ref path) => {
+                write!(f, "the file '{:?}' does not exist", path)
+            }
+            OpenReadError::IOError(ref err) => {
+                write!(f,
+                       "an io error occurred while opening a file for reading: '{}'",
+                       err)
+            }
         }
     }
 }
@@ -150,7 +163,7 @@ impl StdError for OpenReadError {
     fn cause(&self) -> Option<&StdError> {
         match *self {
             OpenReadError::FileDoesNotExist(_) => None,
-            OpenReadError::IOError(ref err) => Some(err)
+            OpenReadError::IOError(ref err) => Some(err),
         }
     }
 }
@@ -177,9 +190,17 @@ impl From<IOError> for DeleteError {
 impl fmt::Display for DeleteError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            DeleteError::FileDoesNotExist(ref path) => write!(f, "the file '{:?}' does not exist", path),
-            DeleteError::FileProtected(ref path) => write!(f, "the file '{:?}' is protected and can't be deleted", path),
-            DeleteError::IOError(ref err) => write!(f, "an io error occurred while opening a file for reading: '{}'", err)
+            DeleteError::FileDoesNotExist(ref path) => {
+                write!(f, "the file '{:?}' does not exist", path)
+            }
+            DeleteError::FileProtected(ref path) => {
+                write!(f, "the file '{:?}' is protected and can't be deleted", path)
+            }
+            DeleteError::IOError(ref err) => {
+                write!(f,
+                       "an io error occurred while opening a file for reading: '{}'",
+                       err)
+            }
         }
     }
 }
@@ -191,8 +212,9 @@ impl StdError for DeleteError {
 
     fn cause(&self) -> Option<&StdError> {
         match *self {
-            DeleteError::FileDoesNotExist(_) | DeleteError::FileProtected(_) => None,
-            DeleteError::IOError(ref err) => Some(err)
+            DeleteError::FileDoesNotExist(_) |
+            DeleteError::FileProtected(_) => None,
+            DeleteError::IOError(ref err) => Some(err),
         }
     }
 }

--- a/src/directory/error.rs
+++ b/src/directory/error.rs
@@ -191,8 +191,7 @@ impl StdError for DeleteError {
 
     fn cause(&self) -> Option<&StdError> {
         match *self {
-            DeleteError::FileDoesNotExist(_) => None,
-            DeleteError::FileProtected(ref path) => None,
+            DeleteError::FileDoesNotExist(_) | DeleteError::FileProtected(_) => None,
             DeleteError::IOError(ref err) => Some(err)
         }
     }

--- a/src/directory/error.rs
+++ b/src/directory/error.rs
@@ -198,7 +198,7 @@ impl fmt::Display for DeleteError {
             }
             DeleteError::IOError(ref err) => {
                 write!(f,
-                       "an io error occurred while opening a file for reading: '{}'",
+                       "an io error occurred while deleting a file: '{}'",
                        err)
             }
         }
@@ -207,7 +207,7 @@ impl fmt::Display for DeleteError {
 
 impl StdError for DeleteError {
     fn description(&self) -> &str {
-        "error occurred while opening a file for reading"
+        "error occurred while deleting a file"
     }
 
     fn cause(&self) -> Option<&StdError> {

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -229,7 +229,8 @@ impl Directory for ManagedDirectory {
     }
 
     fn open_write(&mut self, path: &Path) -> result::Result<WritePtr, OpenWriteError> {
-        self.register_file_as_managed(path).map_err(|e| IOError::with_path(path.to_owned(), e))?;
+        self.register_file_as_managed(path)
+            .map_err(|e| IOError::with_path(path.to_owned(), e))?;
         self.directory.open_write(path)
     }
 

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -12,7 +12,7 @@ use std::io::Write;
 use core::MANAGED_FILEPATH;
 use std::collections::HashMap;
 use std::fmt;
-use error::*;
+use error::{Result, ErrorKind, ResultExt};
 
 /// Wrapper of directories that keeps track of files created by Tantivy.
 ///

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use serde_json;
-use directory::error::{OpenReadError, DeleteError, OpenWriteError};
+use directory::error::{IOError, OpenReadError, DeleteError, OpenWriteError};
 use directory::{ReadOnlySource, WritePtr};
 use std::result;
 use std::io;
@@ -12,8 +12,7 @@ use std::io::Write;
 use core::MANAGED_FILEPATH;
 use std::collections::HashMap;
 use std::fmt;
-use Result;
-use Error;
+use error::*;
 
 /// Wrapper of directories that keeps track of files created by Tantivy.
 ///
@@ -86,7 +85,7 @@ impl ManagedDirectory {
                 let managed_files_json = String::from_utf8_lossy(&data);
                 let managed_files: HashSet<PathBuf> =
                     serde_json::from_str(&managed_files_json)
-                        .map_err(|e| Error::CorruptedFile(MANAGED_FILEPATH.clone(), Box::new(e)))?;
+                        .chain_err(|| ErrorKind::CorruptedFile(MANAGED_FILEPATH.clone()))?;
                 Ok(ManagedDirectory {
                        directory: box directory,
                        meta_informations: Arc::new(RwLock::new(MetaInformation {
@@ -230,7 +229,7 @@ impl Directory for ManagedDirectory {
     }
 
     fn open_write(&mut self, path: &Path) -> result::Result<WritePtr, OpenWriteError> {
-        self.register_file_as_managed(path)?;
+        self.register_file_as_managed(path).map_err(|e| IOError::with_path(path.to_owned(), e))?;
         self.directory.open_write(path)
     }
 

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -1,7 +1,7 @@
 use atomicwrites;
 use common::make_io_err;
 use directory::Directory;
-use directory::error::{OpenWriteError, OpenReadError, DeleteError, OpenDirectoryError};
+use directory::error::{IOError, OpenWriteError, OpenReadError, DeleteError, OpenDirectoryError};
 use directory::ReadOnlySource;
 use directory::shared_vec_slice::SharedVecSlice;
 use directory::WritePtr;
@@ -24,13 +24,15 @@ use std::sync::Weak;
 use tempdir::TempDir;
 
 fn open_mmap(full_path: &PathBuf) -> result::Result<Option<Arc<Mmap>>, OpenReadError> {
-    let convert_file_error = |err: io::Error| if err.kind() == io::ErrorKind::NotFound {
-        OpenReadError::FileDoesNotExist(full_path.clone())
-    } else {
-        OpenReadError::IOError(err)
-    };
-    let file = File::open(&full_path).map_err(convert_file_error)?;
-    let meta_data = file.metadata().map_err(OpenReadError::IOError)?;
+    let file = File::open(&full_path).map_err(|e| {
+        if e.kind() == io::ErrorKind::NotFound {
+            OpenReadError::FileDoesNotExist(full_path.clone())
+        } else {
+            OpenReadError::IOError(IOError::with_path(full_path.to_owned(), e))
+        }
+    })?;
+
+    let meta_data = file.metadata().map_err(|e| IOError::with_path(full_path.to_owned(), e))?;
     if meta_data.len() == 0 {
         // if the file size is 0, it will not be possible
         // to mmap the file, so we return an anonymous mmap_cache
@@ -39,7 +41,7 @@ fn open_mmap(full_path: &PathBuf) -> result::Result<Option<Arc<Mmap>>, OpenReadE
     }
     match Mmap::open(&file, Protection::Read) {
         Ok(mmap) => Ok(Some(Arc::new(mmap))),
-        Err(e) => Err(OpenReadError::IOError(e)),
+        Err(e) => Err(IOError::with_path(full_path.to_owned(), e))?,
     }
 
 }
@@ -274,7 +276,7 @@ impl Directory for MmapDirectory {
                          let msg = format!("Failed to acquired write lock \
                                             on mmap cache while reading {:?}",
                                            path);
-                         OpenReadError::IOError(make_io_err(msg))
+                         IOError::with_path(path.to_owned(), make_io_err(msg))
                      })?;
 
         Ok(mmap_cache
@@ -295,17 +297,17 @@ impl Directory for MmapDirectory {
 
         let mut file = open_res
             .map_err(|err| if err.kind() == io::ErrorKind::AlreadyExists {
-                         OpenWriteError::FileAlreadyExists(PathBuf::from(path))
+                         OpenWriteError::FileAlreadyExists(path.to_owned())
                      } else {
-                         OpenWriteError::IOError(err)
+                         IOError::with_path(path.to_owned(), err).into()
                      })?;
 
         // making sure the file is created.
-        try!(file.flush());
+        file.flush().map_err(|e| IOError::with_path(path.to_owned(), e))?;
 
         // Apparetntly, on some filesystem syncing the parent
         // directory is required.
-        try!(self.sync_directory());
+        self.sync_directory().map_err(|e| IOError::with_path(path.to_owned(), e))?;
 
         let writer = SafeFileWriter::new(file);
         Ok(BufWriter::new(Box::new(writer)))
@@ -320,19 +322,19 @@ impl Directory for MmapDirectory {
                          let msg = format!("Failed to acquired write lock \
                                             on mmap cache while deleting {:?}",
                                            path);
-                         DeleteError::IOError(make_io_err(msg))
+                         IOError::with_path(path.to_owned(), make_io_err(msg))
                      })?;
         // Removing the entry in the MMap cache.
         // The munmap will appear on Drop,
         // when the last reference is gone.
         mmap_cache.cache.remove(&full_path);
         match fs::remove_file(&full_path) {
-            Ok(_) => self.sync_directory().map_err(DeleteError::IOError),
+            Ok(_) => self.sync_directory().map_err(|e| IOError::with_path(path.to_owned(), e).into()),
             Err(e) => {
                 if e.kind() == io::ErrorKind::NotFound {
                     Err(DeleteError::FileDoesNotExist(path.to_owned()))
                 } else {
-                    Err(DeleteError::IOError(e))
+                    Err(IOError::with_path(path.to_owned(), e).into())
                 }
             }
         }
@@ -349,14 +351,14 @@ impl Directory for MmapDirectory {
         match File::open(&full_path) {
             Ok(mut file) => {
                 file.read_to_end(&mut buffer)
-                    .map_err(OpenReadError::IOError)?;
+                    .map_err(|e| IOError::with_path(path.to_owned(), e))?;
                 Ok(buffer)
             }
             Err(e) => {
                 if e.kind() == io::ErrorKind::NotFound {
                     Err(OpenReadError::FileDoesNotExist(path.to_owned()))
                 } else {
-                    Err(OpenReadError::IOError(e))
+                    Err(IOError::with_path(path.to_owned(), e).into())
                 }
             }
         }

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -6,7 +6,7 @@ use std::result;
 use std::sync::{Arc, RwLock};
 use common::make_io_err;
 use directory::{Directory, ReadOnlySource};
-use directory::error::{OpenWriteError, OpenReadError, DeleteError};
+use directory::error::{IOError, OpenWriteError, OpenReadError, DeleteError};
 use directory::WritePtr;
 use super::shared_vec_slice::SharedVecSlice;
 
@@ -97,7 +97,7 @@ impl InnerDirectory {
                                             directory when trying to read {:?}",
                                            path);
                          let io_err = make_io_err(msg);
-                         OpenReadError::IOError(io_err)
+                         OpenReadError::IOError(IOError::with_path(path.to_owned(), io_err))
                      })
             .and_then(|readable_map| {
                 readable_map
@@ -115,7 +115,7 @@ impl InnerDirectory {
                                             directory when trying to delete {:?}",
                                            path);
                          let io_err = make_io_err(msg);
-                         DeleteError::IOError(io_err)
+                         DeleteError::IOError(IOError::with_path(path.to_owned(), io_err))
                      })
             .and_then(|mut writable_map| match writable_map.remove(path) {
                           Some(_) => Ok(()),
@@ -163,8 +163,11 @@ impl Directory for RAMDirectory {
     fn open_write(&mut self, path: &Path) -> Result<WritePtr, OpenWriteError> {
         let path_buf = PathBuf::from(path);
         let vec_writer = VecWriter::new(path_buf.clone(), self.fs.clone());
+
+        let exists = self.fs.write(path_buf.clone(), &Vec::new()).map_err(|err| IOError::with_path(path.to_owned(), err))?;
+
         // force the creation of the file to mimic the MMap directory.
-        if try!(self.fs.write(path_buf.clone(), &Vec::new())) {
+        if exists {
             Err(OpenWriteError::FileAlreadyExists(path_buf))
         } else {
             Ok(BufWriter::new(Box::new(vec_writer)))

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -164,7 +164,9 @@ impl Directory for RAMDirectory {
         let path_buf = PathBuf::from(path);
         let vec_writer = VecWriter::new(path_buf.clone(), self.fs.clone());
 
-        let exists = self.fs.write(path_buf.clone(), &Vec::new()).map_err(|err| IOError::with_path(path.to_owned(), err))?;
+        let exists = self.fs
+            .write(path_buf.clone(), &Vec::new())
+            .map_err(|err| IOError::with_path(path.to_owned(), err))?;
 
         // force the creation of the file to mimic the MMap directory.
         if exists {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,6 @@
 use std::io;
 
 use std::path::PathBuf;
-use std::error;
 use std::sync::PoisonError;
 use directory::error::{IOError, OpenReadError, OpenWriteError, OpenDirectoryError};
 use query;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-/// Definition of Tantivy's error and result.
+//! Definition of Tantivy's error and result.
 
 use std::io;
 
@@ -12,37 +12,48 @@ use serde_json;
 
 error_chain!(
     errors {
+        /// Path does not exist.
         PathDoesNotExist(buf: PathBuf) {
             description("path does not exist")
             display("path does not exist: '{:?}'", buf)
         }
+        /// File already exists, this is a problem when we try to write into a new file.
         FileAlreadyExists(buf: PathBuf) {
             description("file already exists")
             display("file already exists: '{:?}'", buf)
         }
+        /// IO Error.
         IOError(err: IOError) {
             description("an IO error occurred")
             display("an IO error occurred: '{}'", err)
         }
+        /// The data within is corrupted.
+        ///
+        /// For instance, it contains invalid JSON.
         CorruptedFile(buf: PathBuf) {
             description("file contains corrupted data")
             display("file contains corrupted data: '{:?}'", buf)
         }
+        /// A thread holding the locked panicked and poisoned the lock.
         Poisoned {
             description("a thread holding the locked panicked and poisoned the lock")
         }
+        /// Invalid argument was passed by the user.
         InvalidArgument(arg: String) {
             description("an invalid argument was passed")
             display("an invalid argument was passed: '{}'", arg)
         }
+        /// An Error happened in one of the thread.
         ErrorInThread(err: String) {
             description("an error occurred in a thread")
             display("an error occurred in a thread: '{}'", err)
         }
+        /// An Error appeared related to the lack of a field.
         SchemaError(field: String) {
             description("a schema field is missing")
             display("a schema field is missing: '{}'", field)
         }
+        /// Tried to access a fastfield reader for a field not configured accordingly.
         FastFieldError(err: FastFieldNotAvailableError) {
             description("fast field not available")
             display("fast field not available: '{:?}'", err)

--- a/src/error.rs
+++ b/src/error.rs
@@ -116,8 +116,9 @@ impl From<OpenDirectoryError> for Error {
                 ErrorKind::PathDoesNotExist(directory_path).into()
             }
             OpenDirectoryError::NotADirectory(directory_path) => {
-                ErrorKind::InvalidArgument(format!("{:?} is not a directory", directory_path)).into()
-            },
+                ErrorKind::InvalidArgument(format!("{:?} is not a directory", directory_path))
+                    .into()
+            }
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,85 +5,108 @@ use std::io;
 use std::path::PathBuf;
 use std::error;
 use std::sync::PoisonError;
-use directory::error::{OpenReadError, OpenWriteError, OpenDirectoryError};
+use directory::error::{IOError, OpenReadError, OpenWriteError, OpenDirectoryError};
 use query;
 use schema;
 use fastfield::FastFieldNotAvailableError;
 use serde_json;
 
-
-/// Generic tantivy error.
-///
-/// Any specialized error return in tantivy can be converted in `tantivy::Error`.
-#[derive(Debug)]
-pub enum Error {
-    /// Path does not exist.
-    PathDoesNotExist(PathBuf),
-    /// File already exists, this is a problem when we try to write into a new file.
-    FileAlreadyExists(PathBuf),
-    /// IO Error
-    IOError(io::Error),
-    /// A thread holding the locked panicked and poisoned the lock.
-    Poisoned,
-    /// The data within is corrupted.
-    ///
-    /// For instance, it contains invalid JSON.
-    CorruptedFile(PathBuf, Box<error::Error + Send + Sync>),
-    /// Invalid argument was passed by the user.
-    InvalidArgument(String),
-    /// An Error happened in one of the thread
-    ErrorInThread(String),
-    /// An Error appeared related to the lack of a field.
-    SchemaError(String),
-    /// Tried to access a fastfield reader for a field not configured accordingly.
-    FastFieldError(FastFieldNotAvailableError),
-}
+error_chain!(
+    errors {
+        PathDoesNotExist(buf: PathBuf) {
+            description("path does not exist")
+            display("path does not exist: '{:?}'", buf)
+        }
+        FileAlreadyExists(buf: PathBuf) {
+            description("file already exists")
+            display("file already exists: '{:?}'", buf)
+        }
+        IOError(err: IOError) {
+            description("an IO error occurred")
+            display("an IO error occurred: '{}'", err)
+        }
+        CorruptedFile(buf: PathBuf) {
+            description("file contains corrupted data")
+            display("file contains corrupted data: '{:?}'", buf)
+        }
+        Poisoned {
+            description("a thread holding the locked panicked and poisoned the lock")
+        }
+        InvalidArgument(arg: String) {
+            description("an invalid argument was passed")
+            display("an invalid argument was passed: '{}'", arg)
+        }
+        ErrorInThread(err: String) {
+            description("an error occurred in a thread")
+            display("an error occurred in a thread: '{}'", err)
+        }
+        SchemaError(field: String) {
+            description("a schema field is missing")
+            display("a schema field is missing: '{}'", field)
+        }
+        FastFieldError(err: FastFieldNotAvailableError) {
+            description("fast field not available")
+            display("fast field not available: '{:?}'", err)
+        }
+    }
+);
 
 impl From<FastFieldNotAvailableError> for Error {
     fn from(fastfield_error: FastFieldNotAvailableError) -> Error {
-        Error::FastFieldError(fastfield_error)
+        ErrorKind::FastFieldError(fastfield_error).into()
+    }
+}
+
+impl From<IOError> for Error {
+    fn from(io_error: IOError) -> Error {
+        ErrorKind::IOError(io_error).into()
     }
 }
 
 impl From<io::Error> for Error {
     fn from(io_error: io::Error) -> Error {
-        Error::IOError(io_error)
+        ErrorKind::IOError(io_error.into()).into()
     }
 }
 
 impl From<query::QueryParserError> for Error {
     fn from(parsing_error: query::QueryParserError) -> Error {
-        Error::InvalidArgument(format!("Query is invalid. {:?}", parsing_error))
+        ErrorKind::InvalidArgument(format!("Query is invalid. {:?}", parsing_error)).into()
     }
 }
 
 impl<Guard> From<PoisonError<Guard>> for Error {
     fn from(_: PoisonError<Guard>) -> Error {
-        Error::Poisoned
+        ErrorKind::Poisoned.into()
     }
 }
 
 impl From<OpenReadError> for Error {
     fn from(error: OpenReadError) -> Error {
         match error {
-            OpenReadError::FileDoesNotExist(filepath) => Error::PathDoesNotExist(filepath),
-            OpenReadError::IOError(io_error) => Error::IOError(io_error),
+            OpenReadError::FileDoesNotExist(filepath) => {
+                ErrorKind::PathDoesNotExist(filepath).into()
+            }
+            OpenReadError::IOError(io_error) => ErrorKind::IOError(io_error).into(),
         }
     }
 }
 
 impl From<schema::DocParsingError> for Error {
     fn from(error: schema::DocParsingError) -> Error {
-        Error::InvalidArgument(format!("Failed to parse document {:?}", error))
+        ErrorKind::InvalidArgument(format!("Failed to parse document {:?}", error)).into()
     }
 }
 
 impl From<OpenWriteError> for Error {
     fn from(error: OpenWriteError) -> Error {
         match error {
-            OpenWriteError::FileAlreadyExists(filepath) => Error::FileAlreadyExists(filepath),
-            OpenWriteError::IOError(io_error) => Error::IOError(io_error),
-        }
+                OpenWriteError::FileAlreadyExists(filepath) => {
+                    ErrorKind::FileAlreadyExists(filepath)
+                }
+                OpenWriteError::IOError(io_error) => ErrorKind::IOError(io_error),
+            }
+            .into()
     }
 }
 
@@ -91,17 +114,18 @@ impl From<OpenDirectoryError> for Error {
     fn from(error: OpenDirectoryError) -> Error {
         match error {
             OpenDirectoryError::DoesNotExist(directory_path) => {
-                Error::PathDoesNotExist(directory_path)
+                ErrorKind::PathDoesNotExist(directory_path).into()
             }
             OpenDirectoryError::NotADirectory(directory_path) => {
-                Error::InvalidArgument(format!("{:?} is not a directory", directory_path))
-            }
+                ErrorKind::InvalidArgument(format!("{:?} is not a directory", directory_path)).into()
+            },
         }
     }
 }
 
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Error {
-        Error::IOError(error.into())
+        let io_err = io::Error::from(error);
+        ErrorKind::IOError(io_err.into()).into()
     }
 }

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -9,7 +9,7 @@ use core::SegmentReader;
 use indexer::stamper::Stamper;
 use datastruct::stacker::Heap;
 use directory::FileProtection;
-use error::*;
+use error::{Error, ErrorKind, Result, ResultExt};
 use Directory;
 use fastfield::write_delete_bitset;
 use indexer::delete_queue::{DeleteCursor, DeleteQueue};

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -325,9 +325,9 @@ impl IndexWriter {
         let former_workers_handles = mem::replace(&mut self.workers_join_handle, vec![]);
         for join_handle in former_workers_handles {
             join_handle
-                     .join()
-                     .expect("Indexing Worker thread panicked")
-                     .chain_err(|| ErrorKind::ErrorInThread("Error in indexing worker thread.".into()))?;
+                .join()
+                .expect("Indexing Worker thread panicked")
+                .chain_err(|| ErrorKind::ErrorInThread("Error in indexing worker thread.".into()))?;
         }
         drop(self.workers_join_handle);
 
@@ -525,8 +525,8 @@ impl IndexWriter {
         for worker_handle in former_workers_join_handle {
             let indexing_worker_result =
                 worker_handle
-                         .join()
-                         .map_err(|e| Error::from_kind(ErrorKind::ErrorInThread(format!("{:?}", e))))?;
+                    .join()
+                    .map_err(|e| Error::from_kind(ErrorKind::ErrorInThread(format!("{:?}", e))))?;
 
             indexing_worker_result?;
             // add a new worker for the next generation.

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -526,7 +526,7 @@ impl IndexWriter {
             let indexing_worker_result =
                 worker_handle
                          .join()
-                         .map_err(|e| Error::from(ErrorKind::ErrorInThread(format!("{:?}", e))))?;
+                         .map_err(|e| Error::from_kind(ErrorKind::ErrorInThread(format!("{:?}", e))))?;
 
             indexing_worker_result?;
             // add a new worker for the next generation.
@@ -601,7 +601,7 @@ mod tests {
     use schema::{self, Document};
     use Index;
     use Term;
-    use Error;
+    use error::*;
     use env_logger;
 
     #[test]
@@ -610,7 +610,7 @@ mod tests {
         let index = Index::create_in_ram(schema_builder.build());
         let _index_writer = index.writer(40_000_000).unwrap();
         match index.writer(40_000_000) {
-            Err(Error::FileAlreadyExists(_)) => {}
+            Err(Error(ErrorKind::FileAlreadyExists(_), _)) => {}
             _ => panic!("Expected FileAlreadyExists error"),
         }
     }

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1,4 +1,4 @@
-use error::*;
+use error::{ErrorKind, Result};
 use core::SegmentReader;
 use core::Segment;
 use DocId;

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1,4 +1,4 @@
-use {Error, Result};
+use error::*;
 use core::SegmentReader;
 use core::Segment;
 use DocId;
@@ -161,7 +161,7 @@ impl IndexMerger {
                         let error_msg = format!("Failed to find a u64_reader for field {:?}",
                                                 field);
                         error!("{}", error_msg);
-                        return Err(Error::SchemaError(error_msg));
+                        bail!(ErrorKind::SchemaError(error_msg));
                     }
                 }
             }

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -7,7 +7,7 @@ use core::SegmentMeta;
 use core::SerializableSegment;
 use directory::Directory;
 use indexer::stamper::Stamper;
-use error::*;
+use error::{Error, ErrorKind, Result};
 use futures_cpupool::CpuPool;
 use futures::Future;
 use futures::Canceled;

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -446,6 +446,7 @@ impl SegmentUpdater {
             for (_, merging_thread_handle) in new_merging_threads {
                 merging_thread_handle
                     .join()
+                    .map(|_| ())
                     .map_err(|_| ErrorKind::ErrorInThread("Merging thread failed.".into()))?;
             }
             // Our merging thread may have queued their completed

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -7,7 +7,7 @@ use core::SegmentMeta;
 use core::SerializableSegment;
 use directory::Directory;
 use indexer::stamper::Stamper;
-use Error;
+use error::*;
 use futures_cpupool::CpuPool;
 use futures::Future;
 use futures::Canceled;
@@ -19,7 +19,6 @@ use indexer::MergeCandidate;
 use indexer::merger::IndexMerger;
 use indexer::SegmentEntry;
 use indexer::SegmentSerializer;
-use Result;
 use futures_cpupool::CpuFuture;
 use serde_json;
 use indexer::delete_queue::DeleteCursor;
@@ -117,7 +116,7 @@ fn perform_merge(segment_ids: &[SegmentId],
             error!("Error, had to abort merge as some of the segment is not managed anymore.");
             let msg = format!("Segment {:?} requested for merge is not managed.",
                               segment_id);
-            return Err(Error::InvalidArgument(msg));
+            bail!(ErrorKind::InvalidArgument(msg));
         }
     }
 
@@ -447,8 +446,7 @@ impl SegmentUpdater {
             for (_, merging_thread_handle) in new_merging_threads {
                 merging_thread_handle
                     .join()
-                    .map(|_| ())
-                    .map_err(|_| Error::ErrorInThread("Merging thread failed.".to_string()))?
+                    .map_err(|_| ErrorKind::ErrorInThread("Merging thread failed.".into()))?;
             }
             // Our merging thread may have queued their completed
             self.run_async(move |_| {}).wait()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ mod functional_test;
 #[macro_use]
 mod macros;
 
-pub use error::Error;
+pub use error::{Error, ErrorKind};
 
 /// Tantivy result.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,9 @@ extern crate serde_derive;
 extern crate log;
 
 #[macro_use]
+extern crate error_chain;
+
+#[macro_use]
 extern crate version;
 extern crate fst;
 extern crate byteorder;

--- a/src/postings/serializer.rs
+++ b/src/postings/serializer.rs
@@ -186,7 +186,8 @@ impl PostingsSerializer {
             // On the other hand, positions are entirely buffered until the
             // end of the term, at which point they are compressed and written.
             if self.text_indexing_options.is_position_enabled() {
-                self.written_bytes_positions += try!(VInt(self.position_deltas.len() as u64)
+                self.written_bytes_positions +=
+                    try!(VInt(self.position_deltas.len() as u64)
                                                          .serialize(&mut self.positions_write));
                 let positions_encoded: &[u8] = self.positions_encoder
                     .compress_unsorted(&self.position_deltas[..]);

--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -37,8 +37,7 @@ impl Query for BooleanQuery {
     }
 
     fn weight(&self, searcher: &Searcher) -> Result<Box<Weight>> {
-        let sub_weights =
-            try!(self.subqueries
+        let sub_weights = try!(self.subqueries
                      .iter()
                      .map(|&(ref _occur, ref subquery)| subquery.weight(searcher))
                      .collect());

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -22,7 +22,8 @@ impl BooleanWeight {
 
 impl Weight for BooleanWeight {
     fn scorer<'a>(&'a self, reader: &'a SegmentReader) -> Result<Box<Scorer + 'a>> {
-        let sub_scorers: Vec<Box<Scorer + 'a>> = try!(self.weights
+        let sub_scorers: Vec<Box<Scorer + 'a>> =
+            try!(self.weights
                                                           .iter()
                                                           .map(|weight| weight.scorer(reader))
                                                           .collect());


### PR DESCRIPTION
Opening this up for visibility, but I've still got plenty of work to do on it before it's ready for review. The plan is:

- Use `error-chain` for the main `tantivy::Error` type
- Ensure all errors implement `std::Error`