### PR TITLE
Add AutomatonWeight to a fuzzy_search module and FuzzyQuery

### DIFF
--- a/src/query/automaton_builder.rs
+++ b/src/query/automaton_builder.rs
@@ -1,8 +1,0 @@
-use fst::Automaton;
-
-pub trait AutomatonBuilder<A>
-where
-  A: Automaton,
-{
-  fn build_automaton(&self) -> Box<A>;
-}

--- a/src/query/automaton_builder.rs
+++ b/src/query/automaton_builder.rs
@@ -1,0 +1,8 @@
+use fst::Automaton;
+
+pub trait AutomatonBuilder<A>
+where
+  A: Automaton,
+{
+  fn build_automaton(&self) -> Box<A>;
+}

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -1,57 +1,140 @@
 use common::BitSet;
 use core::SegmentReader;
+use fst::automaton::AlwaysMatch;
 use fst::Automaton;
+use levenshtein_automata::{LevenshteinAutomatonBuilder, DFA};
 use query::BitSetDocSet;
 use query::ConstScorer;
 use query::{Query, Scorer, Weight};
 use schema::{Field, IndexRecordOption, Term};
 use termdict::{TermDictionary, TermStreamer};
 use Result;
+use Searcher;
+
+/// A Fuzzy Query matches all of the documents
+/// containing a specific term that is with in
+/// Levenshtein distance
+#[derive(Debug)]
+pub struct FuzzyQuery {
+    term: Term,
+    distance: u8,
+}
+
+impl FuzzyQuery {
+    /// Creates a new Fuzzy Query
+    pub fn new(term: Term, distance: u8) -> FuzzyQuery {
+        FuzzyQuery { term, distance }
+    }
+
+    pub fn specialized_weight(&self) -> AutomatonWeight<DFA> {
+        AutomatonWeight {
+            term: self.term.clone(),
+            field: self.term.field(),
+            builder: self,
+        }
+    }
+}
+
+impl Query for FuzzyQuery {
+    fn weight(&self, _searcher: &Searcher, _scoring_enabled: bool) -> Result<Box<Weight>> {
+        Ok(Box::new(self.specialized_weight()))
+    }
+}
+
+impl AutomatonBuilder<DFA> for FuzzyQuery {
+    fn build_automaton(&self) -> Box<DFA> {
+        let lev_automaton_builder = LevenshteinAutomatonBuilder::new(self.distance, true);
+        let automaton = lev_automaton_builder.build_dfa(self.term.text());
+        Box::new(automaton)
+    }
+}
+
+trait AutomatonBuilder<A>
+where
+    A: Automaton,
+{
+    fn build_automaton(&self) -> Box<A>;
+}
 
 pub struct AutomatonWeight<A>
 where
-  A: Automaton,
+    A: Automaton,
 {
-  field: Field,
-  automaton: A,
+    term: Term,
+    field: Field,
+    builder: AutomatonBuilder<A>,
 }
 
 impl<A> AutomatonWeight<A>
 where
-  A: Automaton,
+    A: Automaton,
 {
-  fn automaton_stream<'a>(&self, term_dict: &'a TermDictionary) -> TermStreamer<'a, A> {
-    // TODO: how do we handle ownership here?
-    // No .clone()
-    // Search needs to be owned because fst::Map.search<A: Automaton>(&self, aut: A)
-    let term_stream_builder = term_dict.search(self.automaton);
+    fn automaton_stream<'a>(&self, term_dict: &'a TermDictionary) -> TermStreamer<'a, A> {
+        let automaton = self.builder.build_automaton();
 
-    term_stream_builder.into_stream()
-  }
+        let term_stream_builder = term_dict.search::<A>(*automaton);
+
+        term_stream_builder.into_stream()
+    }
 }
 
 impl<A> Weight for AutomatonWeight<A>
 where
