### PR TITLE
Fix trait object in doctest

### DIFF
--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -128,7 +128,7 @@ impl TopDocs {
     /// ///
     /// /// `field` is required to be a FAST field.
     /// fn docs_sorted_by_rating(searcher: &Searcher,
-    ///                          query: &Query,
+    ///                          query: &dyn Query,
     ///                          sort_by_field: Field)
     ///     -> Result<Vec<(u64, DocAddress)>> {
     ///


### PR DESCRIPTION
A doctest is failing in AppVeyor because it uses a trait object without the `dyn` keyword:
```rust
---- src\collector\top_score_collector.rs - collector::top_score_collector::TopDocs::order_by_u64_field (line 89) stdout ----
error: trait objects without an explicit `dyn` are deprecated
  --> src\collector\top_score_collector.rs:131:34
   |
44 |                          query: &Query,
   |                                  ^^^^^ help: use `dyn`: `dyn Query`
   |
note: lint level defined here
  --> src\collector\top_score_collector.rs:89:9
   |
2  | #![deny(warnings)]
   |         ^^^^^^^^
   = note: #[deny(bare_trait_objects)] implied by #[deny(warnings)]
error: aborting due to previous error
```