### PR TITLE
WIP: compiling to wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ overflow-checks = true
 [features]
 # by default no-fail is disabled. We manually enable it when running test.
 default = ["mmap", "no_fail"]
-mmap = ["atomicwrites", "fs2", "memmap"]
+mmap = ["atomicwrites", "fs2", "memmap", "fst-regex/mmap"]
 lz4-compression = ["lz4"]
 no_fail = ["fail/no_fail"]
 unstable = [] # useful for benches.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ byteorder = "1.0"
 lazy_static = "1"
 regex = "1.0"
 tantivy-fst = "0.1"
-memmap = { version="0.7", optional = true }
-fst-regex = { version = "0.2", features = [], default-features = false }
+memmap = {version = "0.7", optional=true}
 lz4 = {version="1.20", optional=true}
 snap = {version="0.2"}
 atomicwrites = {version="0.2.2", optional=true}
@@ -34,7 +33,7 @@ fs2={version="0.4", optional=true}
 itertools = "0.8"
 levenshtein_automata = {version="0.1", features=["fst_automaton"]}
 bit-set = "0.5"
-uuid = { version = "0.7", features = ["v4", "serde"] }
+uuid = { version = "0.7.2", features = ["v4", "serde"] }
 crossbeam = "0.5"
 futures = "0.1"
 futures-cpupool = "0.1"
@@ -72,7 +71,7 @@ overflow-checks = true
 [features]
 # by default no-fail is disabled. We manually enable it when running test.
 default = ["mmap", "no_fail"]
-mmap = ["atomicwrites", "fs2", "memmap", "fst-regex/mmap"]
+mmap = ["atomicwrites", "fs2",  "memmap"]
 lz4-compression = ["lz4"]
 no_fail = ["fail/no_fail"]
 unstable = [] # useful for benches.
@@ -80,5 +79,3 @@ wasm-bindgen = ["uuid/wasm-bindgen"]
 
 [badges]
 travis-ci = { repository = "tantivy-search/tantivy" }
-
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ byteorder = "1.0"
 lazy_static = "1"
 regex = "1.0"
 tantivy-fst = "0.1"
-memmap = "0.7"
-fst-regex = { version="0.2" }
+memmap = { version="0.7", optional = true }
+fst-regex = { version = "0.2", features = [], default-features = false }
 lz4 = {version="1.20", optional=true}
 snap = {version="0.2"}
 atomicwrites = {version="0.2.2", optional=true}
@@ -72,10 +72,11 @@ overflow-checks = true
 [features]
 # by default no-fail is disabled. We manually enable it when running test.
 default = ["mmap", "no_fail"]
-mmap = ["atomicwrites", "fs2"]
+mmap = ["atomicwrites", "fs2", "memmap"]
 lz4-compression = ["lz4"]
 no_fail = ["fail/no_fail"]
 unstable = [] # useful for benches.
+wasm-bindgen = ["uuid/wasm-bindgen"]
 
 [badges]
 travis-ci = { repository = "tantivy-search/tantivy" }


### PR DESCRIPTION
I started an experiment to compile tantivy to wasm. These are some of the features I had to adjust to get it to compile. 

The index writing doesn't work because it seems to be using std lib features that aren't supported by wasm target yet, such as `std::thread`s. I can see from https://github.com/fulmicoton/tantivy-wasm that tantivy seems to have worked with wasm at some point with `StaticDirectory` which confirms that at least the index writing never worked in wasm.

Although there is no `StaticDirectory` in the current master, I don't see the `Directory` trait having changed since when it existed, so I could add it back. But I am a little stumped at how the `DATA: &'static [u8]` was generated. Would appreciate any pointers