### PR TITLE
Add a doctest to BooleanQuery

### DIFF
--- a/query-grammar/src/occur.rs
+++ b/query-grammar/src/occur.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::fmt::Write;
 
 /// Defines whether a term in a query must be present,
-/// should be present or must not be present.
+/// should be present or must be not present.
 #[derive(Debug, Clone, Hash, Copy, Eq, PartialEq)]
 pub enum Occur {
     /// For a given document to be considered for scoring,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,15 +212,13 @@ pub type Score = f32;
 pub type SegmentLocalId = u32;
 
 impl DocAddress {
-    /// Return the segment ordinal.
-    /// The segment ordinal is an id identifying the segment
-    /// hosting the document. It is only meaningful, in the context
-    /// of a searcher.
+    /// Return the segment ordinal id that identifies the segment
+    /// hosting the document in the `Searcher` it is called from.
     pub fn segment_ord(self) -> SegmentLocalId {
         self.0
     }
 
-    /// Return the segment local `DocId`
+    /// Return the segment-local `DocId`
     pub fn doc(self) -> DocId {
         self.1
     }
@@ -229,11 +227,11 @@ impl DocAddress {
 /// `DocAddress` contains all the necessary information
 /// to identify a document given a `Searcher` object.
 ///
-/// It consists in an id identifying its segment, and
-/// its segment-local `DocId`.
+/// It consists of an id identifying its segment, and
+/// a segment-local `DocId`.
 ///
 /// The id used for the segment is actually an ordinal
-/// in the list of segment hold by a `Searcher`.
+/// in the list of `Segment`s held by a `Searcher`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct DocAddress(pub SegmentLocalId, pub DocId);
 

--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -25,8 +25,6 @@ use std::collections::BTreeSet;
 /// You combine other query types and their `Occur`ances into one `BooleanQuery`
 ///
 /// ```rust
-///#[macro_use]
-///extern crate tantivy;
 ///use tantivy::collector::Count;
 ///use tantivy::query::{BooleanQuery, Occur, PhraseQuery, Query, TermQuery};
 ///use tantivy::schema::{IndexRecordOption, Schema, TEXT};
@@ -49,11 +47,11 @@ use std::collections::BTreeSet;
 ///        ));
 ///        index_writer.add_document(doc!(
 ///            title => "A Dairy Cow",
-///            body => "find me",
+///            body => "hidden",
 ///        ));
 ///        index_writer.add_document(doc!(
 ///            title => "A Dairy Cow",
-///            body => "i won't be found",
+///            body => "found",
 ///        ));
 ///        index_writer.add_document(doc!(
 ///            title => "The Diary of a Young Girl",
@@ -163,7 +161,6 @@ impl Query for BooleanQuery {
 impl BooleanQuery {
     /// Helper method to create a boolean query matching a given list of terms.
     /// The resulting query is a disjunction of the terms.
-    #[cfg(test)]
     pub fn new_multiterms_query(terms: Vec<Term>) -> BooleanQuery {
         let occur_term_queries: Vec<(Occur, Box<dyn Query>)> = terms
             .into_iter()

--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -25,6 +25,7 @@ use std::collections::BTreeSet;
 /// You combine other query types and their `Occur`ances into one `BooleanQuery`
 ///
 /// ```rust
+///use tantivy::doc;
 ///use tantivy::collector::Count;
 ///use tantivy::query::{BooleanQuery, Occur, PhraseQuery, Query, TermQuery};
 ///use tantivy::schema::{IndexRecordOption, Schema, TEXT};
@@ -112,7 +113,7 @@ use std::collections::BTreeSet;
 ///        IndexRecordOption::Basic,
 ///    ));
 ///    let query5 = BooleanQuery::from(vec![(Occur::Must, body_query),
-///                                         (Occur::Must, query4)]);
+///                                         (Occur::Must, Box::new(query4))]);
 ///    let count5 = searcher.search(&query5, &Count)?;
 ///    assert_eq!(count5, 1);
 ///    Ok(())

--- a/src/query/phrase_query/phrase_query.rs
+++ b/src/query/phrase_query/phrase_query.rs
@@ -40,7 +40,7 @@ impl PhraseQuery {
         PhraseQuery::new_with_offset(terms_with_offset)
     }
 
-    /// Creates a new `PhraseQuery` given a list of terms and there offsets.
+    /// Creates a new `PhraseQuery` given a list of terms and their offsets.
     ///
     /// Can be used to provide custom offset for each term.
     pub fn new_with_offset(mut terms: Vec<(usize, Term)>) -> PhraseQuery {
@@ -73,7 +73,7 @@ impl PhraseQuery {
             .collect::<Vec<Term>>()
     }
 
-    /// Returns the `PhraseWeight` for the given phrase query given a specific `searcher`.  
+    /// Returns the `PhraseWeight` for the given phrase query given a specific `searcher`.
     ///
     /// This function is the same as `.weight(...)` except it returns
     /// a specialized type `PhraseWeight` instead of a Boxed trait.


### PR DESCRIPTION
Closes #446 - add a doctest explaining and showing that a BooleanQuery is the building block for other query types. 

This is a draft, since I am not sure if this closes the ticket completely. The first comment suggests adding a `::new()` constructor. Doesn't the `::from` constructor already satisfy our requirements? 

I can add a type alias explaining that (Occur, Box<dyn Query>) = Clause thus changing the type signature to 
Vec<Clause>

Mark a function that is only used in tests to be compiled for tests only. If we expect it to be used externally (it's marked pub), maybe we should add an integration test to simulate that behaviour.

Fix doc-comments in a couple of related files