### PR TITLE
Closes #184

### DIFF
--- a/src/common/bitpacker.rs
+++ b/src/common/bitpacker.rs
@@ -123,9 +123,7 @@ impl<Data> BitUnpacker<Data>
         let bit_shift = addr_in_bits & 7;
         debug_assert!(addr + 8 <= data.len(),
                       "The fast field field should have been padded with 7 bytes.");
-        let val_unshifted_unmasked: u64 = unsafe {
-            *(data[addr..].as_ptr() as *const u64)
-        };
+        let val_unshifted_unmasked: u64 = unsafe { *(data[addr..].as_ptr() as *const u64) };
         let val_shifted = (val_unshifted_unmasked >> bit_shift) as u64;
         (val_shifted & mask)
     }

--- a/src/postings/postings_writer.rs
+++ b/src/postings/postings_writer.rs
@@ -88,7 +88,7 @@ impl<'a> MultiFieldPostingsWriter<'a> {
             .cloned()
             .map(|(key, _)| Term::wrap(key).field())
             .enumerate();
-        
+
         let mut prev_field = Field(u32::max_value());
         for (offset, field) in term_offsets_it {
             if field != prev_field {


### PR DESCRIPTION
Resizing the `Vec` was a bad idea, as for some stacker operation,
we may have a living reference to an object in the current heap.