### PR TITLE
Remove unnecessary duplicate methods

### DIFF
--- a/src/postings/serializer.rs
+++ b/src/postings/serializer.rs
@@ -141,10 +141,7 @@ impl<'a> FieldSerializer<'a> {
             FieldType::Str(ref text_options) => {
                 if let Some(text_indexing_options) = text_options.get_indexing_options() {
                     let index_option = text_indexing_options.index_option();
-                    (
-                        index_option.is_termfreq_enabled(),
-                        index_option.is_position_enabled(),
-                    )
+                    (index_option.has_freq(), index_option.has_positions())
                 } else {
                     (false, false)
                 }

--- a/src/schema/index_record_option.rs
+++ b/src/schema/index_record_option.rs
@@ -29,22 +29,6 @@ pub enum IndexRecordOption {
 }
 
 impl IndexRecordOption {
-    /// Returns true iff the term frequency will be encoded.
-    pub fn is_termfreq_enabled(self) -> bool {
-        match self {
-            IndexRecordOption::WithFreqsAndPositions | IndexRecordOption::WithFreqs => true,
-            _ => false,
-        }
-    }
-
-    /// Returns true iff the term positions within the document are stored as well.
-    pub fn is_position_enabled(self) -> bool {
-        match self {
-            IndexRecordOption::WithFreqsAndPositions => true,
-            _ => false,
-        }
-    }
-
     /// Returns true iff this option includes encoding
     /// term frequencies.
     pub fn has_freq(self) -> bool {


### PR DESCRIPTION
Closes #649

Spotted by @imor

Grepping for "is_(positions|termfreq)_enabled" finds nothing, so it should be safe to delete.