### PR TITLE
Create segment id from string, expose inventory.

### DIFF
--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -216,7 +216,7 @@ impl Index {
         Index::open(mmap_directory)
     }
 
-    pub(crate) fn inventory(&self) -> &SegmentMetaInventory {
+    pub fn inventory(&self) -> &SegmentMetaInventory {
         &self.inventory
     }
 

--- a/src/core/segment_id.rs
+++ b/src/core/segment_id.rs
@@ -46,6 +46,12 @@ impl SegmentId {
         SegmentId(create_uuid())
     }
 
+    /// Creates a new segment id from a uuid string.
+    pub fn from_uuid_string(uuid_string: &str) -> Result<SegmentId, uuid::parser::ParseError> {
+        let uuid = Uuid::parse_str(uuid_string)?;
+        Ok(SegmentId(uuid))
+    }
+
     /// Returns a shorter identifier of the segment.
     ///
     /// We are using UUID4, so only 6 bits are fixed,


### PR DESCRIPTION
Hi,
we're starting to use tantivy as the search engine core for [sonar](https://github.com/Frando/sonar/), which will end up being integrated with a [Dat](https://dat.foundation) based p2p stack. We're looking into replicating the actual tantivy index over p2p as well - as its basically an append-only log of segments, it should be very much feasable.

As a very first step this PR allows to create segments from predefined info by allowing to create a segment id from string and exposing the segment inventory, which allows to add new segments then.