### PR TITLE
Adds open_or_create method

### DIFF
--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -107,6 +107,8 @@ impl Index {
     }
 
     /// Create a new index from a directory.
+    ///
+    /// This will overwrite existing meta.json
     fn from_directory(mut directory: ManagedDirectory, schema: Schema) -> Result<Index> {
         save_new_metas(schema.clone(), 0, directory.borrow_mut())?;
         let metas = IndexMeta::with_schema(schema);

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -365,6 +365,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_open_non_existant_path() {
+        assert!(MmapDirectory::open(PathBuf::from("./nowhere")).is_err());
+    }
+
+    #[test]
     fn test_open_empty() {
         // empty file is actually an edge case because those
         // cannot be mmapped.

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,9 @@ pub enum TantivyError {
     /// File already exists, this is a problem when we try to write into a new file.
     #[fail(display = "file already exists: '{:?}'", _0)]
     FileAlreadyExists(PathBuf),
+    /// Index already exists in this directory
+    #[fail(display = "index already exists")]
+    IndexAlreadyExists,
     /// Failed to acquire file lock
     #[fail(
         display = "Failed to acquire Lockfile: {:?}. Possible causes: another IndexWriter instance or panic during previous lock drop.",

--- a/src/schema/field_entry.rs
+++ b/src/schema/field_entry.rs
@@ -14,7 +14,7 @@ use std::fmt;
 /// - a field name
 /// - a field type, itself wrapping up options describing
 /// how the field should be indexed.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FieldEntry {
     name: String,
     field_type: FieldType,

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -134,6 +134,20 @@ struct InnerSchema {
     fields_map: HashMap<String, Field>, // transient
 }
 
+impl PartialEq for InnerSchema {
+    fn eq(&self, other: &InnerSchema) -> bool {
+        if self.fields.len() !=  other.fields.len() {
+            return false;
+        }
+        self.fields.iter()
+            .zip(other.fields.iter())
+            .all(|(left, right)| left == right)
+    }
+}
+
+impl Eq for InnerSchema {}
+
+
 /// Tantivy has a very strict schema.
 /// You need to specify in advance, whether a field is indexed or not,
 /// stored or not, and RAM-based or not.
@@ -154,7 +168,7 @@ struct InnerSchema {
 /// let schema = schema_builder.build();
 ///
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Schema(Arc<InnerSchema>);
 
 impl Schema {

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -136,12 +136,7 @@ struct InnerSchema {
 
 impl PartialEq for InnerSchema {
     fn eq(&self, other: &InnerSchema) -> bool {
-        if self.fields.len() !=  other.fields.len() {
-            return false;
-        }
-        self.fields.iter()
-            .zip(other.fields.iter())
-            .all(|(left, right)| left == right)
+        self.fields == other.fields
     }
 }
 


### PR DESCRIPTION
closes #416 

- adds open_or_create
- makes create throw a new error if an index already exists