### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -327,8 +327,7 @@ mod tests_mmap_specific {
                 .unwrap();
             assert!(managed_directory.exists(test_path1));
             assert!(managed_directory.exists(test_path2));
-            let living_files: HashSet<PathBuf> =
-                [test_path1.to_owned()].iter().cloned().collect();
+            let living_files: HashSet<PathBuf> = [test_path1.to_owned()].iter().cloned().collect();
             managed_directory.garbage_collect(|| living_files);
             assert!(managed_directory.exists(test_path1));
             assert!(!managed_directory.exists(test_path2));

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -328,7 +328,7 @@ mod tests_mmap_specific {
             assert!(managed_directory.exists(test_path1));
             assert!(managed_directory.exists(test_path2));
             let living_files: HashSet<PathBuf> =
-                [test_path1.to_owned()].into_iter().cloned().collect();
+                [test_path1.to_owned()].iter().cloned().collect();
             managed_directory.garbage_collect(|| living_files);
             assert!(managed_directory.exists(test_path1));
             assert!(!managed_directory.exists(test_path2));


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
