### PR TITLE
add support for float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Tantivy 0.11.0
+=====================
+
+- Added f64 field. Internally reuse u64 code the same way i64 does (@fdb-hiroshima)
+
 Tantivy 0.10.0
 =====================
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ performance for different type of queries / collection.
 - Multithreaded indexing (indexing English Wikipedia takes < 3 minutes on my desktop)
 - Mmap directory
 - SIMD integer compression when the platform/CPU includes the SSE2 instruction set.
-- Single valued and multivalued u64 and i64 fast fields (equivalent of doc values in Lucene)
+- Single valued and multivalued u64, i64 and f64 fast fields (equivalent of doc values in Lucene)
 - `&[u8]` fast fields
-- Text, i64, u64, dates and hierarchical facet fields
+- Text, i64, u64, f64, dates and hierarchical facet fields
 - LZ4 compressed document store
 - Range queries
 - Faceted search

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -160,6 +160,7 @@ impl TopDocs {
                 .fast_fields()
                 .u64(field)
                 .expect("Field requested is not a i64/u64 fast field.");
+            //TODO error message missmatch actual behavior for i64
             move |doc: DocId| ff_reader.get(doc)
         })
     }

--- a/src/common/serialize.rs
+++ b/src/common/serialize.rs
@@ -102,6 +102,19 @@ impl FixedSize for i64 {
     const SIZE_IN_BYTES: usize = 8;
 }
 