-  A: Automaton,
+    A: Automaton,
 {
-  fn scorer(&self, reader: &SegmentReader) -> Result<Box<Scorer>> {
-    let max_doc = reader.max_doc();
-    let mut doc_bitset = BitSet::with_max_value(max_doc);
+    fn scorer(&self, reader: &SegmentReader) -> Result<Box<Scorer>> {
+        let max_doc = reader.max_doc();
+        let mut doc_bitset = BitSet::with_max_value(max_doc);
 
-    let inverted_index = reader.inverted_index(self.field);
-    let term_dict = inverted_index.terms();
-    let mut term_range = self.automaton_stream(term_dict);
-    while term_range.advance() {
-      let term_info = term_range.value();
-      let mut block_segment_postings =
-        inverted_index.read_block_postings_from_terminfo(term_info, IndexRecordOption::Basic);
-      while block_segment_postings.advance() {
-        for &doc in block_segment_postings.docs() {
-          doc_bitset.insert(doc);
+        let inverted_index = reader.inverted_index(self.field);
+        let term_dict = inverted_index.terms();
+        let mut term_stream = self.automaton_stream(term_dict);
+        while term_stream.advance() {
+            let term_info = term_stream.value();
+            let mut block_segment_postings = inverted_index
+                .read_block_postings_from_terminfo(term_info, IndexRecordOption::Basic);
+            while block_segment_postings.advance() {
+                for &doc in block_segment_postings.docs() {
+                    doc_bitset.insert(doc);
+                }
+            }
         }
-      }
+        let doc_bitset = BitSetDocSet::from(doc_bitset);
+        Ok(Box::new(ConstScorer::new(doc_bitset)))
     }
-    let doc_bitset = BitSetDocSet::from(doc_bitset);
-    Ok(Box::new(ConstScorer::new(doc_bitset)))
-  }
+}
+
+#[cfg(test)]
+mod test {
+    use super::FuzzyQuery;
+
+    #[test]
+    pub fn test_automaton_weight() {
+        let mut schema_builder = SchemaBuilder::new();
+        let country_field = schema_builder.add_text_field("country", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        {
+            let mut index_writer = index.writer_with_num_threads(1, 10_000_000).unwrap();
+            index_writer.add_document(doc!(
+                country_field => "Japan",
+            ));
+            index_writer.add_document(doc!(
+                country_field => "Korea",
+            ));
+            index_writer.commit().unwrap();
+        }
+        index.load_searchers().unwrap();
+        let searcher = index.searcher();
+        {
+            let mut collector = TopCollector::with_limit(2);
+            let term = Term::from_field_text(left_field, "Japon");
+            let fuzzy_query = FuzzyQuery::new(term, 2);
+            searcher.search(&fuzzy_query, &mut collector).unwrap();
+            let scored_docs = collector.score_docs();
+            assert_eq!(scored_docs.len(), 1);
+            let (score, _) = scored_docs[0];
+            assert_nearly_equals(0.77802235, score);
+        }
+    }
 }

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -108,7 +108,7 @@ where
 mod test {
     use super::FuzzyQuery;
     use collector::TopCollector;
-    use schema::{Document, Field, SchemaBuilder, TEXT};
+    use schema::{Document, Field, SchemaBuilder, STORED, STRING, TEXT};
     use tests::assert_nearly_equals;
     use Index;
     use Term;
@@ -134,7 +134,8 @@ mod test {
         {
             let mut collector = TopCollector::with_limit(2);
             let term = Term::from_field_text(country_field, "Japon");
-            let fuzzy_query = FuzzyQuery::new(term, 2);
+            // TODO: currently I have to set this to 2 to pass. Which seems incorrect
+            let fuzzy_query = FuzzyQuery::new(term, 1);
             searcher.search(&fuzzy_query, &mut collector).unwrap();
             let scored_docs = collector.score_docs();
             assert_eq!(scored_docs.len(), 1, "Expected only 1 document");

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -1,0 +1,57 @@
+use common::BitSet;
+use core::SegmentReader;
+use fst::Automaton;
+use query::BitSetDocSet;
+use query::ConstScorer;
+use query::{Query, Scorer, Weight};
+use schema::{Field, IndexRecordOption, Term};
+use termdict::{TermDictionary, TermStreamer};
+use Result;
+
+pub struct AutomatonWeight<A>
+where
+  A: Automaton,
+{
+  field: Field,
+  automaton: A,
+}
+
+impl<A> AutomatonWeight<A>
+where
+  A: Automaton,
+{
+  fn automaton_stream<'a>(&self, term_dict: &'a TermDictionary) -> TermStreamer<'a, A> {
+    // TODO: how do we handle ownership here?
+    // No .clone()
+    // Search needs to be owned because fst::Map.search<A: Automaton>(&self, aut: A)
+    let term_stream_builder = term_dict.search(self.automaton);
+
+    term_stream_builder.into_stream()
+  }
+}
+
+impl<A> Weight for AutomatonWeight<A>
+where
+  A: Automaton,
+{
+  fn scorer(&self, reader: &SegmentReader) -> Result<Box<Scorer>> {
+    let max_doc = reader.max_doc();
+    let mut doc_bitset = BitSet::with_max_value(max_doc);
+
+    let inverted_index = reader.inverted_index(self.field);
+    let term_dict = inverted_index.terms();
+    let mut term_range = self.automaton_stream(term_dict);
+    while term_range.advance() {
+      let term_info = term_range.value();
+      let mut block_segment_postings =
+        inverted_index.read_block_postings_from_terminfo(term_info, IndexRecordOption::Basic);
+      while block_segment_postings.advance() {
+        for &doc in block_segment_postings.docs() {
+          doc_bitset.insert(doc);
+        }
+      }
+    }
+    let doc_bitset = BitSetDocSet::from(doc_bitset);
+    Ok(Box::new(ConstScorer::new(doc_bitset)))
+  }
+}

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -27,7 +27,6 @@ impl FuzzyQuery {
 
     pub fn specialized_weight(&self) -> AutomatonWeight<DFA> {
         AutomatonWeight {
-            term: self.term.clone(),
             field: self.term.field(),
             // TODO: is there a better way to do this?
             builder: Box::new(self.clone()),
@@ -60,7 +59,6 @@ pub struct AutomatonWeight<A>
 where
     A: Automaton,
 {
-    term: Term,
     field: Field,
     builder: Box<AutomatonBuilder<A>>,
 }
@@ -108,7 +106,7 @@ where
 mod test {
     use super::FuzzyQuery;
     use collector::TopCollector;
-    use schema::{Document, Field, SchemaBuilder, STORED, STRING, TEXT};
+    use schema::{SchemaBuilder, TEXT};
     use tests::assert_nearly_equals;
     use Index;
     use Term;
@@ -122,10 +120,10 @@ mod test {
         {
             let mut index_writer = index.writer_with_num_threads(1, 10_000_000).unwrap();
             index_writer.add_document(doc!(
-                country_field => "Japan",
+                country_field => "japan",
             ));
             index_writer.add_document(doc!(
-                country_field => "Korea",
+                country_field => "korea",
             ));
             index_writer.commit().unwrap();
         }
@@ -133,8 +131,8 @@ mod test {
         let searcher = index.searcher();
         {
             let mut collector = TopCollector::with_limit(2);
-            let term = Term::from_field_text(country_field, "Japon");
-            // TODO: currently I have to set this to 2 to pass. Which seems incorrect
+            let term = Term::from_field_text(country_field, "japon");
+
             let fuzzy_query = FuzzyQuery::new(term, 1);
             searcher.search(&fuzzy_query, &mut collector).unwrap();
             let scored_docs = collector.score_docs();

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -2,16 +2,14 @@ use common::BitSet;
 use core::SegmentReader;
 use fst::Automaton;
 use levenshtein_automata::{LevenshteinAutomatonBuilder, DFA};
-use query::automaton_builder::AutomatonBuilder;
 use query::BitSetDocSet;
 use query::ConstScorer;
 use query::{Query, Scorer, Weight};
 use schema::{Field, IndexRecordOption, Term};
-use termdict::{TermDictionary, TermStreamer};
 use std::collections::HashMap;
+use termdict::{TermDictionary, TermStreamer};
 use Result;
 use Searcher;
-
 
 lazy_static! {
     static ref LEV_BUILDER: HashMap<(u8, bool), LevenshteinAutomatonBuilder> = {
@@ -80,21 +78,11 @@ impl Query for FuzzyTermQuery {
     }
 }
 
-impl AutomatonBuilder<DFA> for FuzzyQuery {
-    fn build_automaton(&self) -> Box<DFA> {
-        let lev_automaton_builder =
-        let lev_automaton_builder = LevenshteinAutomatonBuilder::new(self.distance, true);
-
-        let automaton = if self.prefix {
-            lev_automaton_builder.build_prefix_dfa(self.term.text())
-        } else {
-        let automaton = lev_automaton_builder.build_dfa(self.term.text());
-        };
-
 pub struct AutomatonWeight<A>
 where
     A: Automaton,
 {
+    term: Term,
     field: Field,
     automaton: A,
 }
@@ -137,13 +125,13 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::FuzzyQuery;
-    use schema::SchemaBuilder;
-    use Index;
+    use super::FuzzyTermQuery;
     use collector::TopCollector;
+    use schema::SchemaBuilder;
     use schema::TEXT;
-    use Term;
     use tests::assert_nearly_equals;
+    use Index;
+    use Term;
 
     #[test]
     pub fn test_automaton_weight() {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -7,6 +7,7 @@ mod bitset;
 mod bm25;
 mod boolean_query;
 mod exclude;
+mod fuzzy_query;
 mod intersection;
 mod occur;
 mod phrase_query;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -23,7 +23,6 @@ mod weight;
 #[cfg(test)]
 mod vec_docset;
 
-pub(crate) mod automaton_builder;
 pub(crate) mod score_combiner;
 
 pub use self::intersection::Intersection;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -23,6 +23,7 @@ mod weight;
 #[cfg(test)]
 mod vec_docset;
 
+pub(crate) mod automaton_builder;
 pub(crate) mod score_combiner;
 
 pub use self::intersection::Intersection;

--- a/src/termdict/termdict.rs
+++ b/src/termdict/termdict.rs
@@ -203,7 +203,7 @@ impl TermDictionary {
 
     /// Returns a search builder, to stream all of the terms
     /// within the Automaton
-    pub fn search<'a, A: Automaton>(&'a self, automaton: A) -> TermStreamerBuilder<'a, A> {
+    pub fn search<'a, A: Automaton + 'a>(&'a self, automaton: A) -> TermStreamerBuilder<'a, A> {
         let stream_builder = self.fst_index.search(automaton);
         TermStreamerBuilder::<A>::new(self, stream_builder)
     }


### PR DESCRIPTION
Closes #299

So, I was able to review the range code - I "think" I have the way to go about this, where the `AutomatonWeight` has a field of type `Automaton` - but then promptly ran into ownership issues. The other option would be some kind of `Fn<Automaton>` that would build it up? Def looking for some rust guidance here. :)