### PR TITLE
Implement `std::error::Error` for `QueryParserError`

### DIFF
--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -13,6 +13,8 @@ use schema::IndexRecordOption;
 use schema::{Field, Schema};
 use schema::{FieldType, Term};
 use std::borrow::Cow;
+use std::error::Error;
+use std::fmt;
 use std::num::ParseIntError;
 use std::ops::Bound;
 use std::str::FromStr;
@@ -49,6 +51,14 @@ pub enum QueryParserError {
     /// Only terms can be used as bounds.
     RangeMustNotHavePhrase,
 }
+
+impl fmt::Display for QueryParserError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl Error for QueryParserError { }
 
 impl From<ParseIntError> for QueryParserError {
     fn from(err: ParseIntError) -> QueryParserError {


### PR DESCRIPTION
This adds impls for `std::fmt::Display` and `std::error::Error` so that
`QueryParser::parse_query` can be used with the `failure` crate more easily