### PR TITLE
Add Index::open_directory function

### DIFF
--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -103,6 +103,13 @@ impl Index {
         Ok(index)
     }
 
+    /// Open the index using the provided directory
+    pub fn open_directory<D: Directory>(directory: D) -> Result<Index> {
+        let directory = ManagedDirectory::new(directory)?;
+        let metas = load_metas(&directory)?;
+        Index::create_from_metas(directory, &metas)
+    }
+
     /// Create a new index from a directory.
     pub fn from_directory(mut directory: ManagedDirectory, schema: Schema) -> Result<Index> {
         save_new_metas(schema.clone(), 0, directory.borrow_mut())?;

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -110,19 +110,17 @@ impl Index {
         Index::create_from_metas(directory, &metas)
     }
 
-    /// Create a new index from a directory.
-    pub fn from_directory(mut directory: ManagedDirectory, schema: Schema) -> Result<Index> {
-        save_new_metas(schema.clone(), 0, directory.borrow_mut())?;
-        let metas = IndexMeta::with_schema(schema);
-        Index::create_from_metas(directory, &metas)
-    }
-
     /// Opens a new directory from an index path.
     #[cfg(feature = "mmap")]
     pub fn open<P: AsRef<Path>>(directory_path: P) -> Result<Index> {
         let mmap_directory = MmapDirectory::open(directory_path)?;
-        let directory = ManagedDirectory::new(mmap_directory)?;
-        let metas = load_metas(&directory)?;
+        Index::open_directory(mmap_directory)
+    }
+
+    /// Create a new index from a directory.
+    pub fn from_directory(mut directory: ManagedDirectory, schema: Schema) -> Result<Index> {
+        save_new_metas(schema.clone(), 0, directory.borrow_mut())?;
+        let metas = IndexMeta::with_schema(schema);
         Index::create_from_metas(directory, &metas)
     }
 


### PR DESCRIPTION
Closes #279

- [x] How would you like this tested, and where?

Side note: happy to make a new issue, but it would be nice if there was a bit more consistency to the method names here. I'm going to attempt to propose a solution, but I'm not trying to cause more trouble than its worth either. :)

## Creation
```
Index::create_in_ram(schema) // uses ram dir -> Index::from_directory
Index::create(path, schema) // uses mmap dir -> Index::from_directory
Index::create_from_tempdir(schema) //uses mmap dir -> Index::from_directory
Index::from_directory(managed_directory, schema) // a little more universal - but creates a new setup
```

- Maybe? make from directory take a directory and wrap it in managed ourselves?
- Does managed need to be exposed outside of the crate?
- `Index::from_directory` -> `Index::create_directory` ?

## Opening
```
Index::open(path) // uses mmap
Index::open_directory(directory) // new one
```

Ok, random ideas aside. Hopefully the meat of the PR is what you were looking for.