### PR TITLE
fix crash on commit with deleted documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Tantivy 0.11.0
 - Avoid rebuilding Regex automaton whenever a regex query is reused. #639 (@brainlock)
 - Add footer with some metadata to index files. #605 (@fdb-hiroshima)
 - TopDocs collector: ensure stable sorting on equal score. #671 (@brainlock)
+- Fix crash when committing multiple times with deleted documents. #681 (@brainlock)
  
 ## How to update?
 


### PR DESCRIPTION
The following sequence of events:

- start with an empty index
- add and then delete a document
- add at least 32 documents
- commit
- commit again

leads to a crash on the second commit operation

```
thread 'segment_updater0' panicked at 'index out of bounds: the len is 4 but the index is 4', src/fastfield/delete.rs:65:21
```

This happens because the `DeleteBitSet` used to track the deleted
documents in a segment is sized to be big enough to represent the
max doc id added, but the `is_deleted()` method can be used with
arbitrarily big indexes, leading to the access out of bounds.

The ultimate culprit is the `advance_deletes` function, which is
doing:
```
        for doc in 0u32..max_doc {
            if segment_reader.is_deleted(doc) {
                delete_bitset.insert(doc as usize);
            }
        }
```

`max_doc` here is bigger than the maximum index of the delete bitset
because we added enough documents.

This patch fixes the crash by making `DeleteBitSet::is_deleted(doc)`
method safe to call with any index.

Fixes gh-681