### PR TITLE
Closes #266

### DIFF
--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -13,7 +13,6 @@ use directory::MmapDirectory;
 use directory::{Directory, RAMDirectory};
 use indexer::index_writer::open_index_writer;
 use core::searcher::Searcher;
-use std::convert::From;
 use num_cpus;
 use super::segment::Segment;
 use core::SegmentReader;
@@ -223,8 +222,9 @@ impl Index {
             .iter()
             .map(SegmentReader::open)
             .collect::<Result<_>>()?;
+        let schema = self.schema();
         let searchers = (0..NUM_SEARCHERS)
-            .map(|_| Searcher::from(segment_readers.clone()))
+            .map(|_| Searcher::new(schema.clone(),segment_readers.clone()))
             .collect();
         self.searcher_pool.publish_new_generation(searchers);
         Ok(())

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -8,6 +8,7 @@ use schema::{Field, Term};
 use termdict::{TermDictionary, TermMerger};
 use std::sync::Arc;
 use std::fmt;
+use schema::Schema;
 use core::InvertedIndexReader;
 
 /// Holds a list of `SegmentReader`s ready for search.
@@ -16,10 +17,20 @@ use core::InvertedIndexReader;
 /// the destruction of the `Searcher`.
 ///
 pub struct Searcher {
+    schema: Schema,
     segment_readers: Vec<SegmentReader>,
 }
 
 impl Searcher {
+
+    pub fn new(
+        schema: Schema,
+        segment_readers: Vec<SegmentReader>) -> Searcher {
+        Searcher {
+            schema,
+            segment_readers
+        }
+    }
     /// Fetches a document from tantivy's store given a `DocAddress`.
     ///
     /// The searcher uses the segment ordinal to route the
@@ -28,6 +39,10 @@ impl Searcher {
         let DocAddress(segment_local_id, doc_id) = *doc_address;
         let segment_reader = &self.segment_readers[segment_local_id as usize];
         segment_reader.doc(doc_id)
+    }
+
+    pub fn schema(&self) -> &Schema {
+        &self.schema
     }
 
     /// Returns the overall number of documents in the index.
@@ -92,11 +107,6 @@ impl FieldSearcher {
     }
 }
 
-impl From<Vec<SegmentReader>> for Searcher {
-    fn from(segment_readers: Vec<SegmentReader>) -> Searcher {
-        Searcher { segment_readers }
-    }
-}
 
 impl fmt::Debug for Searcher {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/query/range_query.rs
+++ b/src/query/range_query.rs
@@ -188,13 +188,12 @@ impl RangeQuery {
 
 impl Query for RangeQuery {
     fn weight(&self, searcher: &Searcher, _scoring_enabled: bool) -> Result<Box<Weight>> {
-        if let Some(first_segment_reader) = searcher.segment_readers().iter().next() {
-            let value_type = first_segment_reader.schema().get_field_entry(self.field).field_type().value_type();
-            assert_eq!(
-                value_type, self.value_type,
-                "Create a range query of the type {:?}, when the field given was of type {:?}",
-                self.value_type, value_type);
-        }
+        let schema = searcher.schema();
+        let value_type = schema.get_field_entry(self.field).field_type().value_type();
+        assert_eq!(
+            value_type, self.value_type,
+            "Create a range query of the type {:?}, when the field given was of type {:?}",
+            self.value_type, value_type);
         Ok(Box::new(RangeWeight {
             field: self.field,
             left_bound: self.left_bound.clone(),


### PR DESCRIPTION
PhraseQuery panics with a nice error message when the underlying field does not have any positions.
The `QueryParser` fails as well with a dedicated error.