### PR TITLE
Prevent tokens from being stored in the document store.

### DIFF
--- a/examples/pre_tokenized_text.rs
+++ b/examples/pre_tokenized_text.rs
@@ -65,8 +65,7 @@ fn main() -> tantivy::Result<()> {
         tokens: pre_tokenize_text(body_text),
     };
 
-    // Now lets create a document and add our `PreTokenizedString` using
-    // `add_pre_tokenized_text` method of `Document`
+    // Now lets create a document and add our `PreTokenizedString`
     let old_man_doc = doc!(title => title_tok, body => body_tok);
 
     // ... now let's just add it to the IndexWriter
@@ -114,6 +113,9 @@ fn main() -> tantivy::Result<()> {
 
     assert_eq!(count, 2);
 
+    // Now let's print out the results.
+    // Note that the tokens are not stored along with the original text
+    // in the document store
     for (_score, doc_address) in top_docs {
         let retrieved_doc = searcher.doc(doc_address)?;
         println!("Document: {}", schema.to_json(&retrieved_doc));

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -249,6 +249,7 @@ impl SegmentWriter {
             }
         }
         doc.filter_fields(|field| schema.get_field_entry(field).is_stored());
+        doc.prepare_for_store();
         let doc_writer = self.segment_serializer.get_store_writer();
         doc_writer.store(&doc)?;
         self.max_doc += 1;


### PR DESCRIPTION
Commit adds prepare_for_store method to Document, which changes all
PreTokenizedString values into String values. The method is called
before adding document to the document store to prevent tokens from
being saved there. Commit also adds small changes to comments in
pre_tokenized_text example.
This follows the discussion in #669 PR.