### PR TITLE
Make u64_lenient() handle f64 fast fields too

### DIFF
--- a/src/fastfield/readers.rs
+++ b/src/fastfield/readers.rs
@@ -203,6 +203,9 @@ impl FastFieldReaders {
         if let Some(i64s_ff_reader) = self.i64s(field) {
             return Some(i64s_ff_reader.into_u64s_reader());
         }
+        if let Some(f64s_ff_reader) = self.f64s(field) {
+            return Some(f64s_ff_reader.into_u64s_reader());
+        }
         None
     }
 

--- a/src/fastfield/readers.rs
+++ b/src/fastfield/readers.rs
@@ -156,8 +156,6 @@ impl FastFieldReaders {
     /// If the field is a i64-fast field, return the associated u64 reader. Values are
     /// mapped from i64 to u64 using a (well the, it is unique) monotonic mapping.    ///
     ///
-    ///TODO should it also be lenient with f64?
-    ///
     /// This method is useful when merging segment reader.
     pub(crate) fn u64_lenient(&self, field: Field) -> Option<FastFieldReader<u64>> {
         if let Some(u64_ff_reader) = self.u64(field) {
@@ -165,6 +163,9 @@ impl FastFieldReaders {
         }
         if let Some(i64_ff_reader) = self.i64(field) {
             return Some(i64_ff_reader.into_u64_reader());
+        }
+        if let Some(f64_ff_reader) = self.f64(field) {
+            return Some(f64_ff_reader.into_u64_reader());
         }
         None
     }

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1496,7 +1496,12 @@ mod tests {
     #[test]
     fn merges_f64_fast_fields_correctly() -> crate::Result<()> {
         let mut builder = schema::SchemaBuilder::new();
+
+        let fast_multi = IntOptions::default().set_fast(Cardinality::MultiValues);
+
         let field = builder.add_f64_field("f64", schema::FAST);
+        let multi_field = builder.add_f64_field("f64s", fast_multi);
+
         let index = Index::create_in_ram(builder.build());
 
         let mut writer = index.writer_with_num_threads(1, 3_000_000)?;
@@ -1508,7 +1513,11 @@ mod tests {
 
         for i in 0..100 {
             let mut doc = Document::new();
-            doc.add_u64(field, 42);
+            doc.add_f64(field, 42.0);
+
+            doc.add_f64(multi_field, 0.24);
+            doc.add_f64(multi_field, 0.27);
+
             writer.add_document(doc);
 
             if i % 5 == 0 {

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1492,4 +1492,37 @@ mod tests {
             assert_eq!(&vals, &[20]);
         }
     }
+
+    #[test]
+    fn merges_f64_fast_fields_correctly() -> crate::Result<()> {
+        let mut builder = schema::SchemaBuilder::new();
+        let field = builder.add_f64_field("f64", schema::FAST);
+        let index = Index::create_in_ram(builder.build());
+
+        let mut writer = index.writer_with_num_threads(1, 3_000_000)?;
+
+        // Make sure we'll attempt to merge every created segment
+        let mut policy = crate::indexer::LogMergePolicy::default();
+        policy.set_min_merge_size(2);
+        writer.set_merge_policy(Box::new(policy));
+
+        for i in 0..100 {
+            let mut doc = Document::new();
+            doc.add_u64(field, 42);
+            writer.add_document(doc);
+
+            if i % 5 == 0 {
+                writer.commit()?;
+            }
+        }
+
+        writer.commit()?;
+        writer.wait_merging_threads()?;
+
+        // If a merging thread fails, we should end up with more
+        // than one segment here
+        assert_eq!(1, index.searchable_segments()?.len());
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Without this, we get a panic during merge since the merger will get a `None` where it expects something.

Prior to this patch, you can reproduce the panic with:

```rust
    use tantivy::{
        self,
        schema::{SchemaBuilder, FAST},
        Document, Index, Result,
    };

    #[test]
    fn pass() -> Result<()> {
        let mut builder = SchemaBuilder::new();
        let field = builder.add_f64_field("f64", FAST);
        let index = Index::create_in_ram(builder.build());

        let mut writer = index.writer_with_num_threads(1, 50_000_000)?;

        for i in 0..1000 {
            let mut doc = Document::new();
            doc.add_f64(field, 0.42);
            writer.add_document(doc);

            if i % 5 == 0 {
                writer.commit()?;
            }
        }

        writer.commit()?;

        Ok(())
    }
```

I couldn't simply add this as a test since `cargo test pass` gets stuck for me when trying it (merger thread dies, main thread waits forever I'd guess).