+impl BinarySerializable for f64 {
+    fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_f64::<Endianness>(*self)
+    }
+    fn deserialize<R: Read>(reader: &mut R) -> io::Result<Self> {
+        reader.read_f64::<Endianness>()
+    }
+}
+
+impl FixedSize for f64 {
+    const SIZE_IN_BYTES: usize = 8;
+}
+
 impl BinarySerializable for u8 {
     fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
         writer.write_u8(*self)
@@ -170,6 +183,11 @@ pub mod test {
     #[test]
     fn test_serialize_i64() {
         fixed_size_test::<i64>();
+    }
+
+    #[test]
+    fn test_serialize_f64() {
+        fixed_size_test::<f64>();
     }
 
     #[test]

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -48,7 +48,7 @@ mod readers;
 mod serializer;
 mod writer;
 
-/// Trait for types that are allowed for fast fields: (u64 or i64).
+/// Trait for types that are allowed for fast fields: (u64, i64 and f64).
 pub trait FastValue: Default + Clone + Copy + Send + Sync + PartialOrd {
     /// Converts a value from u64
     ///
@@ -114,11 +114,33 @@ impl FastValue for i64 {
     }
 }
 
+impl FastValue for f64 {
+    fn from_u64(val: u64) -> Self {
+        common::u64_to_f64(val)
+    }
+
+    fn to_u64(&self) -> u64 {
+        common::f64_to_u64(*self)
+    }
+
+    fn fast_field_cardinality(field_type: &FieldType) -> Option<Cardinality> {
+        match *field_type {
+            FieldType::F64(ref integer_options) => integer_options.get_fastfield_cardinality(),
+            _ => None,
+        }
+    }
+
+    fn as_u64(&self) -> u64 {
+        self.to_bits()
+    }
+}
+
 fn value_to_u64(value: &Value) -> u64 {
     match *value {
         Value::U64(ref val) => *val,
         Value::I64(ref val) => common::i64_to_u64(*val),
-        _ => panic!("Expected a u64/i64 field, got {:?} ", value),
+        Value::F64(ref val) => common::f64_to_u64(*val),
+        _ => panic!("Expected a u64/i64/f64 field, got {:?} ", value),
     }
 }
 

--- a/src/fastfield/writer.rs
+++ b/src/fastfield/writer.rs
@@ -25,13 +25,13 @@ impl FastFieldsWriter {
 
         for (field_id, field_entry) in schema.fields().iter().enumerate() {
             let field = Field(field_id as u32);
-            let default_value = if let FieldType::I64(_) = *field_entry.field_type() {
-                common::i64_to_u64(0i64)
-            } else {
-                0u64
+            let default_value = match *field_entry.field_type() {
+                FieldType::I64(_) => common::i64_to_u64(0i64),
+                FieldType::F64(_) => common::f64_to_u64(0.0f64),
+                _ => 0u64,
             };
             match *field_entry.field_type() {
-                FieldType::I64(ref int_options) | FieldType::U64(ref int_options) => {
+                FieldType::I64(ref int_options) | FieldType::U64(ref int_options) | FieldType::F64(ref int_options) => {
                     match int_options.get_fastfield_cardinality() {
                         Some(Cardinality::SingleValue) => {
                             let mut fast_field_writer = IntFastFieldWriter::new(field);
@@ -142,9 +142,9 @@ impl FastFieldsWriter {
 /// bitpacked and the number of bits required for bitpacking
 /// can only been known once we have seen all of the values.
 ///
-/// Both u64, and i64 use the same writer.
-/// i64 are just remapped to the `0..2^64 - 1`
-/// using `common::i64_to_u64`.
+/// Both u64, i64 and f64 use the same writer.
+/// i64 and f64 are just remapped to the `0..2^64 - 1`
+/// using `common::i64_to_u64` and `common::f64_to_u64`.
 pub struct IntFastFieldWriter {
     field: Field,
     vals: Vec<u8>,
@@ -203,8 +203,8 @@ impl IntFastFieldWriter {
     /// Extract the value associated to the fast field for
     /// this document.
     ///
-    /// i64 are remapped to u64 using the logic
-    /// in `common::i64_to_u64`.
+    /// i64 and f64 are remapped to u64 using the logic
+    /// in `common::i64_to_u64` and `common::f64_to_u64`.
     ///
     /// If the value is missing, then the default value is used
     /// instead.

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -207,6 +207,7 @@ impl IndexMerger {
                 }
                 FieldType::U64(ref options)
                 | FieldType::I64(ref options)
+                | FieldType::F64(ref options)
                 | FieldType::Date(ref options) => match options.get_fastfield_cardinality() {
                     Some(Cardinality::SingleValue) => {
                         self.write_single_fast_field(field, fast_field_serializer)?;

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -214,6 +214,17 @@ impl SegmentWriter {
                         }
                     }
                 }
+                FieldType::F64(ref int_option) => {
+                    if int_option.is_indexed() {
+                        for field_value in field_values {
+                            let term = Term::from_field_f64(
+                                field_value.field(),
+                                field_value.value().f64_value(),
+                            );
+                            self.multifield_postings.subscribe(doc_id, &term);
+                        }
+                    }
+                }
                 FieldType::Bytes => {
                     // Do nothing. Bytes only supports fast fields.
                 }

--- a/src/postings/postings_writer.rs
+++ b/src/postings/postings_writer.rs
@@ -35,6 +35,7 @@ fn posting_from_field_entry(field_entry: &FieldEntry) -> Box<dyn PostingsWriter>
             .unwrap_or_else(|| SpecializedPostingsWriter::<NothingRecorder>::new_boxed()),
         FieldType::U64(_)
         | FieldType::I64(_)
+        | FieldType::F64(_)
         | FieldType::Date(_)
         | FieldType::HierarchicalFacet => SpecializedPostingsWriter::<NothingRecorder>::new_boxed(),
         FieldType::Bytes => {
@@ -154,7 +155,7 @@ impl MultiFieldPostingsWriter {
                         .collect();
                     unordered_term_mappings.insert(field, mapping);
                 }
-                FieldType::U64(_) | FieldType::I64(_) | FieldType::Date(_) => {}
+                FieldType::U64(_) | FieldType::I64(_) | FieldType::F64(_) | FieldType::Date(_) => {}
                 FieldType::Bytes => {}
             }
 

--- a/src/query/query_parser/query_grammar.rs
+++ b/src/query/query_parser/query_grammar.rs
@@ -20,7 +20,7 @@ parser! {
 parser! {
     fn word[I]()(I) -> String
     where [I: Stream<Item = char>] {
-        many1(satisfy(char::is_alphanumeric))
+        many1(satisfy(|c: char| c.is_alphanumeric() || c=='.'))
                .and_then(|s: String| {
                    match s.as_str() {
                      "OR" => Err(StreamErrorFor::<I>::unexpected_static_message("OR")),
@@ -266,6 +266,7 @@ mod test {
         test_parse_query_to_ast_helper("(+a)", "+(\"a\")");
         test_parse_query_to_ast_helper("(+a +b)", "(+(\"a\") +(\"b\"))");
         test_parse_query_to_ast_helper("abc:toto", "abc:\"toto\"");
+        test_parse_query_to_ast_helper("abc:1.1", "abc:\"1.1\"");
         test_parse_query_to_ast_helper("+abc:toto", "+(abc:\"toto\")");
         test_parse_query_to_ast_helper("(+abc:toto -titi)", "(+(abc:\"toto\") -(\"titi\"))");
         test_parse_query_to_ast_helper("-abc:toto", "-(abc:\"toto\")");
@@ -277,6 +278,7 @@ mod test {
         test_parse_query_to_ast_helper("foo:[1 TO toto}", "foo:[\"1\" TO \"toto\"}");
         test_parse_query_to_ast_helper("foo:[* TO toto}", "foo:[\"*\" TO \"toto\"}");
         test_parse_query_to_ast_helper("foo:[1 TO *}", "foo:[\"1\" TO \"*\"}");
+        test_parse_query_to_ast_helper("foo:[1.1 TO *}", "foo:[\"1.1\" TO \"*\"}");
         test_is_parse_err("abc +    ");
     }
 }

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -252,7 +252,7 @@ impl QueryParser {
                 let val: f64 = f64::from_str(phrase)?;
                 let term = Term::from_field_f64(field, val);
                 Ok(vec![(0, term)])
-            } 
+            }
             FieldType::Date(_) => match chrono::DateTime::parse_from_rfc3339(phrase) {
                 Ok(x) => Ok(vec![(
                     0,

--- a/src/schema/document.rs
+++ b/src/schema/document.rs
@@ -88,6 +88,11 @@ impl Document {
         self.add(FieldValue::new(field, Value::I64(value)));
     }
 
+    /// Add a f64 field
+    pub fn add_f64(&mut self, field: Field, value: f64) {
+        self.add(FieldValue::new(field, Value::F64(value)));
+    }
+
     /// Add a date field
     pub fn add_date(&mut self, field: Field, value: &DateTime) {
         self.add(FieldValue::new(field, Value::Date(*value)));

--- a/src/schema/flags.rs
+++ b/src/schema/flags.rs
@@ -22,7 +22,7 @@ pub const STORED: SchemaFlagList<StoredFlag, ()> = SchemaFlagList {
 pub struct IndexedFlag;
 /// Flag to mark the field as indexed.
 ///
-/// The `INDEXED` flag can only be used when building `IntOptions` (`u64` and `i64` fields)
+/// The `INDEXED` flag can only be used when building `IntOptions` (`u64`, `i64` and `f64` fields)
 /// Of course, text fields can also be indexed... But this is expressed by using either the
 /// `STRING` (untokenized) or `TEXT` (tokenized with the english tokenizer) flags.
 pub const INDEXED: SchemaFlagList<IndexedFlag, ()> = SchemaFlagList {
@@ -36,7 +36,7 @@ pub struct FastFlag;
 ///
 /// Fast fields can be random-accessed rapidly. Fields useful for scoring, filtering
 /// or collection should be mark as fast fields.
-/// The `FAST` flag can only be used when building `IntOptions` (`u64` and `i64` fields)
+/// The `FAST` flag can only be used when building `IntOptions` (`u64`, `i64` and `f64` fields)
 pub const FAST: SchemaFlagList<FastFlag, ()> = SchemaFlagList {
     head: FastFlag,
     tail: (),

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -54,7 +54,7 @@ On the other hand setting the field as stored or not determines whether the fiel
 when [`searcher.doc(doc_address)`](../struct.Searcher.html#method.doc) is called.
 
 
-## Setting a u64 or a i64 field
+## Setting a u64, a i64 or a f64 field
 
 ### Example
 

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -508,7 +508,7 @@ mod tests {
         let author_field = schema_builder.add_text_field("author", STRING);
         let count_field = schema_builder.add_u64_field("count", count_options);
         let popularity_field = schema_builder.add_i64_field("popularity", popularity_options);
-        let score_field = schema_builder.add_i64_field("score", score_options);
+        let score_field = schema_builder.add_f64_field("score", score_options);
         let schema = schema_builder.build();
         {
             let doc = schema.parse_document("{}").unwrap();

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -19,15 +19,27 @@ where
     B: AsRef<[u8]>;
 
 impl Term {
-    /// Builds a term given a field, and a u64-value
+    /// Builds a term given a field, and a i64-value
     ///
-    /// Assuming the term has a field id of 1, and a u64 value of 3234,
+    /// Assuming the term has a field id of 1, and a i64 value of 3234,
     /// the Term will have 8 bytes.
     ///
     /// The first four byte are dedicated to storing the field id as a u64.
     /// The 4 following bytes are encoding the u64 value.
     pub fn from_field_i64(field: Field, val: i64) -> Term {
         let val_u64: u64 = common::i64_to_u64(val);
+        Term::from_field_u64(field, val_u64)
+    }
+
+    /// Builds a term given a field, and a f64-value
+    ///
+    /// Assuming the term has a field id of 1, and a u64 value of 3234,
+    /// the Term will have 8 bytes. <= this is wrong
+    ///
+    /// The first four byte are dedicated to storing the field id as a u64.
+    /// The 4 following bytes are encoding the u64 value.
+    pub fn from_field_f64(field: Field, val: f64) -> Term {
+        let val_u64: u64 = common::f64_to_u64(val);
         Term::from_field_u64(field, val_u64)
     }
 
@@ -112,6 +124,11 @@ impl Term {
         self.set_u64(common::i64_to_u64(val));
     }
 
+    /// Sets a `f64` value in the term.
+    pub fn set_f64(&mut self, val: f64) {
+        self.set_u64(common::f64_to_u64(val));
+    }
+
     fn set_bytes(&mut self, bytes: &[u8]) {
         self.0.resize(4, 0u8);
         self.0.extend(bytes);
@@ -159,6 +176,15 @@ where
     /// if the term is not a `i64` field.
     pub fn get_i64(&self) -> i64 {
         common::u64_to_i64(BigEndian::read_u64(&self.0.as_ref()[4..]))
+    }
+
+    /// Returns the `f64` value stored in a term.
+    ///
+    /// # Panics
+    /// ... or returns an invalid value
+    /// if the term is not a `i64` field.
+    pub fn get_f64(&self) -> f64 {
+        common::u64_to_f64(BigEndian::read_u64(&self.0.as_ref()[4..]))
     }
 
     /// Returns the text associated with the term.

--- a/src/schema/value.rs
+++ b/src/schema/value.rs
@@ -116,10 +116,7 @@ impl<'de> Deserialize<'de> for Value {
 
 impl Value {
     /// Returns the text value, provided the value is of the `Str` type.
-    ///
-    /// # Panics
-    /// If the value is not of type `Str`
-    /// #TODO doc comment is wrong
+    /// (Returns None if the value is not of the `Str` type).
     pub fn text(&self) -> Option<&str> {
         match *self {
             Value::Str(ref text) => Some(text),

--- a/src/schema/value.rs
+++ b/src/schema/value.rs
@@ -149,7 +149,7 @@ impl Value {
     /// Returns the f64-value, provided the value is of the `F64` type.
     ///
     /// # Panics
-    /// If the value is not of type `I64`
+    /// If the value is not of type `F64`
     pub fn f64_value(&self) -> f64 {
         match *self {
             Value::F64(ref value) => *value,

--- a/src/schema/value.rs
+++ b/src/schema/value.rs
@@ -2,11 +2,11 @@ use crate::schema::Facet;
 use crate::DateTime;
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
+use std::{fmt, cmp::Ordering};
 
 /// Value represents the value of a any field.
 /// It is an enum over all over all of the possible field type.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub enum Value {
     /// The str type is used for any text information.
     Str(String),
@@ -14,12 +14,48 @@ pub enum Value {
     U64(u64),
     /// Signed 64-bits Integer `i64`
     I64(i64),
+    /// 64-bits Float `f64`
+    F64(f64),
     /// Signed 64-bits Date time stamp `date`
     Date(DateTime),
     /// Hierarchical Facet
     Facet(Facet),
     /// Arbitrarily sized byte array
     Bytes(Vec<u8>),
+}
+
+impl Eq for Value {}
+impl Ord for Value {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self,other) {
+            (Value::Str(l), Value::Str(r)) => l.cmp(r),
+            (Value::U64(l), Value::U64(r)) => l.cmp(r),
+            (Value::I64(l), Value::I64(r)) => l.cmp(r),
+            (Value::Date(l), Value::Date(r)) => l.cmp(r),
+            (Value::Facet(l), Value::Facet(r)) => l.cmp(r),
+            (Value::Bytes(l), Value::Bytes(r)) => l.cmp(r),
+            (Value::F64(l), Value::F64(r)) => {
+                match (l.is_nan(),r.is_nan()) {
+                    (false, false) => l.partial_cmp(r).unwrap(), // only fail on NaN
+                    (true, true) => Ordering::Equal,
+                    (true, false) => Ordering::Less, // we define NaN as less than -∞
+                    (false, true) => Ordering::Greater,
+                }
+            }
+            (Value::Str(_), _) => Ordering::Less,
+            (_, Value::Str(_)) => Ordering::Greater,
+            (Value::U64(_), _) => Ordering::Less,
+            (_, Value::U64(_)) => Ordering::Greater,
+            (Value::I64(_), _) => Ordering::Less,
+            (_, Value::I64(_)) => Ordering::Greater,
+            (Value::F64(_), _) => Ordering::Less,
+            (_, Value::F64(_)) => Ordering::Greater,
+            (Value::Date(_), _) => Ordering::Less,
+            (_, Value::Date(_)) => Ordering::Greater,
+            (Value::Facet(_), _) => Ordering::Less,
+            (_, Value::Facet(_)) => Ordering::Greater,
+        }
+    }
 }
 
 impl Serialize for Value {
@@ -31,6 +67,7 @@ impl Serialize for Value {
             Value::Str(ref v) => serializer.serialize_str(v),
             Value::U64(u) => serializer.serialize_u64(u),
             Value::I64(u) => serializer.serialize_i64(u),
+            Value::F64(u) => serializer.serialize_f64(u),
             Value::Date(ref date) => serializer.serialize_i64(date.timestamp()),
             Value::Facet(ref facet) => facet.serialize(serializer),
             Value::Bytes(ref bytes) => serializer.serialize_bytes(bytes),
@@ -60,6 +97,10 @@ impl<'de> Deserialize<'de> for Value {
                 Ok(Value::I64(v))
             }
 
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E> {
+                Ok(Value::F64(v))
+            }
+
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
                 Ok(Value::Str(v.to_owned()))
             }
@@ -78,6 +119,7 @@ impl Value {
     ///
     /// # Panics
     /// If the value is not of type `Str`
+    /// #TODO doc comment is wrong
     pub fn text(&self) -> Option<&str> {
         match *self {
             Value::Str(ref text) => Some(text),
@@ -92,7 +134,7 @@ impl Value {
     pub fn u64_value(&self) -> u64 {
         match *self {
             Value::U64(ref value) => *value,
-            _ => panic!("This is not a text field."),
+            _ => panic!("This is not a u64 field."),
         }
     }
 
@@ -103,9 +145,20 @@ impl Value {
     pub fn i64_value(&self) -> i64 {
         match *self {
             Value::I64(ref value) => *value,
-            _ => panic!("This is not a text field."),
+            _ => panic!("This is not a i64 field."),
         }
     }
+
+    /// Returns the f64-value, provided the value is of the `F64` type.
+    ///
+    /// # Panics
+    /// If the value is not of type `I64`
+    pub fn f64_value(&self) -> f64 {
+        match *self {
+            Value::F64(ref value) => *value,
+            _ => panic!("This is not a f64 field."),
+        }
+    }    
 
     /// Returns the Date-value, provided the value is of the `Date` type.
     ///
@@ -137,6 +190,12 @@ impl From<i64> for Value {
     }
 }
 
+impl From<f64> for Value {
+    fn from(v: f64) -> Value {
+        Value::F64(v)
+    }
+}
+
 impl From<DateTime> for Value {
     fn from(date_time: DateTime) -> Value {
         Value::Date(date_time)
@@ -163,7 +222,7 @@ impl From<Vec<u8>> for Value {
 
 mod binary_serialize {
     use super::Value;
-    use crate::common::BinarySerializable;
+    use crate::common::{BinarySerializable, f64_to_u64, u64_to_f64};
     use crate::schema::Facet;
     use chrono::{TimeZone, Utc};
     use std::io::{self, Read, Write};
@@ -174,6 +233,7 @@ mod binary_serialize {
     const HIERARCHICAL_FACET_CODE: u8 = 3;
     const BYTES_CODE: u8 = 4;
     const DATE_CODE: u8 = 5;
+    const F64_CODE: u8 = 6;
 
     impl BinarySerializable for Value {
         fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
@@ -189,6 +249,10 @@ mod binary_serialize {
                 Value::I64(ref val) => {
                     I64_CODE.serialize(writer)?;
                     val.serialize(writer)
+                }
+                Value::F64(ref val) => {
+                    F64_CODE.serialize(writer)?;
+                    f64_to_u64(*val).serialize(writer)
                 }
                 Value::Date(ref val) => {
                     DATE_CODE.serialize(writer)?;
@@ -218,6 +282,10 @@ mod binary_serialize {
                 I64_CODE => {
                     let value = i64::deserialize(reader)?;
                     Ok(Value::I64(value))
+                }
+                F64_CODE => {
+                    let value = u64_to_f64(u64::deserialize(reader)?);
+                    Ok(Value::F64(value))
                 }
                 DATE_CODE => {
                     let timestamp = i64::deserialize(reader)?;

--- a/src/termdict/mod.rs
+++ b/src/termdict/mod.rs
@@ -14,6 +14,9 @@ lexicographical order matches the natural order of integers.
 `i64`-terms are transformed to `u64` using a continuous mapping `val ⟶ val - i64::min_value()`
 and then treated as a `u64`.
 
+`f64`-terms are transformed to `u64` using a mapping that preserve order, and are then treated
+as `u64`.
+
 A second datastructure makes it possible to access a [`TermInfo`](../postings/struct.TermInfo.html).
 */
 


### PR DESCRIPTION
as for i64, they are mapped to u64 for indexing, but using a different formula.
query parser doesn't work yet
fix #327 