### PR TITLE
Optimize segment readers alive doc iterator

### DIFF
--- a/src/common/bitset.rs
+++ b/src/common/bitset.rs
@@ -27,6 +27,12 @@ impl IntoIterator for TinySet {
     }
 }
 
+impl From<u64> for TinySet {
+    fn from(value: u64) -> Self {
+        TinySet(value)
+    }
+}
+
 impl TinySet {
     /// Returns an empty `TinySet`.
     pub fn empty() -> TinySet {
@@ -34,7 +40,7 @@ impl TinySet {
     }
 
     /// Returns the complement of the set in `[0, 64[`.
-    fn complement(&self) -> TinySet {
+    pub fn complement(&self) -> TinySet {
         TinySet(!self.0)
     }
 


### PR DESCRIPTION
I took a stab at tackling https://github.com/tantivy-search/tantivy/issues/296. The `DeleteBitSet` now builds a slice of TinySets, then the `SegmentReaderAliveDocsIterator` leverages the tinysets to iterate through the alive documents more efficiently. As I'm not very familiar with the codebase, there may have been a cleaner way to do some parts of this - feedback is appreciated!

Closes #296