### PR TITLE
Add default EN stopwords to the default analyzer

### DIFF
--- a/src/tokenizer/stop_word_filter.rs
+++ b/src/tokenizer/stop_word_filter.rs
@@ -98,3 +98,15 @@ where
         false
     }
 }
+
+impl Default for StopWordFilter {
+    fn default() -> StopWordFilter {
+        let words = vec![
+            "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into",
+            "is", "it", "no", "not", "of", "on", "or", "such", "that", "the", "their", "then",
+            "there", "these", "they", "this", "to", "was", "will", "with",
+        ];
+
+        StopWordFilter::remove(words.iter().map(|s| s.to_string()).collect())
+    }
+}

--- a/src/tokenizer/stop_word_filter.rs
+++ b/src/tokenizer/stop_word_filter.rs
@@ -39,6 +39,16 @@ impl StopWordFilter {
 
         StopWordFilter { words: set }
     }
+
+    fn english() -> StopWordFilter {
+        let words: [&'static str; 33] = [
+            "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into",
+            "is", "it", "no", "not", "of", "on", "or", "such", "that", "the", "their", "then",
+            "there", "these", "they", "this", "to", "was", "will", "with",
+        ];
+
+        StopWordFilter::remove(words.iter().map(|s| s.to_string()).collect())
+    }
 }
 
 pub struct StopWordFilterStream<TailTokenStream>
@@ -101,12 +111,6 @@ where
 
 impl Default for StopWordFilter {
     fn default() -> StopWordFilter {
-        let words = vec![
-            "a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into",
-            "is", "it", "no", "not", "of", "on", "or", "such", "that", "the", "their", "then",
-            "there", "these", "they", "this", "to", "was", "will", "with",
-        ];
-
-        StopWordFilter::remove(words.iter().map(|s| s.to_string()).collect())
+        StopWordFilter::english()
     }
 }

--- a/src/tokenizer/tokenizer_manager.rs
+++ b/src/tokenizer/tokenizer_manager.rs
@@ -8,6 +8,7 @@ use tokenizer::RawTokenizer;
 use tokenizer::RemoveLongFilter;
 use tokenizer::SimpleTokenizer;
 use tokenizer::Stemmer;
+use tokenizer::StopWordFilter;
 use tokenizer::Tokenizer;
 
 /// The tokenizer manager serves as a store for
@@ -64,12 +65,14 @@ impl Default for TokenizerManager {
         manager.register(
             "default",
             SimpleTokenizer
+                .filter(StopWordFilter::default())
                 .filter(RemoveLongFilter::limit(40))
                 .filter(LowerCaser),
         );
         manager.register(
             "en_stem",
             SimpleTokenizer
+                .filter(StopWordFilter::default())
                 .filter(RemoveLongFilter::limit(40))
                 .filter(LowerCaser)
                 .filter(Stemmer::new()),

--- a/src/tokenizer/tokenizer_manager.rs
+++ b/src/tokenizer/tokenizer_manager.rs
@@ -65,14 +65,12 @@ impl Default for TokenizerManager {
         manager.register(
             "default",
             SimpleTokenizer
-                .filter(StopWordFilter::default())
                 .filter(RemoveLongFilter::limit(40))
                 .filter(LowerCaser),
         );
         manager.register(
             "en_stem",
             SimpleTokenizer
-                .filter(StopWordFilter::default())
                 .filter(RemoveLongFilter::limit(40))
                 .filter(LowerCaser)
                 .filter(Stemmer::new()),


### PR DESCRIPTION
I'd like to suggest adding a default set of EN stopwords to the standard tokenizers for Tantivy.

1. I'm not sure that `Stopwords::default` is the best method name and very open to renaming.
2. I'm pretty sure my implementation could be quite a bit better memory wise.
3. Is this a sensible add to the default tokenizers?