### PR TITLE
fix Term documentation

### DIFF
--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -22,10 +22,10 @@ impl Term {
     /// Builds a term given a field, and a i64-value
     ///
     /// Assuming the term has a field id of 1, and a i64 value of 3234,
-    /// the Term will have 8 bytes.
+    /// the Term will have 12 bytes.
     ///
     /// The first four byte are dedicated to storing the field id as a u64.
-    /// The 4 following bytes are encoding the u64 value.
+    /// The 8 following bytes are encoding the u64 value.
     pub fn from_field_i64(field: Field, val: i64) -> Term {
         let val_u64: u64 = common::i64_to_u64(val);
         Term::from_field_u64(field, val_u64)
@@ -33,11 +33,11 @@ impl Term {
 
     /// Builds a term given a field, and a f64-value
     ///
-    /// Assuming the term has a field id of 1, and a u64 value of 3234,
-    /// the Term will have 8 bytes. <= this is wrong
+    /// Assuming the term has a field id of 1, and a f64 value of 1.5,
+    /// the Term will have 12 bytes.
     ///
     /// The first four byte are dedicated to storing the field id as a u64.
-    /// The 4 following bytes are encoding the u64 value.
+    /// The 8 following bytes are encoding the f64 as a u64 value.
     pub fn from_field_f64(field: Field, val: f64) -> Term {
         let val_u64: u64 = common::f64_to_u64(val);
         Term::from_field_u64(field, val_u64)
@@ -46,10 +46,10 @@ impl Term {
     /// Builds a term given a field, and a DateTime value
     ///
     /// Assuming the term has a field id of 1, and a timestamp i64 value of 3234,
-    /// the Term will have 8 bytes.
+    /// the Term will have 12 bytes.
     ///
     /// The first four byte are dedicated to storing the field id as a u64.
-    /// The 4 following bytes are encoding the DateTime as i64 timestamp value.
+    /// The 8 following bytes are encoding the DateTime as i64 timestamp value.
     pub fn from_field_date(field: Field, val: &DateTime) -> Term {
         let val_timestamp = val.timestamp();
         Term::from_field_i64(field, val_timestamp)
@@ -82,10 +82,10 @@ impl Term {
     /// Builds a term given a field, and a u64-value
     ///
     /// Assuming the term has a field id of 1, and a u64 value of 3234,
-    /// the Term will have 8 bytes.
+    /// the Term will have 12 bytes.
     ///
     /// The first four byte are dedicated to storing the field id as a u64.
-    /// The 4 following bytes are encoding the u64 value.
+    /// The 8 following bytes are encoding the u64 value.
     pub fn from_field_u64(field: Field, val: u64) -> Term {
         let mut term = Term(vec![0u8; INT_TERM_LEN]);
         term.set_field(field);
@@ -182,7 +182,7 @@ where
     ///
     /// # Panics
     /// ... or returns an invalid value
-    /// if the term is not a `i64` field.
+    /// if the term is not a `f64` field.
     pub fn get_f64(&self) -> f64 {
         common::u64_to_f64(BigEndian::read_u64(&self.0.as_ref()[4..]))
     }


### PR DESCRIPTION
u64-based fields are actually 4+8=12 bytes long