### PR TITLE
Standardizes the Index::create_* APIs

### DIFF
--- a/examples/custom_tokenizer.rs
+++ b/examples/custom_tokenizer.rs
@@ -61,7 +61,7 @@ fn run_example(index_path: &Path) -> tantivy::Result<()> {
     //
     // This will actually just save a meta.json
     // with our schema in the directory.
-    let index = Index::create(index_path, schema.clone())?;
+    let index = Index::create_in_dir(index_path, schema.clone())?;
 
     // here we are registering our custome tokenizer
     // this will store tokens of 3 characters each

--- a/examples/simple_search.rs
+++ b/examples/simple_search.rs
@@ -64,7 +64,7 @@ fn run_example(index_path: &Path) -> tantivy::Result<()> {
     //
     // This will actually just save a meta.json
     // with our schema in the directory.
-    let index = Index::create(index_path, schema.clone())?;
+    let index = Index::create_in_dir(index_path, schema.clone())?;
 
     // To insert document we need an index writer.
     // There must be only one writer at a time.

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -71,7 +71,7 @@ impl Index {
     ///
     /// If a previous index was in this directory, then its meta file will be destroyed.
     #[cfg(feature = "mmap")]
-    pub fn create<P: AsRef<Path>>(directory_path: P, schema: Schema) -> Result<Index> {
+    pub fn create_in_dir<P: AsRef<Path>>(directory_path: P, schema: Schema) -> Result<Index> {
         let mmap_directory = MmapDirectory::open(directory_path)?;
         let directory = ManagedDirectory::new(mmap_directory)?;
         Index::from_directory(directory, schema)

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -58,12 +58,7 @@ impl Index {
     /// This should only be used for unit tests.
     pub fn create_in_ram(schema: Schema) -> Index {
         let ram_directory = RAMDirectory::create();
-        // unwrap is ok here
-        let directory = ManagedDirectory::new(ram_directory).expect(
-            "Creating a managed directory from a brand new RAM directory \
-             should never fail.",
-        );
-        Index::from_directory(directory, schema).expect("Creating a RAMDirectory should never fail")
+        Index::create(ram_directory, schema).expect("Creating a RAMDirectory should never fail")
     }
 
     /// Creates a new index in a given filepath.
@@ -73,8 +68,7 @@ impl Index {
     #[cfg(feature = "mmap")]
     pub fn create_in_dir<P: AsRef<Path>>(directory_path: P, schema: Schema) -> Result<Index> {
         let mmap_directory = MmapDirectory::open(directory_path)?;
-        let directory = ManagedDirectory::new(mmap_directory)?;
-        Index::from_directory(directory, schema)
+        Index::create(mmap_directory, schema)
     }
 
     /// Creates a new index in a temp directory.
@@ -88,7 +82,12 @@ impl Index {
     #[cfg(feature = "mmap")]
     pub fn create_from_tempdir(schema: Schema) -> Result<Index> {
         let mmap_directory = MmapDirectory::create_from_tempdir()?;
-        let directory = ManagedDirectory::new(mmap_directory)?;
+        Index::create(mmap_directory, schema)
+    }
+
+    /// Creates a new index given an implementation of the trait `Directory`
+    pub fn create<Dir: Directory>(dir: Dir, schema: Schema) -> Result<Index> {
+        let directory = ManagedDirectory::new(dir)?;
         Index::from_directory(directory, schema)
     }
 

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -46,7 +46,7 @@ pub struct Index {
 
 impl Index {
     /// Create a new index from a directory.
-    pub fn from_directory(mut directory: ManagedDirectory, schema: Schema) -> Result<Index> {
+    fn from_directory(mut directory: ManagedDirectory, schema: Schema) -> Result<Index> {
         save_new_metas(schema.clone(), 0, directory.borrow_mut())?;
         let metas = IndexMeta::with_schema(schema);
         Index::create_from_metas(directory, &metas)

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -45,6 +45,13 @@ pub struct Index {
 }
 
 impl Index {
+    /// Create a new index from a directory.
+    pub fn from_directory(mut directory: ManagedDirectory, schema: Schema) -> Result<Index> {
+        save_new_metas(schema.clone(), 0, directory.borrow_mut())?;
+        let metas = IndexMeta::with_schema(schema);
+        Index::create_from_metas(directory, &metas)
+    }
+
     /// Creates a new index using the `RAMDirectory`.
     ///
     /// The index will be allocated in anonymous memory.
@@ -68,11 +75,6 @@ impl Index {
         let mmap_directory = MmapDirectory::open(directory_path)?;
         let directory = ManagedDirectory::new(mmap_directory)?;
         Index::from_directory(directory, schema)
-    }
-
-    /// Accessor for the tokenizer manager.
-    pub fn tokenizers(&self) -> &TokenizerManager {
-        &self.tokenizers
     }
 
     /// Creates a new index in a temp directory.
@@ -103,6 +105,11 @@ impl Index {
         Ok(index)
     }
 
+    /// Accessor for the tokenizer manager.
+    pub fn tokenizers(&self) -> &TokenizerManager {
+        &self.tokenizers
+    }
+
     /// Open the index using the provided directory
     pub fn open_directory<D: Directory>(directory: D) -> Result<Index> {
         let directory = ManagedDirectory::new(directory)?;
@@ -115,13 +122,6 @@ impl Index {
     pub fn open<P: AsRef<Path>>(directory_path: P) -> Result<Index> {
         let mmap_directory = MmapDirectory::open(directory_path)?;
         Index::open_directory(mmap_directory)
-    }
-
-    /// Create a new index from a directory.
-    pub fn from_directory(mut directory: ManagedDirectory, schema: Schema) -> Result<Index> {
-        save_new_metas(schema.clone(), 0, directory.borrow_mut())?;
-        let metas = IndexMeta::with_schema(schema);
-        Index::create_from_metas(directory, &metas)
     }
 
     /// Reads the index meta file from the directory.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //! // Indexing documents
 //!
-//! let index = Index::create(index_path, schema.clone())?;
+//! let index = Index::create_in_dir(index_path, schema.clone())?;
 //!
 //! // Here we use a buffer of 100MB that will be split
 //! // between indexing threads.


### PR DESCRIPTION
This pull request addresses the create half of #286

The goal here is to create a consistent api that will flow well in IDE's that support code completion since there are grouped together.

The docs now have them next to each other as well

![image](https://user-images.githubusercontent.com/63355/41352801-09132e4a-6ee0-11e8-9123-2d5404115464.png)

Ok, this is an "important" change since its the API for creating indices. Let me have it with the questions and comments. :)

After this I'll do a PR for the `open_*` API's with what was learned from here.