### PR TITLE
Closes #339.

### DIFF
--- a/src/fastfield/multivalued/reader.rs
+++ b/src/fastfield/multivalued/reader.rs
@@ -102,7 +102,7 @@ mod tests {
         let mut vals = Vec::new();
         {
             facet_reader.facet_ords(0, &mut vals);
-            assert_eq!(&vals[..], &[3, 2]);
+            assert_eq!(&vals[..], &[2, 3]);
         }
         {
             facet_reader.facet_ords(1, &mut vals);


### PR DESCRIPTION
As required per the FacetCollector,
facet values needs to be sorted before being encoded in the
multivalued field.