### PR TITLE
Standardizes the Index::open_* APIs

### DIFF
--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -111,13 +111,13 @@ impl Index {
 
     /// Opens a new directory from an index path.
     #[cfg(feature = "mmap")]
-    pub fn open<P: AsRef<Path>>(directory_path: P) -> Result<Index> {
+    pub fn open_in_dir<P: AsRef<Path>>(directory_path: P) -> Result<Index> {
         let mmap_directory = MmapDirectory::open(directory_path)?;
-        Index::open_directory(mmap_directory)
+        Index::open(mmap_directory)
     }
 
     /// Open the index using the provided directory
-    pub fn open_directory<D: Directory>(directory: D) -> Result<Index> {
+    pub fn open<D: Directory>(directory: D) -> Result<Index> {
         let directory = ManagedDirectory::new(directory)?;
         let metas = load_metas(&directory)?;
         Index::create_from_metas(directory, &metas)

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -45,13 +45,6 @@ pub struct Index {
 }
 
 impl Index {
-    /// Create a new index from a directory.
-    fn from_directory(mut directory: ManagedDirectory, schema: Schema) -> Result<Index> {
-        save_new_metas(schema.clone(), 0, directory.borrow_mut())?;
-        let metas = IndexMeta::with_schema(schema);
-        Index::create_from_metas(directory, &metas)
-    }
-
     /// Creates a new index using the `RAMDirectory`.
     ///
     /// The index will be allocated in anonymous memory.
@@ -89,6 +82,13 @@ impl Index {
     pub fn create<Dir: Directory>(dir: Dir, schema: Schema) -> Result<Index> {
         let directory = ManagedDirectory::new(dir)?;
         Index::from_directory(directory, schema)
+    }
+
+    /// Create a new index from a directory.
+    fn from_directory(mut directory: ManagedDirectory, schema: Schema) -> Result<Index> {
+        save_new_metas(schema.clone(), 0, directory.borrow_mut())?;
+        let metas = IndexMeta::with_schema(schema);
+        Index::create_from_metas(directory, &metas)
     }
 
     /// Creates a new index given a directory and an `IndexMeta`.

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -109,18 +109,18 @@ impl Index {
         &self.tokenizers
     }
 
-    /// Open the index using the provided directory
-    pub fn open_directory<D: Directory>(directory: D) -> Result<Index> {
-        let directory = ManagedDirectory::new(directory)?;
-        let metas = load_metas(&directory)?;
-        Index::create_from_metas(directory, &metas)
-    }
-
     /// Opens a new directory from an index path.
     #[cfg(feature = "mmap")]
     pub fn open<P: AsRef<Path>>(directory_path: P) -> Result<Index> {
         let mmap_directory = MmapDirectory::open(directory_path)?;
         Index::open_directory(mmap_directory)
+    }
+
+    /// Open the index using the provided directory
+    pub fn open_directory<D: Directory>(directory: D) -> Result<Index> {
+        let directory = ManagedDirectory::new(directory)?;
+        let metas = load_metas(&directory)?;
+        Index::create_from_metas(directory, &metas)
     }
 
     /// Reads the index meta file from the directory.


### PR DESCRIPTION
Follow on to #317 
Closes #286 

One positive change of this that I like, is that post merge, you will always have `create` and `open` no matter what features you turn on. And for each feature you turn on, you get a `create_in_*` and a `open_in_*` type methods.

# Open Methods

```
Index::open(path) -> Index::open_in_dir
Index::open(directory) // universal
```

There were fewer of these, so it wasn't as "hard".

# Create Methods

```
Index::create_in_ram(schema)  -> Index::create_in_ram
Index::create(path, schema)  -> Index::create_in_dir
Index::create_from_tempdir(schema) -> Index::create_from_tempdir * I missed this one
Index::from_directory -> hidden as it uses ManagedDirectory
Index::create(D: Directory, schema) // added universal method
```

Question: Should I take this moment to rename `create_from_tempdir` to `create_in_tempdir` to better align?

Ok, this is an "important" change since its the API for creating indices. Let me have it with the questions and comments. :)