### PR TITLE
Fix NGram processing of non-ascii characters

### DIFF
--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -291,6 +291,46 @@ pub mod test {
     }
 
     #[test]
+    fn test_ngram_non_ascii_tokenizer() {
+        use super::NgramTokenizer;
+        use tokenizer::tokenizer::TokenStream;
+        use tokenizer::tokenizer::Tokenizer;
+
+        let tokenizer = NgramTokenizer::new(1, 2, false);
+        let mut tokens: Vec<Token> = vec![];
+        {
+            let mut add_token = |token: &Token| {
+                tokens.push(token.clone());
+            };
+            tokenizer.token_stream("hεllo").process(&mut add_token);
+        }
+        assert_eq!(tokens.len(), 9);
+        assert_token(&tokens[0], 0, "h", 0, 1);
+        assert_token(&tokens[1], 0, "hε", 0, 3);
+        assert_token(&tokens[2], 1, "ε", 1, 3);
+        assert_token(&tokens[3], 1, "εl", 1, 4);
+        assert_token(&tokens[4], 2, "l", 3, 4);
+        assert_token(&tokens[5], 2, "ll", 3, 5);
+        assert_token(&tokens[6], 3, "l", 4, 5);
+        assert_token(&tokens[7], 3, "lo", 4, 6);
+        assert_token(&tokens[8], 4, "o", 5, 6);
+
+        let tokenizer = NgramTokenizer::new(2, 5, true);
+        let mut tokens: Vec<Token> = vec![];
+        {
+            let mut add_token = |token: &Token| {
+                tokens.push(token.clone());
+            };
+            tokenizer.token_stream("hεllo").process(&mut add_token);
+        }
+        assert_eq!(tokens.len(), 4);
+        assert_token(&tokens[0], 0, "hε", 0, 3);
+        assert_token(&tokens[1], 0, "hεl", 0, 4);
+        assert_token(&tokens[2], 0, "hεll", 0, 5);
+        assert_token(&tokens[3], 0, "hεllo", 0, 6);
+    }
+
+    #[test]
     fn test_tokenizer_empty() {
         let tokenizer_manager = TokenizerManager::default();
         let en_tokenizer = tokenizer_manager.get("en_stem").unwrap();

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -309,11 +309,11 @@ pub mod test {
         assert_token(&tokens[1], 0, "hε", 0, 3);
         assert_token(&tokens[2], 1, "ε", 1, 3);
         assert_token(&tokens[3], 1, "εl", 1, 4);
-        assert_token(&tokens[4], 2, "l", 3, 4);
-        assert_token(&tokens[5], 2, "ll", 3, 5);
-        assert_token(&tokens[6], 3, "l", 4, 5);
-        assert_token(&tokens[7], 3, "lo", 4, 6);
-        assert_token(&tokens[8], 4, "o", 5, 6);
+        assert_token(&tokens[4], 3, "l", 3, 4);
+        assert_token(&tokens[5], 3, "ll", 3, 5);
+        assert_token(&tokens[6], 4, "l", 4, 5);
+        assert_token(&tokens[7], 4, "lo", 4, 6);
+        assert_token(&tokens[8], 5, "o", 5, 6);
 
         let tokenizer = NgramTokenizer::new(2, 5, true);
         let mut tokens: Vec<Token> = vec![];

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -157,34 +157,33 @@ pub use self::tokenizer::BoxedTokenizer;
 pub use self::tokenizer::{Token, TokenFilter, TokenStream, Tokenizer};
 pub use self::tokenizer_manager::TokenizerManager;
 
-/// This is a function that can be used in tests and doc tests
-/// to assert a token's correctness.
-/// TODO: can this be wrapped in #[cfg(test)] so as not to be in the
-/// public api?
-pub fn assert_token(token: &Token, position: usize, text: &str, from: usize, to: usize) {
-    assert_eq!(
-        token.position, position,
-        "expected position {} but {:?}",
-        position, token
-    );
-    assert_eq!(token.text, text, "expected text {} but {:?}", text, token);
-    assert_eq!(
-        token.offset_from, from,
-        "expected offset_from {} but {:?}",
-        from, token
-    );
-    assert_eq!(
-        token.offset_to, to,
-        "expected offset_to {} but {:?}",
-        to, token
-    );
-}
 
 #[cfg(test)]
-pub mod test {
-    use super::assert_token;
+pub mod tests {
     use super::Token;
     use super::TokenizerManager;
+
+
+    /// This is a function that can be used in tests and doc tests
+    /// to assert a token's correctness.
+    pub fn assert_token(token: &Token, position: usize, text: &str, from: usize, to: usize) {
+        assert_eq!(
+            token.position, position,
+            "expected position {} but {:?}",
+            position, token
+        );
+        assert_eq!(token.text, text, "expected text {} but {:?}", text, token);
+        assert_eq!(
+            token.offset_from, from,
+            "expected offset_from {} but {:?}",
+            from, token
+        );
+        assert_eq!(
+            token.offset_to, to,
+            "expected offset_to {} but {:?}",
+            to, token
+        );
+    }
 
     #[test]
     fn test_raw_tokenizer() {
@@ -222,112 +221,6 @@ pub mod test {
         assert_token(&tokens[1], 1, "happi", 7, 12);
         assert_token(&tokens[2], 2, "tax", 13, 16);
         assert_token(&tokens[3], 3, "payer", 17, 22);
-    }
-
-    #[test]
-    fn test_ngram_tokenizer() {
-        use super::{LowerCaser, NgramTokenizer};
-        use tokenizer::tokenizer::TokenStream;
-        use tokenizer::tokenizer::Tokenizer;
-
-        let tokenizer_manager = TokenizerManager::default();
-        tokenizer_manager.register("ngram12", NgramTokenizer::new(1, 2, false));
-        tokenizer_manager.register(
-            "ngram3",
-            NgramTokenizer::new(3, 3, false).filter(LowerCaser),
-        );
-        tokenizer_manager.register(
-            "edgegram5",
-            NgramTokenizer::new(2, 5, true).filter(LowerCaser),
-        );
-
-        let tokenizer = NgramTokenizer::new(1, 2, false);
-        let mut tokens: Vec<Token> = vec![];
-        {
-            let mut add_token = |token: &Token| {
-                tokens.push(token.clone());
-            };
-            tokenizer.token_stream("hello").process(&mut add_token);
-        }
-        assert_eq!(tokens.len(), 9);
-        assert_token(&tokens[0], 0, "h", 0, 1);
-        assert_token(&tokens[1], 0, "he", 0, 2);
-        assert_token(&tokens[2], 1, "e", 1, 2);
-        assert_token(&tokens[3], 1, "el", 1, 3);
-        assert_token(&tokens[4], 2, "l", 2, 3);
-        assert_token(&tokens[5], 2, "ll", 2, 4);
-        assert_token(&tokens[6], 3, "l", 3, 4);
-        assert_token(&tokens[7], 3, "lo", 3, 5);
-        assert_token(&tokens[8], 4, "o", 4, 5);
-
-        let tokenizer = tokenizer_manager.get("ngram3").unwrap();
-        let mut tokens: Vec<Token> = vec![];
-        {
-            let mut add_token = |token: &Token| {
-                tokens.push(token.clone());
-            };
-            tokenizer.token_stream("Hello").process(&mut add_token);
-        }
-        assert_eq!(tokens.len(), 3);
-        assert_token(&tokens[0], 0, "hel", 0, 3);
-        assert_token(&tokens[1], 1, "ell", 1, 4);
-        assert_token(&tokens[2], 2, "llo", 2, 5);
-
-        let tokenizer = tokenizer_manager.get("edgegram5").unwrap();
-        let mut tokens: Vec<Token> = vec![];
-        {
-            let mut add_token = |token: &Token| {
-                tokens.push(token.clone());
-            };
-            tokenizer
-                .token_stream("Frankenstein")
-                .process(&mut add_token);
-        }
-        assert_eq!(tokens.len(), 4);
-        assert_token(&tokens[0], 0, "fr", 0, 2);
-        assert_token(&tokens[1], 0, "fra", 0, 3);
-        assert_token(&tokens[2], 0, "fran", 0, 4);
-        assert_token(&tokens[3], 0, "frank", 0, 5);
-    }
-
-    #[test]
-    fn test_ngram_non_ascii_tokenizer() {
-        use super::NgramTokenizer;
-        use tokenizer::tokenizer::TokenStream;
-        use tokenizer::tokenizer::Tokenizer;
-
-        let tokenizer = NgramTokenizer::new(1, 2, false);
-        let mut tokens: Vec<Token> = vec![];
-        {
-            let mut add_token = |token: &Token| {
-                tokens.push(token.clone());
-            };
-            tokenizer.token_stream("hεllo").process(&mut add_token);
-        }
-        assert_eq!(tokens.len(), 9);
-        assert_token(&tokens[0], 0, "h", 0, 1);
-        assert_token(&tokens[1], 0, "hε", 0, 3);
-        assert_token(&tokens[2], 1, "ε", 1, 3);
-        assert_token(&tokens[3], 1, "εl", 1, 4);
-        assert_token(&tokens[4], 3, "l", 3, 4);
-        assert_token(&tokens[5], 3, "ll", 3, 5);
-        assert_token(&tokens[6], 4, "l", 4, 5);
-        assert_token(&tokens[7], 4, "lo", 4, 6);
-        assert_token(&tokens[8], 5, "o", 5, 6);
-
-        let tokenizer = NgramTokenizer::new(2, 5, true);
-        let mut tokens: Vec<Token> = vec![];
-        {
-            let mut add_token = |token: &Token| {
-                tokens.push(token.clone());
-            };
-            tokenizer.token_stream("hεllo").process(&mut add_token);
-        }
-        assert_eq!(tokens.len(), 4);
-        assert_token(&tokens[0], 0, "hε", 0, 3);
-        assert_token(&tokens[1], 0, "hεl", 0, 4);
-        assert_token(&tokens[2], 0, "hεll", 0, 5);
-        assert_token(&tokens[3], 0, "hεllo", 0, 6);
     }
 
     #[test]

--- a/src/tokenizer/ngram_tokenizer.rs
+++ b/src/tokenizer/ngram_tokenizer.rs
@@ -2,14 +2,15 @@ use super::{Token, TokenStream, Tokenizer};
 
 /// Tokenize the text by splitting words into n-grams of the given size(s)
 ///
-/// With this tokenizer, the `position` field expresses the starting offset of the ngram
-/// rather than the `token` offset.
+/// With this tokenizer, the `position` is always 0.
+/// Beware however, in presence of multiple value for the same field,
+/// the position will be `POSITION_GAP * index of value`.
 ///
 /// Example 1: `hello` would be tokenized as (min_gram: 2, max_gram: 3, prefix_only: false)
 ///
 /// | Term     | he  | hel | el  | ell | ll  | llo | lo |
 /// |----------|-----|-----|-----|-----|-----|-----|----|
-/// | Position | 0   | 0   | 1   | 1   | 2   | 2   | 3  |
+/// | Position | 0   | 0   | 0   | 0   | 0   | 0   | 0  |
 /// | Offsets  | 0,2 | 0,3 | 1,3 | 1,4 | 2,4 | 2,5 | 3,5|
 ///
 /// Example 2: `hello` would be tokenized as (min_gram: 2, max_gram: 5, prefix_only: **true**)
@@ -29,21 +30,53 @@ use super::{Token, TokenStream, Tokenizer};
 /// # Example
 ///
 /// ```
-/// extern crate tantivy;
+/// # extern crate tantivy;
 /// use tantivy::tokenizer::*;
-/// use tantivy::tokenizer::assert_token;
-///
 /// # fn main() {
 /// let tokenizer = NgramTokenizer::new(2, 3, false);
 /// let mut stream = tokenizer.token_stream("hello");
-///
-/// assert_token(stream.next().unwrap(), 0, "he", 0, 2);
-/// assert_token(stream.next().unwrap(), 0, "hel", 0, 3);
-/// assert_token(stream.next().unwrap(), 1, "el", 1, 3);
-/// assert_token(stream.next().unwrap(), 1, "ell", 1, 4);
-/// assert_token(stream.next().unwrap(), 2, "ll", 2, 4);
-/// assert_token(stream.next().unwrap(), 2, "llo", 2, 5);
-/// assert_token(stream.next().unwrap(), 3, "lo", 3, 5);
+/// {
+///     let token = stream.next().unwrap();
+///     assert_eq!(token.text, "he");
+///     assert_eq!(token.offset_from, 0);
+///     assert_eq!(token.offset_to, 2);
+/// }
+/// {
+///   let token = stream.next().unwrap();
+///     assert_eq!(token.text, "hel");
+///     assert_eq!(token.offset_from, 0);
+///     assert_eq!(token.offset_to, 3);
+/// }
+/// {
+///   let token = stream.next().unwrap();
+///     assert_eq!(token.text, "el");
+///     assert_eq!(token.offset_from, 1);
+///     assert_eq!(token.offset_to, 3);
+/// }
+/// {
+///   let token = stream.next().unwrap();
+///     assert_eq!(token.text, "ell");
+///     assert_eq!(token.offset_from, 1);
+///     assert_eq!(token.offset_to, 4);
+/// }
+/// {
+///   let token = stream.next().unwrap();
+///     assert_eq!(token.text, "ll");
+///     assert_eq!(token.offset_from, 2);
+///     assert_eq!(token.offset_to, 4);
+/// }
+/// {
+///   let token = stream.next().unwrap();
+///     assert_eq!(token.text, "llo");
+///     assert_eq!(token.offset_from, 2);
+///     assert_eq!(token.offset_to, 5);
+/// }
+/// {
+///   let token = stream.next().unwrap();
+///   assert_eq!(token.text, "lo");
+///   assert_eq!(token.offset_from, 3);
+///   assert_eq!(token.offset_to, 5);
+/// }
 /// assert!(stream.next().is_none());
 /// # }
 /// ```
@@ -65,111 +98,67 @@ impl NgramTokenizer {
             min_gram <= max_gram,
             "min_gram must not be greater than max_gram"
         );
-
         NgramTokenizer {
             min_gram,
             max_gram,
             prefix_only,
         }
     }
+
+    /// Create a `NGramTokenizer` which generates tokens for all inner ngrams.
+    ///
+    /// This is as opposed to only prefix ngrams    .
+    pub fn all_ngrams(min_gram: usize, max_gram:usize) ->  NgramTokenizer {
+        Self::new(min_gram, max_gram, false)
+    }
+
+    /// Create a `NGramTokenizer` which only generates tokens for the
+    /// prefix ngrams.
+    pub fn prefix_only(min_gram: usize, max_gram: usize) -> NgramTokenizer {
+        Self::new(min_gram, max_gram, true)
+    }
 }
+
+
 pub struct NgramTokenStream<'a> {
-    text: &'a str,
-    bytes: &'a [u8],
-    bytes_length: usize,
-    position: usize,
-    token: Token,
-    min_gram: usize,
-    max_gram: usize,
-    gram_size: usize,
+    // parameters
+    ngram_charidx_iterator: StutteringIterator<CodepointFrontiers<'a>>,
+    // true if the NgramTokenStream is in prefix mode.
     prefix_only: bool,
+    // input
+    text: &'a str,
+    // output
+    token: Token,
 }
 
 impl<'a> Tokenizer<'a> for NgramTokenizer {
     type TokenStreamImpl = NgramTokenStream<'a>;
 
     fn token_stream(&self, text: &'a str) -> Self::TokenStreamImpl {
+        let char_limit_it = CodepointFrontiers::for_str(text);
         NgramTokenStream {
-            text,
-            bytes: text.as_bytes(),
-            bytes_length: text.as_bytes().len(),
-            position: 0,
-            token: Token::default(),
-            min_gram: self.min_gram,
-            max_gram: self.max_gram,
+            ngram_charidx_iterator: StutteringIterator::new(
+                char_limit_it,
+                self.min_gram,
+                self.max_gram),
             prefix_only: self.prefix_only,
-            gram_size: self.min_gram,
+            text,
+            token: Token::default(),
         }
-    }
-}
-
-impl<'a> NgramTokenStream<'a> {
-    /// Get the next set of token options
-    /// cycle through 1,2 (min..=max)
-    /// returning None if processing should stop
-    fn chomp(&mut self) -> Option<(usize, usize)> {
-        // Have we exceeded the bounds of the text we are indexing?
-
-        if self.gram_size > self.max_gram {
-            if self.prefix_only {
-                return None;
-            }
-
-            // since we aren't just processing edges
-            // we need to reset the gram size
-            self.gram_size = self.min_gram;
-
-            // and move down the chain of letters (respecting multi-byte chars)
-            let char_width = utf8_char_width(self.bytes[self.position]);
-
-            self.position += char_width;
-        }
-
-        // convert gram_size into bytes
-        // TODO: how could this be better?
-        let mut size = 0;
-        for _ in 0..self.gram_size {
-            let next_char_index = self.position + size;
-            if next_char_index >= self.bytes_length {
-                // reset - this has gotten too big
-                size = 0;
-                // exit the loop
-                break;
-            } else {
-                let byte = self.bytes[next_char_index];
-                let width = utf8_char_width(byte);
-                size += width;
-            }
-        }
-
-        let result = if size > 0 && (self.position + size) <= self.bytes_length {
-            Some((self.position, size))
-        } else {
-            None
-        };
-
-        self.gram_size += 1;
-
-        result
     }
 }
 
 impl<'a> TokenStream for NgramTokenStream<'a> {
     fn advance(&mut self) -> bool {
-        // clear out working token text
-        self.token.text.clear();
-
-        if let Some((position, size)) = self.chomp() {
-            self.token.position = self.position;
-            let offset_from = position;
-            let offset_to = offset_from + size;
-
+        if let Some((offset_from, offset_to)) = self.ngram_charidx_iterator.next() {
+            if self.prefix_only && offset_from > 0 {
+                return false;
+            }
+            self.token.position = 0;
             self.token.offset_from = offset_from;
             self.token.offset_to = offset_to;
-
-            let a = &self.text[offset_from..offset_to];
-            self.token.text.push_str(a);
-
+            self.token.text.clear();
+            self.token.text.push_str(&self.text[offset_from..offset_to]);
             true
         } else {
             false
@@ -179,45 +168,234 @@ impl<'a> TokenStream for NgramTokenStream<'a> {
     fn token(&self) -> &Token {
         &self.token
     }
-
     fn token_mut(&mut self) -> &mut Token {
         &mut self.token
     }
 }
 
-#[cfg(test)]
-mod test {
-    #[test]
-    fn multi_byte() {
-        use super::utf8_char_width;
 
-        let multi = "ε";
-        let bytes = multi.as_bytes();
-        assert_eq!(bytes.len(), 2);
-        assert_eq!(utf8_char_width(bytes[0]), 2);
+/// This iterator takes an underlying Iterator
+/// and emits all of the pairs `(a,b)` such that
+/// a and b are items emitted by the iterator at
+/// an interval between `min_gram` and `max_gram`.
+///
+/// The elements are emitted in the order of appearance
+/// of `a` first, `b` then.
+///
+/// See test_stutterring_iterator for an example of its
+/// output.
+struct StutteringIterator<T> {
+    underlying: T,
+    min_gram: usize,
+    max_gram: usize,
+
+    memory: Vec<usize>,
+    cursor: usize,
+    gram_len: usize
+}
+
+impl<T> StutteringIterator<T> where T: Iterator<Item=usize> {
+    pub fn new(mut underlying: T, min_gram: usize, max_gram: usize) -> StutteringIterator<T> {
+        let memory: Vec<usize> = (&mut underlying).take(max_gram + 1).collect();
+        if memory.len() < min_gram {
+            StutteringIterator {
+                underlying,
+                min_gram: 1,
+                max_gram: 0,
+                memory,
+                cursor: 0,
+                gram_len: min_gram,
+            }
+        } else {
+            StutteringIterator {
+                underlying,
+                min_gram,
+                max_gram: memory.len() - 1,
+                memory,
+                cursor: 0,
+                gram_len: min_gram,
+            }
+        }
+
     }
 }
 
-static UTF8_CHAR_WIDTH: [u8; 256] = [
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, // 0x1F
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, // 0x3F
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, // 0x5F
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, // 0x7F
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, // 0x9F
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, // 0xBF
-    0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    2, // 0xDF
-    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // 0xEF
-    4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xFF
-];
+impl<T> Iterator for StutteringIterator<T>
+    where T: Iterator<Item=usize> {
+    type Item = (usize, usize);
 
-#[inline]
-pub fn utf8_char_width(b: u8) -> usize {
-    unsafe { *UTF8_CHAR_WIDTH.get_unchecked(b as usize) as usize }
+    fn next(&mut self) -> Option<(usize, usize)> {
+        if self.max_gram >= self.min_gram {
+            if self.gram_len <= self.max_gram {
+                let start = self.memory[self.cursor % self.memory.len()];
+                let stop = self.memory[(self.cursor + self.gram_len) % self.memory.len()];
+                self.gram_len += 1;
+                Some((start, stop))
+            } else {
+                self.gram_len = self.min_gram;
+                if let Some(next_val) = self.underlying.next() {
+                    self.memory[self.cursor] = next_val;
+                } else {
+                    self.max_gram -= 1;
+                }
+                self.cursor = (self.cursor + 1) % self.memory.len();
+                self.next()
+            }
+        } else {
+            None
+        }
+    }
+}
+
+struct CodepointFrontiers<'a> {
+    len: Option<usize>,
+    offsets: std::str::CharIndices<'a>
+}
+
+impl<'a> CodepointFrontiers<'a> {
+    fn for_str(s: &'a str) -> Self {
+        if s.is_empty() {
+            CodepointFrontiers {
+                len: None,
+                offsets: s.char_indices(),
+            }
+        } else {
+            CodepointFrontiers {
+                len: Some(s.len()),
+                offsets: s.char_indices()
+            }
+        }
+    }
+}
+
+impl<'a> Iterator for CodepointFrontiers<'a> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<usize> {
+        self.offsets.next()
+            .map(|(offset,_)| offset)
+            .or_else(|| self.len.take())
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+
+    use tokenizer::tokenizer::{TokenStream, Tokenizer};
+    use super::NgramTokenizer;
+    use tokenizer::Token;
+    use tokenizer::tests::assert_token;
+    use super::StutteringIterator;
+
+    fn test_helper<T: TokenStream>(mut tokenizer: T) -> Vec<Token> {
+        let mut tokens: Vec<Token> = vec![];
+        tokenizer.process(&mut |token: &Token| tokens.push(token.clone()));
+        tokens
+    }
+
+    #[test]
+    fn test_ngram_tokenizer_1_2_false() {
+        let tokens = test_helper(NgramTokenizer::all_ngrams(1, 2).token_stream("hello"));
+        assert_eq!(tokens.len(), 9);
+        assert_token(&tokens[0], 0, "h", 0, 1);
+        assert_token(&tokens[1], 0, "he", 0, 2);
+        assert_token(&tokens[2], 0, "e", 1, 2);
+        assert_token(&tokens[3], 0, "el", 1, 3);
+        assert_token(&tokens[4], 0, "l", 2, 3);
+        assert_token(&tokens[5], 0, "ll", 2, 4);
+        assert_token(&tokens[6], 0, "l", 3, 4);
+        assert_token(&tokens[7], 0, "lo", 3, 5);
+        assert_token(&tokens[8], 0, "o", 4, 5);
+    }
+
+    #[test]
+    fn test_ngram_tokenizer_min_max_equal() {
+        let tokens = test_helper(NgramTokenizer::all_ngrams(3, 3).token_stream("hello"));
+        assert_eq!(tokens.len(), 3);
+        assert_token(&tokens[0], 0, "hel", 0, 3);
+        assert_token(&tokens[1], 0, "ell", 1, 4);
+        assert_token(&tokens[2], 0, "llo", 2, 5);
+    }
+
+    #[test]
+    fn test_ngram_tokenizer_2_5_prefix() {
+        let tokens = test_helper(NgramTokenizer::prefix_only(2, 5).token_stream("frankenstein"));
+        assert_eq!(tokens.len(), 4);
+        assert_token(&tokens[0], 0, "fr", 0, 2);
+        assert_token(&tokens[1], 0, "fra", 0, 3);
+        assert_token(&tokens[2], 0, "fran", 0, 4);
+        assert_token(&tokens[3], 0, "frank", 0, 5);
+    }
+
+    #[test]
+    fn test_ngram_non_ascii_1_2() {
+        let tokens = test_helper(NgramTokenizer::all_ngrams(1, 2).token_stream("hεllo"));
+        assert_eq!(tokens.len(), 9);
+        assert_token(&tokens[0], 0, "h", 0, 1);
+        assert_token(&tokens[1], 0, "hε", 0, 3);
+        assert_token(&tokens[2], 0, "ε", 1, 3);
+        assert_token(&tokens[3], 0, "εl", 1, 4);
+        assert_token(&tokens[4], 0, "l", 3, 4);
+        assert_token(&tokens[5], 0, "ll", 3, 5);
+        assert_token(&tokens[6], 0, "l", 4, 5);
+        assert_token(&tokens[7], 0, "lo", 4, 6);
+        assert_token(&tokens[8], 0, "o", 5, 6);
+    }
+
+    #[test]
+    fn test_ngram_non_ascii_2_5_prefix() {
+        let tokens = test_helper(NgramTokenizer::prefix_only(2, 5).token_stream("hεllo"));
+        assert_eq!(tokens.len(), 4);
+        assert_token(&tokens[0], 0, "hε", 0, 3);
+        assert_token(&tokens[1], 0, "hεl", 0, 4);
+        assert_token(&tokens[2], 0, "hεll", 0, 5);
+        assert_token(&tokens[3], 0, "hεllo", 0, 6);
+    }
+
+    #[test]
+    fn test_ngram_empty() {
+        let tokens = test_helper(NgramTokenizer::all_ngrams(2, 5).token_stream(""));
+        assert_eq!(tokens.len(), 0);
+    }
+
+
+    #[test]
+    #[should_panic(expected = "min_gram must be greater than 0")]
+    fn test_ngram_min_max_interval_empty() {
+        test_helper(NgramTokenizer::all_ngrams(0, 2).token_stream("hellossss"));
+    }
+
+    #[test]
+    #[should_panic(expected = "min_gram must not be greater than max_gram")]
+    fn test_invalid_interval_should_panic_if_smaller() {
+        NgramTokenizer::all_ngrams(2, 1);
+    }
+
+    #[test]
+    fn test_stutterring_iterator() {
+        let rg: Vec<usize> = (0..10).collect();
+        let mut it = StutteringIterator::new(rg.into_iter(), 1, 2);
+        assert_eq!(it.next(), Some((0, 1)));
+        assert_eq!(it.next(), Some((0, 2)));
+        assert_eq!(it.next(), Some((1, 2)));
+        assert_eq!(it.next(), Some((1, 3)));
+        assert_eq!(it.next(), Some((2, 3)));
+        assert_eq!(it.next(), Some((2, 4)));
+        assert_eq!(it.next(), Some((3, 4)));
+        assert_eq!(it.next(), Some((3, 5)));
+        assert_eq!(it.next(), Some((4, 5)));
+        assert_eq!(it.next(), Some((4, 6)));
+        assert_eq!(it.next(), Some((5, 6)));
+        assert_eq!(it.next(), Some((5, 7)));
+        assert_eq!(it.next(), Some((6, 7)));
+        assert_eq!(it.next(), Some((6, 8)));
+        assert_eq!(it.next(), Some((7, 8)));
+        assert_eq!(it.next(), Some((7, 9)));
+        assert_eq!(it.next(), Some((8, 9)));
+        assert_eq!(it.next(), None);
+
+    }
+
 }

--- a/src/tokenizer/ngram_tokenizer.rs
+++ b/src/tokenizer/ngram_tokenizer.rs
@@ -1,5 +1,4 @@
 use super::{Token, TokenStream, Tokenizer};
-use std::str::Chars;
 
 /// Tokenize the text by splitting words into n-grams of the given size(s)
 ///
@@ -76,9 +75,9 @@ impl NgramTokenizer {
 }
 pub struct NgramTokenStream<'a> {
     text: &'a str,
-    chars: Chars<'a>,
+    bytes: &'a [u8],
+    bytes_length: usize,
     position: usize,
-    char_count: usize,
     token: Token,
     min_gram: usize,
     max_gram: usize,
@@ -90,13 +89,10 @@ impl<'a> Tokenizer<'a> for NgramTokenizer {
     type TokenStreamImpl = NgramTokenStream<'a>;
 
     fn token_stream(&self, text: &'a str) -> Self::TokenStreamImpl {
-        let chars = text.chars();
-        let char_count = text.chars().count();
-
         NgramTokenStream {
             text,
-            chars,
-            char_count,
+            bytes: text.as_bytes(),
+            bytes_length: text.as_bytes().len(),
             position: 0,
             token: Token::default(),
             min_gram: self.min_gram,
@@ -113,6 +109,7 @@ impl<'a> NgramTokenStream<'a> {
     /// returning None if processing should stop
     fn chomp(&mut self) -> Option<(usize, usize)> {
         // Have we exceeded the bounds of the text we are indexing?
+
         if self.gram_size > self.max_gram {
             if self.prefix_only {
                 return None;
@@ -122,30 +119,35 @@ impl<'a> NgramTokenStream<'a> {
             // we need to reset the gram size
             self.gram_size = self.min_gram;
 
-            // and move down the chain of letters
-            self.position += 1;
+            // and move down the chain of letters (respecting multi-byte chars)
+            let char_width = utf8_char_width(self.bytes[self.position]);
+
+            self.position += char_width;
         }
 
-        let result = if (self.position + self.gram_size) <= self.char_count {
-            // map from logical to physical
-            let chars = self.chars.clone();
-            let raw_position = chars.take(self.position).map(|c| c.len_utf8()).sum();
+        // convert gram_size into bytes
+        // TODO: how could this be better?
+        let mut size = 0;
+        for _ in 0..self.gram_size {
+            let next_char_index = self.position + size;
+            if next_char_index >= self.bytes_length {
+                // reset - this has gotten too big
+                size = 0;
+                // exit the loop
+                break;
+            } else {
+                let byte = self.bytes[next_char_index];
+                let width = utf8_char_width(byte);
+                size += width;
+            }
+        }
 
-            let chars = self.chars.clone();
-            let raw_size = chars
-                .skip(self.position)
-                .take(self.gram_size)
-                .map(|c| c.len_utf8())
-                .sum();
-
-            println!("logical: {},{}", self.position, self.gram_size);
-            println!("physical: {},{}", raw_position, raw_size);
-            Some((raw_position, raw_size))
+        let result = if size > 0 && (self.position + size) <= self.bytes_length {
+            Some((self.position, size))
         } else {
             None
         };
 
-        // increase the gram size for the next pass
         self.gram_size += 1;
 
         result
@@ -165,7 +167,8 @@ impl<'a> TokenStream for NgramTokenStream<'a> {
             self.token.offset_from = offset_from;
             self.token.offset_to = offset_to;
 
-            self.token.text.push_str(&self.text[offset_from..offset_to]);
+            let a = &self.text[offset_from..offset_to];
+            self.token.text.push_str(a);
 
             true
         } else {
@@ -180,4 +183,41 @@ impl<'a> TokenStream for NgramTokenStream<'a> {
     fn token_mut(&mut self) -> &mut Token {
         &mut self.token
     }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn multi_byte() {
+        use super::utf8_char_width;
+
+        let multi = "ε";
+        let bytes = multi.as_bytes();
+        assert_eq!(bytes.len(), 2);
+        assert_eq!(utf8_char_width(bytes[0]), 2);
+    }
+}
+
+static UTF8_CHAR_WIDTH: [u8; 256] = [
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, // 0x1F
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, // 0x3F
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, // 0x5F
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, // 0x7F
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, // 0x9F
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, // 0xBF
+    0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, // 0xDF
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // 0xEF
+    4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xFF
+];
+
+#[inline]
+pub fn utf8_char_width(b: u8) -> usize {
+    unsafe { *UTF8_CHAR_WIDTH.get_unchecked(b as usize) as usize }
 }

--- a/src/tokenizer/ngram_tokenizer.rs
+++ b/src/tokenizer/ngram_tokenizer.rs
@@ -290,13 +290,20 @@ impl<'a> Iterator for CodepointFrontiers<'a> {
     }
 }
 
+const CODEPOINT_UTF8_WIDTH: [u8; 16] = [
+    1, 1, 1, 1,
+    1, 1, 1, 1,
+    2, 2, 2, 2,
+    2, 2, 3, 4,
+];
+
 // Number of bytes to encode a codepoint in UTF-8 given
 // the first byte.
 //
 // To do that we count the number of higher significant bits set to `1`.
 fn utf8_codepoint_width(b: u8) -> usize {
-    let num_bits = (!b | 15u8).leading_zeros() as usize;
-    num_bits.max(1)
+    let higher_4_bits = (b as usize) >> 4;
+    CODEPOINT_UTF8_WIDTH[higher_4_bits] as usize
 }
 
 #[cfg(test)]


### PR DESCRIPTION
closes #429 

- [ ] does this design pass "performance" demands

i'm calling clone twice to iterate the chars and get the physical offsets

- [ ] did i correctly map the concept of position and other token properties

i need to reread the docs to make sure i wrote the test code correctly when asserting non-ascii tokens