### PR TITLE
Update to memmap 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["search", "information", "retrieval"]
 
 [dependencies]
 byteorder = "1.0"
-memmap = "0.4"
+memmap = "0.6"
 lazy_static = "0.2.1"
 tinysegmenter = "0.1.0"
 regex = "0.2"

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -6,7 +6,7 @@ use directory::ReadOnlySource;
 use directory::shared_vec_slice::SharedVecSlice;
 use directory::WritePtr;
 use fst::raw::MmapReadOnly;
-use memmap::{Mmap, Protection};
+use memmap::Mmap;
 use std::collections::hash_map::Entry as HashMapEntry;
 use std::collections::HashMap;
 use std::convert::From;
@@ -41,7 +41,7 @@ fn open_mmap(full_path: &PathBuf) -> result::Result<Option<Arc<Mmap>>, OpenReadE
         // instead.
         return Ok(None);
     }
-    match Mmap::open(&file, Protection::Read) {
+    match Mmap::map(&file) {
         Ok(mmap) => Ok(Some(Arc::new(mmap))),
         Err(e) => Err(IOError::with_path(full_path.to_owned(), e))?,
     }


### PR DESCRIPTION
`memmap` 0.6.0 introduces major API changes in anticipation of a 1.0
release. See https://github.com/danburkert/memmap-rs/releases/tag/0.6.0
for more information. CC danburkert/memmap-rs#33.