### PR TITLE
Closes #732

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tantivy 0.11.2
+=======================
+- The future returned by `IndexWriter::merge` does not borrow `self` mutably anymore (#732)
+
 Tantivy 0.11.1
 =====================
 - Bug fix #729

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Paul Masurel <paul.masurel@gmail.com>"]
 license = "MIT"
 categories = ["database-implementations", "data-structures"]

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -514,9 +514,13 @@ impl IndexWriter {
     /// Merges a given list of segments
     ///
     /// `segment_ids` is required to be non-empty.
-    pub async fn merge(&mut self, segment_ids: &[SegmentId]) -> crate::Result<SegmentMeta> {
+    pub fn merge(
+        &mut self,
+        segment_ids: &[SegmentId],
+    ) -> impl Future<Output = crate::Result<SegmentMeta>> {
         let merge_operation = self.segment_updater.make_merge_operation(segment_ids);
-        self.segment_updater.start_merge(merge_operation)?.await
+        let segment_updater = self.segment_updater.clone();
+        async move { segment_updater.start_merge(merge_operation)?.await }
     }
 
     /// Closes the current document channel send.


### PR DESCRIPTION
The future returned by `IndexWriter::merge` does not borrow `&mut self`