### PR TITLE
[RFC] directory: Convert the ReadOnlySource to provide a Read + Seek based …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ tantivy-query-grammar = { version="0.11", path="./query-grammar" }
 bitpacking = {version="0.8", default-features = false, features=["bitpacker4x"]}
 census = "0.4"
 fnv = "1.0.6"
-owned-read = "0.4"
 failure = "0.1"
 htmlescape = "0.3.1"
 fail = "0.3"

--- a/src/common/composite_file.rs
+++ b/src/common/composite_file.rs
@@ -1,7 +1,7 @@
 use crate::common::BinarySerializable;
 use crate::common::CountingWriter;
-use crate::common::VInt;
 use crate::common::HasLen;
+use crate::common::VInt;
 use crate::directory::ReadOnlySource;
 use crate::directory::{TerminatingWrite, WritePtr};
 use crate::schema::Field;
@@ -9,7 +9,7 @@ use crate::space_usage::FieldUsage;
 use crate::space_usage::PerFieldSpaceUsage;
 use std::collections::HashMap;
 use std::io::Write;
-use std::io::{self, Read, Cursor};
+use std::io::{self, Cursor, Read};
 
 #[derive(Eq, PartialEq, Hash, Copy, Ord, PartialOrd, Clone, Debug)]
 pub struct FileAddr {
@@ -189,9 +189,9 @@ mod test {
     use crate::common::VInt;
     use crate::directory::{Directory, RAMDirectory};
     use crate::schema::Field;
+    use std::io::Read;
     use std::io::Write;
     use std::path::Path;
-    use std::io::Read;
 
     #[test]
     fn test_composite_file() {

--- a/src/core/inverted_index_reader.rs
+++ b/src/core/inverted_index_reader.rs
@@ -1,6 +1,6 @@
 use crate::common::BinarySerializable;
 use crate::common::HasLen;
-use crate::directory::{ReadOnlySource, AdvancingReadOnlySource};
+use crate::directory::{AdvancingReadOnlySource, ReadOnlySource};
 use crate::positions::PositionReader;
 use crate::postings::TermInfo;
 use crate::postings::{BlockSegmentPostings, SegmentPostings};
@@ -96,7 +96,10 @@ impl InvertedIndexReader {
         let offset = term_info.postings_offset as usize;
         let end_source = self.postings_source.len();
         let postings_slice = self.postings_source.slice(offset, end_source);
-        block_postings.reset(term_info.doc_freq, AdvancingReadOnlySource::from(postings_slice));
+        block_postings.reset(
+            term_info.doc_freq,
+            AdvancingReadOnlySource::from(postings_slice),
+        );
     }
 
     /// Returns a block postings given a `Term`.

--- a/src/core/segment_reader.rs
+++ b/src/core/segment_reader.rs
@@ -146,27 +146,27 @@ impl SegmentReader {
 
     /// Open a new segment for reading.
     pub fn open(segment: &Segment) -> Result<SegmentReader> {
-        let termdict_source = segment.open_read(SegmentComponent::TERMS)?;
-        let termdict_composite = CompositeFile::open(&termdict_source)?;
+        let mut termdict_source = segment.open_read(SegmentComponent::TERMS)?;
+        let termdict_composite = CompositeFile::open(&mut termdict_source)?;
 
         let store_source = segment.open_read(SegmentComponent::STORE)?;
 
         fail_point!("SegmentReader::open#middle");
 
-        let postings_source = segment.open_read(SegmentComponent::POSTINGS)?;
-        let postings_composite = CompositeFile::open(&postings_source)?;
+        let mut postings_source = segment.open_read(SegmentComponent::POSTINGS)?;
+        let postings_composite = CompositeFile::open(&mut postings_source)?;
 
         let positions_composite = {
-            if let Ok(source) = segment.open_read(SegmentComponent::POSITIONS) {
-                CompositeFile::open(&source)?
+            if let Ok(mut source) = segment.open_read(SegmentComponent::POSITIONS) {
+                CompositeFile::open(&mut source)?
             } else {
                 CompositeFile::empty()
             }
         };
 
         let positions_idx_composite = {
-            if let Ok(source) = segment.open_read(SegmentComponent::POSITIONSSKIP) {
-                CompositeFile::open(&source)?
+            if let Ok(mut source) = segment.open_read(SegmentComponent::POSITIONSSKIP) {
+                CompositeFile::open(&mut source)?
             } else {
                 CompositeFile::empty()
             }
@@ -174,13 +174,13 @@ impl SegmentReader {
 
         let schema = segment.schema();
 
-        let fast_fields_data = segment.open_read(SegmentComponent::FASTFIELDS)?;
-        let fast_fields_composite = CompositeFile::open(&fast_fields_data)?;
+        let mut fast_fields_data = segment.open_read(SegmentComponent::FASTFIELDS)?;
+        let fast_fields_composite = CompositeFile::open(&mut fast_fields_data)?;
         let fast_field_readers =
             Arc::new(FastFieldReaders::load_all(&schema, &fast_fields_composite)?);
 
-        let fieldnorms_data = segment.open_read(SegmentComponent::FIELDNORMS)?;
-        let fieldnorms_composite = CompositeFile::open(&fieldnorms_data)?;
+        let mut fieldnorms_data = segment.open_read(SegmentComponent::FIELDNORMS)?;
+        let fieldnorms_composite = CompositeFile::open(&mut fieldnorms_data)?;
 
         let delete_bitset_opt = if segment.meta().has_deletes() {
             let delete_data = segment.open_read(SegmentComponent::DELETE)?;

--- a/src/directory/footer.rs
+++ b/src/directory/footer.rs
@@ -1,13 +1,13 @@
+use crate::common::HasLen;
 use crate::common::{BinarySerializable, CountingWriter, FixedSize, VInt};
 use crate::directory::error::Incompatibility;
 use crate::directory::read_only_source::ReadOnlySource;
 use crate::directory::{AntiCallToken, TerminatingWrite};
 use crate::Version;
-use byteorder::{LittleEndian, WriteBytesExt, ReadBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crc32fast::Hasher;
 use std::io;
 use std::io::Write;
-use crate::common::HasLen;
 
 type CrcHashU32 = u32;
 

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -14,12 +14,12 @@ use crc32fast::Hasher;
 use serde_json;
 use std::collections::HashSet;
 use std::io;
+use std::io::Read;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::result;
 use std::sync::RwLockWriteGuard;
 use std::sync::{Arc, RwLock};
-use std::io::Read;
 
 /// Returns true iff the file is "managed".
 /// Non-managed file are not subject to garbage collection.
@@ -237,7 +237,8 @@ impl ManagedDirectory {
             .map_err(|err| IOError::with_path(path.to_path_buf(), err))?;
         let mut hasher = Hasher::new();
         let mut read_data = Vec::new();
-        data.read_to_end(&mut read_data).expect("Can't read data for checksum");
+        data.read_to_end(&mut read_data)
+            .expect("Can't read data for checksum");
         hasher.update(&read_data);
         let crc = hasher.finalize();
         Ok(footer

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -29,10 +29,10 @@ use std::fs::OpenOptions;
 use std::fs::{self, File};
 use std::io::{self, Seek, SeekFrom};
 use std::io::{BufWriter, Read, Write};
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::result;
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::RwLock;
@@ -539,11 +539,11 @@ mod tests {
     // The following tests are specific to the MmapDirectory
 
     use super::*;
+    use crate::common::HasLen;
     use crate::indexer::LogMergePolicy;
     use crate::schema::{Schema, SchemaBuilder, TEXT};
     use crate::Index;
     use crate::ReloadPolicy;
-    use crate::common::HasLen;
     use std::fs;
     use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/src/directory/mod.rs
+++ b/src/directory/mod.rs
@@ -22,7 +22,7 @@ pub use self::directory::DirectoryLock;
 pub use self::directory::{Directory, DirectoryClone};
 pub use self::directory_lock::{Lock, INDEX_WRITER_LOCK, META_LOCK};
 pub use self::ram_directory::RAMDirectory;
-pub use self::read_only_source::ReadOnlySource;
+pub use self::read_only_source::{ReadOnlySource, AdvancingReadOnlySource, ReadOnlyData};
 pub use self::watch_event_router::{WatchCallback, WatchCallbackList, WatchHandle};
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;

--- a/src/directory/mod.rs
+++ b/src/directory/mod.rs
@@ -22,7 +22,7 @@ pub use self::directory::DirectoryLock;
 pub use self::directory::{Directory, DirectoryClone};
 pub use self::directory_lock::{Lock, INDEX_WRITER_LOCK, META_LOCK};
 pub use self::ram_directory::RAMDirectory;
-pub use self::read_only_source::{ReadOnlySource, AdvancingReadOnlySource, ReadOnlyData};
+pub use self::read_only_source::{AdvancingReadOnlySource, ReadOnlyData, ReadOnlySource};
 pub use self::watch_event_router::{WatchCallback, WatchCallbackList, WatchHandle};
 use std::io::{self, BufWriter, Write};
 use std::path::PathBuf;

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -4,6 +4,7 @@ use crate::directory::AntiCallToken;
 use crate::directory::WatchCallbackList;
 use crate::directory::{Directory, ReadOnlySource, WatchCallback, WatchHandle};
 use crate::directory::{TerminatingWrite, WritePtr};
+use crate::common::HasLen;
 use fail::fail_point;
 use std::collections::HashMap;
 use std::fmt;
@@ -86,7 +87,7 @@ struct InnerDirectory {
 
 impl InnerDirectory {
     fn write(&mut self, path: PathBuf, data: &[u8]) -> bool {
-        let data = ReadOnlySource::new(Vec::from(data));
+        let data = ReadOnlySource::from(Vec::from(data));
         self.fs.insert(path, data).is_some()
     }
 
@@ -178,7 +179,7 @@ impl Directory for RAMDirectory {
     }
 
     fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError> {
-        Ok(self.open_read(path)?.as_slice().to_owned())
+        Ok(self.open_read(path)?.read_all().expect("Can't read read only source for RAM directory"))
     }
 
     fn atomic_write(&mut self, path: &Path, data: &[u8]) -> io::Result<()> {

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -1,10 +1,10 @@
+use crate::common::HasLen;
 use crate::core::META_FILEPATH;
 use crate::directory::error::{DeleteError, OpenReadError, OpenWriteError};
 use crate::directory::AntiCallToken;
 use crate::directory::WatchCallbackList;
 use crate::directory::{Directory, ReadOnlySource, WatchCallback, WatchHandle};
 use crate::directory::{TerminatingWrite, WritePtr};
-use crate::common::HasLen;
 use fail::fail_point;
 use std::collections::HashMap;
 use std::fmt;
@@ -179,7 +179,10 @@ impl Directory for RAMDirectory {
     }
 
     fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError> {
-        Ok(self.open_read(path)?.read_all().expect("Can't read read only source for RAM directory"))
+        Ok(self
+            .open_read(path)?
+            .read_all()
+            .expect("Can't read read only source for RAM directory"))
     }
 
     fn atomic_write(&mut self, path: &Path, data: &[u8]) -> io::Result<()> {

--- a/src/directory/read_only_source.rs
+++ b/src/directory/read_only_source.rs
@@ -2,7 +2,7 @@ use crate::common::HasLen;
 use std::cmp;
 use std::convert::TryInto;
 use std::io::{Cursor, Read, Seek, SeekFrom};
-use std::ops::{Deref};
+use std::ops::Deref;
 use std::sync::{Arc, Weak};
 
 pub struct InnerBoxedData(Arc<Box<dyn Deref<Target = [u8]> + Send + Sync + 'static>>);
@@ -137,7 +137,6 @@ impl AdvancingReadOnlySource {
             .seek(SeekFrom::Start(0))
             .expect("Can't seek while advancing");
     }
-
 
     /// Splits into 2 `AdvancingReadOnlySource`, at the offset given
     /// as an argument.
@@ -279,12 +278,13 @@ impl ReadOnlySource {
         assert!(stop <= self.len());
 
         let mut data = self.data.snapshot();
-        let pos = data.seek(SeekFrom::Start(
-            (self.start + start)
-                .try_into()
-                .expect("Can't convert seek start position while slicing"),
-        ))
-        .expect("Can't seek while slicing");
+        let pos = data
+            .seek(SeekFrom::Start(
+                (self.start + start)
+                    .try_into()
+                    .expect("Can't convert seek start position while slicing"),
+            ))
+            .expect("Can't seek while slicing");
 
         ReadOnlySource {
             data,
@@ -325,10 +325,12 @@ impl Seek for ReadOnlySource {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
         let seek = match pos {
             SeekFrom::Start(n) => {
-                let n = n.checked_add(self.start as u64).ok_or_else(|| std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "invalid seek to a negative or overflowing position",
-                ))?;
+                let n = n.checked_add(self.start as u64).ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "invalid seek to a negative or overflowing position",
+                    )
+                })?;
                 SeekFrom::Start(n)
             }
             SeekFrom::End(n) => {
@@ -342,13 +344,15 @@ impl Seek for ReadOnlySource {
                 } else {
                     let true_end = self.data.seek(SeekFrom::End(0))?;
                     let offset = true_end - self.stop as u64;
-                    let offset: i64 = n.checked_add(offset as i64).ok_or_else(|| std::io::Error::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "invalid seek to a negative or overflowing position",
-                    ))?;
+                    let offset: i64 = n.checked_add(offset as i64).ok_or_else(|| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "invalid seek to a negative or overflowing position",
+                        )
+                    })?;
                     SeekFrom::End(offset)
                 }
-            },
+            }
 
             SeekFrom::Current(n) => SeekFrom::Current(n),
         };

--- a/src/directory/read_only_source.rs
+++ b/src/directory/read_only_source.rs
@@ -1,9 +1,98 @@
 use crate::common::HasLen;
-use stable_deref_trait::{CloneStableDeref, StableDeref};
-use std::ops::Deref;
-use std::sync::Arc;
+use std::cmp;
+use std::convert::TryInto;
+use std::io::{Cursor, Read, Seek, SeekFrom};
+use std::ops::{Deref};
+use std::sync::{Arc, Weak};
 
-pub type BoxedData = Box<dyn Deref<Target = [u8]> + Send + Sync + 'static>;
+pub struct InnerBoxedData(Arc<Box<dyn Deref<Target = [u8]> + Send + Sync + 'static>>);
+
+pub struct BoxedData(Cursor<InnerBoxedData>);
+
+impl Deref for InnerBoxedData {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for InnerBoxedData {
+    fn as_ref(&self) -> &[u8] {
+        &self.0.as_ref()
+    }
+}
+
+impl InnerBoxedData {
+    pub fn new(data: Arc<Box<dyn Deref<Target = [u8]> + Send + Sync + 'static>>) -> Self {
+        InnerBoxedData(data)
+    }
+
+    pub(crate) fn downgrade(&self) -> Weak<Box<dyn Deref<Target = [u8]> + Send + Sync + 'static>> {
+        Arc::downgrade(&self.0)
+    }
+}
+
+impl Clone for InnerBoxedData {
+    fn clone(&self) -> Self {
+        InnerBoxedData(self.0.clone())
+    }
+}
+
+impl BoxedData {
+    pub fn new(data: Arc<Box<dyn Deref<Target = [u8]> + Send + Sync + 'static>>) -> Self {
+        BoxedData(Cursor::new(InnerBoxedData::new(data)))
+    }
+}
+
+impl Read for BoxedData {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl Seek for BoxedData {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.0.seek(pos)
+    }
+}
+
+impl Deref for BoxedData {
+    type Target = InnerBoxedData;
+    fn deref(&self) -> &InnerBoxedData {
+        self.0.get_ref()
+    }
+}
+
+impl Clone for BoxedData {
+    fn clone(&self) -> Self {
+        BoxedData(Cursor::new(self.0.get_ref().clone()))
+    }
+}
+
+impl HasLen for BoxedData {
+    fn len(&self) -> usize {
+        self.0.get_ref().len()
+    }
+}
+
+/// A trait that is used as the underlying data source for `ReadOnlySource`
+pub trait ReadOnlyData: Read + Seek + HasLen + Sync + Send {
+    /// Create a new view of the data source. This is essentially a clone that
+    /// gets boxed.
+    fn snapshot(&self) -> Box<dyn ReadOnlyData>;
+}
+
+impl ReadOnlyData for BoxedData {
+    fn snapshot(&self) -> Box<dyn ReadOnlyData> {
+        Box::new(self.clone())
+    }
+}
+
+impl ReadOnlyData for ReadOnlySource {
+    fn snapshot(&self) -> Box<dyn ReadOnlyData> {
+        Box::new(self.clone())
+    }
+}
 
 /// Read object that represents files in tantivy.
 ///
@@ -12,54 +101,127 @@ pub type BoxedData = Box<dyn Deref<Target = [u8]> + Send + Sync + 'static>;
 /// Whatever happens to the directory file, the data
 /// hold by this object should never be altered or destroyed.
 pub struct ReadOnlySource {
-    data: Arc<BoxedData>,
+    data: Box<dyn ReadOnlyData>,
     start: usize,
     stop: usize,
+    pos: usize,
 }
 
-unsafe impl StableDeref for ReadOnlySource {}
-unsafe impl CloneStableDeref for ReadOnlySource {}
-
-impl Deref for ReadOnlySource {
-    type Target = [u8];
-
-    fn deref(&self) -> &[u8] {
-        self.as_slice()
-    }
-}
-
-impl From<Arc<BoxedData>> for ReadOnlySource {
-    fn from(data: Arc<BoxedData>) -> Self {
+impl From<BoxedData> for ReadOnlySource {
+    fn from(data: BoxedData) -> Self {
         let len = data.len();
         ReadOnlySource {
-            data,
+            data: Box::new(data),
             start: 0,
             stop: len,
+            pos: 0,
         }
     }
 }
 
+/// A version of ReadOnlySource that slices forward as you read from it.
+pub struct AdvancingReadOnlySource(ReadOnlySource);
+
+impl AdvancingReadOnlySource {
+    /// Create an empty AdvancingReadOnlySource.
+    pub fn empty() -> AdvancingReadOnlySource {
+        AdvancingReadOnlySource(ReadOnlySource::empty())
+    }
+
+    /// Slice this current source forward.
+    /// # Arguments
+    /// `clip_len` - How many bytes should the source slice forward.
+    pub fn advance(&mut self, clip_len: usize) {
+        self.0.start += clip_len;
+        self.0
+            .seek(SeekFrom::Start(0))
+            .expect("Can't seek while advancing");
+    }
+
+
+    /// Splits into 2 `AdvancingReadOnlySource`, at the offset given
+    /// as an argument.
+    pub fn split(self, addr: usize) -> (AdvancingReadOnlySource, AdvancingReadOnlySource) {
+        let (left, right) = self.0.split(addr);
+        (
+            AdvancingReadOnlySource::from(left),
+            AdvancingReadOnlySource::from(right),
+        )
+    }
+
+    /// Get a single byte out of the source without advancing the cursor.
+    /// # Arguments
+    /// `idx` - The position of the byte that should be retrieved.
+    pub fn get(&mut self, idx: usize) -> u8 {
+        self.0.get(idx).expect("Can't get a byte out of the reader")
+    }
+
+    /// Read the whole source into a vector. This reads from the current
+    /// position to the end and seeks back to the start.
+    pub fn read_all(&mut self) -> std::io::Result<Vec<u8>> {
+        self.0.read_all()
+    }
+
+    /// Read data into the provided buffer without slicing forward.
+    /// Afther the read this method seeks back to the cursor position before the
+    /// read.
+    pub fn read_without_advancing(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let current_location = self.0.seek(SeekFrom::Current(0))?;
+        let n = self.0.read(buf)?;
+        self.0.seek(SeekFrom::Start(current_location))?;
+        Ok(n)
+    }
+
+    /// Is the source empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.start == self.0.stop
+    }
+}
+
+impl From<ReadOnlySource> for AdvancingReadOnlySource {
+    fn from(source: ReadOnlySource) -> AdvancingReadOnlySource {
+        AdvancingReadOnlySource(source)
+    }
+}
+
+impl From<Vec<u8>> for AdvancingReadOnlySource {
+    fn from(data: Vec<u8>) -> AdvancingReadOnlySource {
+        AdvancingReadOnlySource::from(ReadOnlySource::from(data))
+    }
+}
+
+impl Clone for AdvancingReadOnlySource {
+    fn clone(&self) -> Self {
+        AdvancingReadOnlySource(self.0.slice_from(0))
+    }
+}
+
+impl Read for AdvancingReadOnlySource {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.0.read(buf)?;
+        self.advance(n);
+        Ok(n)
+    }
+}
+
 impl ReadOnlySource {
-    pub(crate) fn new<D>(data: D) -> ReadOnlySource
+    /// Create a new ReadOnlySource from a data source.
+    pub fn new<D>(data: D) -> ReadOnlySource
     where
-        D: Deref<Target = [u8]> + Send + Sync + 'static,
+        D: ReadOnlyData + 'static,
     {
         let len = data.len();
         ReadOnlySource {
-            data: Arc::new(Box::new(data)),
+            data: Box::new(data),
             start: 0,
             stop: len,
+            pos: 0,
         }
     }
 
     /// Creates an empty ReadOnlySource
     pub fn empty() -> ReadOnlySource {
-        ReadOnlySource::new(&[][..])
-    }
-
-    /// Returns the data underlying the ReadOnlySource object.
-    pub fn as_slice(&self) -> &[u8] {
-        &self.data[self.start..self.stop]
+        ReadOnlySource::from(Vec::new())
     }
 
     /// Splits into 2 `ReadOnlySource`, at the offset given
@@ -74,6 +236,27 @@ impl ReadOnlySource {
     pub fn split_from_end(self, right_len: usize) -> (ReadOnlySource, ReadOnlySource) {
         let left_len = self.len() - right_len;
         self.split(left_len)
+    }
+
+    /// Read the whole source into a vector. This reads from the current
+    /// position to the end and seeks back to the start.
+    pub fn read_all(&mut self) -> std::io::Result<Vec<u8>> {
+        let mut ret = Vec::new();
+        self.read_to_end(&mut ret)?;
+        self.seek(SeekFrom::Start(0))?;
+        Ok(ret)
+    }
+
+    /// Get a single byte out of the source without advancing the cursor.
+    /// # Arguments
+    /// `idx` - The position of the byte that should be retrieved.
+    pub fn get(&mut self, idx: usize) -> std::io::Result<u8> {
+        let current_location = self.seek(SeekFrom::Current(0))?;
+        let mut ret = vec![0u8; 1];
+        self.seek(SeekFrom::Start(idx as u64))?;
+        self.read_exact(&mut ret)?;
+        self.seek(SeekFrom::Start(current_location))?;
+        Ok(ret[0])
     }
 
     /// Creates a ReadOnlySource that is just a
@@ -94,10 +277,20 @@ impl ReadOnlySource {
             stop
         );
         assert!(stop <= self.len());
+
+        let mut data = self.data.snapshot();
+        let pos = data.seek(SeekFrom::Start(
+            (self.start + start)
+                .try_into()
+                .expect("Can't convert seek start position while slicing"),
+        ))
+        .expect("Can't seek while slicing");
+
         ReadOnlySource {
-            data: self.data.clone(),
+            data,
             start: self.start + start,
             stop: self.start + stop,
+            pos: pos as usize,
         }
     }
 
@@ -118,6 +311,55 @@ impl ReadOnlySource {
     }
 }
 
+impl Read for ReadOnlySource {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let max = cmp::min(buf.len(), self.stop - self.pos);
+
+        let n = self.data.read(&mut buf[..max])?;
+        self.pos += n;
+        Ok(n)
+    }
+}
+
+impl Seek for ReadOnlySource {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let seek = match pos {
+            SeekFrom::Start(n) => {
+                let n = n.checked_add(self.start as u64).ok_or_else(|| std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "invalid seek to a negative or overflowing position",
+                ))?;
+                SeekFrom::Start(n)
+            }
+            SeekFrom::End(n) => {
+                if n > 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "invalid seek beyond the source",
+                    ));
+                } else if n == 0 {
+                    SeekFrom::End(n)
+                } else {
+                    let true_end = self.data.seek(SeekFrom::End(0))?;
+                    let offset = true_end - self.stop as u64;
+                    let offset: i64 = n.checked_add(offset as i64).ok_or_else(|| std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "invalid seek to a negative or overflowing position",
+                    ))?;
+                    SeekFrom::End(offset)
+                }
+            },
+
+            SeekFrom::Current(n) => SeekFrom::Current(n),
+        };
+
+        let pos = self.data.seek(seek)?;
+        self.pos = pos as usize;
+
+        Ok(pos - self.start as u64)
+    }
+}
+
 impl HasLen for ReadOnlySource {
     fn len(&self) -> usize {
         self.stop - self.start
@@ -132,6 +374,6 @@ impl Clone for ReadOnlySource {
 
 impl From<Vec<u8>> for ReadOnlySource {
     fn from(data: Vec<u8>) -> ReadOnlySource {
-        ReadOnlySource::new(data)
+        ReadOnlySource::new(BoxedData::new(Arc::new(Box::new(data))))
     }
 }

--- a/src/directory/tests.rs
+++ b/src/directory/tests.rs
@@ -134,8 +134,8 @@ fn test_simple(directory: &mut dyn Directory) {
         write_file.flush().unwrap();
     }
     {
-        let read_file = directory.open_read(test_path).unwrap();
-        let data: &[u8] = &*read_file;
+        let mut read_file = directory.open_read(test_path).unwrap();
+        let data = read_file.read_all().expect("Can't read data");
         assert_eq!(data, &[4u8, 3u8, 7u8, 3u8, 5u8]);
     }
     assert!(directory.delete(test_path).is_ok());
@@ -172,12 +172,13 @@ fn test_directory_delete(directory: &mut dyn Directory) {
     write_file.write_all(&[1, 2, 3, 4]).unwrap();
     write_file.flush().unwrap();
     {
-        let read_handle = directory.open_read(&test_path).unwrap();
-        assert_eq!(&*read_handle, &[1u8, 2u8, 3u8, 4u8]);
+        let mut read_handle = directory.open_read(&test_path).unwrap();
+        let data = read_handle.read_all().expect("Can't read data");
+        assert_eq!(data, &[1u8, 2u8, 3u8, 4u8]);
         // Mapped files can't be deleted on Windows
         if !cfg!(windows) {
             assert!(directory.delete(&test_path).is_ok());
-            assert_eq!(&*read_handle, &[1u8, 2u8, 3u8, 4u8]);
+            assert_eq!(data, &[1u8, 2u8, 3u8, 4u8]);
         }
 
         assert!(directory.delete(Path::new("SomeOtherPath")).is_err());

--- a/src/fastfield/bytes/reader.rs
+++ b/src/fastfield/bytes/reader.rs
@@ -4,6 +4,8 @@ use crate::directory::ReadOnlySource;
 use crate::fastfield::FastFieldReader;
 use crate::DocId;
 
+use std::sync::Arc;
+
 /// Reader for byte array fast fields
 ///
 /// The reader is implemented as a `u64` fast field and a separate collection of bytes.
@@ -17,15 +19,15 @@ use crate::DocId;
 #[derive(Clone)]
 pub struct BytesFastFieldReader {
     idx_reader: FastFieldReader<u64>,
-    values: OwningRef<ReadOnlySource, [u8]>,
+    values: OwningRef<Arc<Vec<u8>>, [u8]>,
 }
 
 impl BytesFastFieldReader {
     pub(crate) fn open(
         idx_reader: FastFieldReader<u64>,
-        values_source: ReadOnlySource,
+        mut values_source: ReadOnlySource,
     ) -> BytesFastFieldReader {
-        let values = OwningRef::new(values_source).map(|source| &source[..]);
+        let values = OwningRef::new(Arc::new(values_source.read_all().expect("Can't read source"))).map(|source| &source[..]);
         BytesFastFieldReader { idx_reader, values }
     }
 

--- a/src/fastfield/bytes/reader.rs
+++ b/src/fastfield/bytes/reader.rs
@@ -27,7 +27,10 @@ impl BytesFastFieldReader {
         idx_reader: FastFieldReader<u64>,
         mut values_source: ReadOnlySource,
     ) -> BytesFastFieldReader {
-        let values = OwningRef::new(Arc::new(values_source.read_all().expect("Can't read source"))).map(|source| &source[..]);
+        let values = OwningRef::new(Arc::new(
+            values_source.read_all().expect("Can't read source"),
+        ))
+        .map(|source| &source[..]);
         BytesFastFieldReader { idx_reader, values }
     }
 

--- a/src/fastfield/delete.rs
+++ b/src/fastfield/delete.rs
@@ -4,8 +4,8 @@ use crate::directory::WritePtr;
 use crate::space_usage::ByteCount;
 use crate::DocId;
 use std::io;
-use std::sync::Arc;
 use std::io::Write;
+use std::sync::Arc;
 
 /// Write a delete `BitSet`
 ///
@@ -46,10 +46,7 @@ impl DeleteBitSet {
     /// Opens a delete bitset given its data source.
     pub fn open(mut data: ReadOnlySource) -> DeleteBitSet {
         let data = data.read_all().expect("Can't read delete bitset");
-        let num_deleted: usize = data
-            .iter()
-            .map(|b| b.count_ones() as usize)
-            .sum();
+        let num_deleted: usize = data.iter().map(|b| b.count_ones() as usize).sum();
         DeleteBitSet {
             data: Arc::new(data),
             len: num_deleted,

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -187,6 +187,7 @@ mod tests {
     use crate::schema::FAST;
     use crate::schema::{Document, IntOptions};
     use crate::{Index, SegmentId, SegmentReader};
+    use crate::common::HasLen;
     use once_cell::sync::Lazy;
     use rand::prelude::SliceRandom;
     use rand::rngs::StdRng;
@@ -232,12 +233,12 @@ mod tests {
                 .unwrap();
             serializer.close().unwrap();
         }
-        let source = directory.open_read(&path).unwrap();
+        let mut source = directory.open_read(&path).unwrap();
         {
             assert_eq!(source.len(), 36 as usize);
         }
         {
-            let composite_file = CompositeFile::open(&source).unwrap();
+            let composite_file = CompositeFile::open(&mut source).unwrap();
             let field_source = composite_file.open_read(*FIELD).unwrap();
             let fast_field_reader = FastFieldReader::<u64>::open(field_source);
             assert_eq!(fast_field_reader.get(0), 13u64);
@@ -268,12 +269,12 @@ mod tests {
                 .unwrap();
             serializer.close().unwrap();
         }
-        let source = directory.open_read(&path).unwrap();
+        let mut source = directory.open_read(&path).unwrap();
         {
             assert_eq!(source.len(), 61 as usize);
         }
         {
-            let fast_fields_composite = CompositeFile::open(&source).unwrap();
+            let fast_fields_composite = CompositeFile::open(&mut source).unwrap();
             let data = fast_fields_composite.open_read(*FIELD).unwrap();
             let fast_field_reader = FastFieldReader::<u64>::open(data);
             assert_eq!(fast_field_reader.get(0), 4u64);
@@ -305,12 +306,12 @@ mod tests {
                 .unwrap();
             serializer.close().unwrap();
         }
-        let source = directory.open_read(&path).unwrap();
+        let mut source = directory.open_read(&path).unwrap();
         {
             assert_eq!(source.len(), 34 as usize);
         }
         {
-            let fast_fields_composite = CompositeFile::open(&source).unwrap();
+            let fast_fields_composite = CompositeFile::open(&mut source).unwrap();
             let data = fast_fields_composite.open_read(*FIELD).unwrap();
             let fast_field_reader = FastFieldReader::<u64>::open(data);
             for doc in 0..10_000 {
@@ -338,12 +339,12 @@ mod tests {
                 .unwrap();
             serializer.close().unwrap();
         }
-        let source = directory.open_read(&path).unwrap();
+        let mut source = directory.open_read(&path).unwrap();
         {
             assert_eq!(source.len(), 80042 as usize);
         }
         {
-            let fast_fields_composite = CompositeFile::open(&source).unwrap();
+            let fast_fields_composite = CompositeFile::open(&mut source).unwrap();
             let data = fast_fields_composite.open_read(*FIELD).unwrap();
             let fast_field_reader = FastFieldReader::<u64>::open(data);
             assert_eq!(fast_field_reader.get(0), 0u64);
@@ -378,12 +379,12 @@ mod tests {
                 .unwrap();
             serializer.close().unwrap();
         }
-        let source = directory.open_read(&path).unwrap();
+        let mut source = directory.open_read(&path).unwrap();
         {
             assert_eq!(source.len(), 17709 as usize);
         }
         {
-            let fast_fields_composite = CompositeFile::open(&source).unwrap();
+            let fast_fields_composite = CompositeFile::open(&mut source).unwrap();
             let data = fast_fields_composite.open_read(i64_field).unwrap();
             let fast_field_reader = FastFieldReader::<i64>::open(data);
 
@@ -420,9 +421,9 @@ mod tests {
             serializer.close().unwrap();
         }
 
-        let source = directory.open_read(&path).unwrap();
+        let mut source = directory.open_read(&path).unwrap();
         {
-            let fast_fields_composite = CompositeFile::open(&source).unwrap();
+            let fast_fields_composite = CompositeFile::open(&mut source).unwrap();
             let data = fast_fields_composite.open_read(i64_field).unwrap();
             let fast_field_reader = FastFieldReader::<i64>::open(data);
             assert_eq!(fast_field_reader.get(0u32), 0i64);
@@ -454,9 +455,9 @@ mod tests {
                 .unwrap();
             serializer.close().unwrap();
         }
-        let source = directory.open_read(&path).unwrap();
+        let mut source = directory.open_read(&path).unwrap();
         {
-            let fast_fields_composite = CompositeFile::open(&source).unwrap();
+            let fast_fields_composite = CompositeFile::open(&mut source).unwrap();
             let data = fast_fields_composite.open_read(*FIELD).unwrap();
             let fast_field_reader = FastFieldReader::<u64>::open(data);
 
@@ -611,9 +612,9 @@ mod bench {
                 .unwrap();
             serializer.close().unwrap();
         }
-        let source = directory.open_read(&path).unwrap();
+        let mut source = directory.open_read(&path).unwrap();
         {
-            let fast_fields_composite = CompositeFile::open(&source).unwrap();
+            let fast_fields_composite = CompositeFile::open(&mut source).unwrap();
             let data = fast_fields_composite.open_read(*FIELD).unwrap();
             let fast_field_reader = FastFieldReader::<u64>::open(data);
 
@@ -645,9 +646,9 @@ mod bench {
                 .unwrap();
             serializer.close().unwrap();
         }
-        let source = directory.open_read(&path).unwrap();
+        let mut source = directory.open_read(&path).unwrap();
         {
-            let fast_fields_composite = CompositeFile::open(&source).unwrap();
+            let fast_fields_composite = CompositeFile::open(&mut source).unwrap();
             let data = fast_fields_composite.open_read(*FIELD).unwrap();
             let fast_field_reader = FastFieldReader::<u64>::open(data);
 

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -179,6 +179,7 @@ mod tests {
 
     use super::*;
     use crate::common::CompositeFile;
+    use crate::common::HasLen;
     use crate::directory::{Directory, RAMDirectory, WritePtr};
     use crate::fastfield::FastFieldReader;
     use crate::merge_policy::NoMergePolicy;
@@ -187,7 +188,6 @@ mod tests {
     use crate::schema::FAST;
     use crate::schema::{Document, IntOptions};
     use crate::{Index, SegmentId, SegmentReader};
-    use crate::common::HasLen;
     use once_cell::sync::Lazy;
     use rand::prelude::SliceRandom;
     use rand::rngs::StdRng;

--- a/src/fastfield/reader.rs
+++ b/src/fastfield/reader.rs
@@ -10,10 +10,10 @@ use crate::schema::Schema;
 use crate::schema::FAST;
 use crate::DocId;
 use owning_ref::OwningRef;
-use std::sync::Arc;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::path::Path;
+use std::sync::Arc;
 
 /// Trait for accessing a fastfield.
 ///
@@ -40,7 +40,8 @@ impl<Item: FastValue> FastFieldReader<Item> {
         }
         let max_value = min_value + amplitude;
         let num_bits = compute_num_bits(amplitude);
-        let owning_ref = OwningRef::new(Arc::new(data.read_all().expect("Can't read data"))).map(|data| &data[0..]);
+        let owning_ref = OwningRef::new(Arc::new(data.read_all().expect("Can't read data")))
+            .map(|data| &data[0..]);
         let bit_unpacker = BitUnpacker::new(owning_ref, num_bits);
         FastFieldReader {
             min_value_u64: min_value,

--- a/src/fastfield/reader.rs
+++ b/src/fastfield/reader.rs
@@ -10,6 +10,7 @@ use crate::schema::Schema;
 use crate::schema::FAST;
 use crate::DocId;
 use owning_ref::OwningRef;
+use std::sync::Arc;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -20,7 +21,7 @@ use std::path::Path;
 /// fast field is required.
 #[derive(Clone)]
 pub struct FastFieldReader<Item: FastValue> {
-    bit_unpacker: BitUnpacker<OwningRef<ReadOnlySource, [u8]>>,
+    bit_unpacker: BitUnpacker<OwningRef<Arc<Vec<u8>>, [u8]>>,
     min_value_u64: u64,
     max_value_u64: u64,
     _phantom: PhantomData<Item>,
@@ -28,19 +29,18 @@ pub struct FastFieldReader<Item: FastValue> {
 
 impl<Item: FastValue> FastFieldReader<Item> {
     /// Opens a fast field given a source.
-    pub fn open(data: ReadOnlySource) -> Self {
+    pub fn open(mut data: ReadOnlySource) -> Self {
         let min_value: u64;
         let amplitude: u64;
         {
-            let mut cursor = data.as_slice();
             min_value =
-                u64::deserialize(&mut cursor).expect("Failed to read the min_value of fast field.");
+                u64::deserialize(&mut data).expect("Failed to read the min_value of fast field.");
             amplitude =
-                u64::deserialize(&mut cursor).expect("Failed to read the amplitude of fast field.");
+                u64::deserialize(&mut data).expect("Failed to read the amplitude of fast field.");
         }
         let max_value = min_value + amplitude;
         let num_bits = compute_num_bits(amplitude);
-        let owning_ref = OwningRef::new(data).map(|data| &data[16..]);
+        let owning_ref = OwningRef::new(Arc::new(data.read_all().expect("Can't read data"))).map(|data| &data[0..]);
         let bit_unpacker = BitUnpacker::new(owning_ref, num_bits);
         FastFieldReader {
             min_value_u64: min_value,
@@ -157,9 +157,9 @@ impl<Item: FastValue> From<Vec<Item>> for FastFieldReader<Item> {
             serializer.close().unwrap();
         }
 
-        let source = directory.open_read(path).expect("Failed to open the file");
+        let mut source = directory.open_read(path).expect("Failed to open the file");
         let composite_file =
-            CompositeFile::open(&source).expect("Failed to read the composite file");
+            CompositeFile::open(&mut source).expect("Failed to read the composite file");
         let field_source = composite_file
             .open_read(field)
             .expect("File component not found");

--- a/src/fieldnorm/reader.rs
+++ b/src/fieldnorm/reader.rs
@@ -38,16 +38,16 @@ impl FieldNormReader {
     ///
     /// The fieldnorm is effectively decoded from the
     /// `fieldnorm_id` by doing a simple table lookup.
-    pub fn fieldnorm(&self, doc_id: DocId) -> u32 {
+    pub fn fieldnorm(&mut self, doc_id: DocId) -> u32 {
         let fieldnorm_id = self.fieldnorm_id(doc_id);
         id_to_fieldnorm(fieldnorm_id)
     }
 
     /// Returns the `fieldnorm_id` associated to a document.
     #[inline(always)]
-    pub fn fieldnorm_id(&self, doc_id: DocId) -> u8 {
-        let fielnorms_data = self.data.as_slice();
-        fielnorms_data[doc_id as usize]
+    pub fn fieldnorm_id(&mut self, doc_id: DocId) -> u8 {
+        let fieldnorms_data = self.data.read_all().expect("Can't read field norm data");
+        fieldnorms_data[doc_id as usize]
     }
 
     /// Converts a `fieldnorm_id` into a fieldnorm.

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -34,7 +34,7 @@ fn compute_total_num_tokens(readers: &[SegmentReader], field: Field) -> u64 {
         if reader.has_deletes() {
             // if there are deletes, then we use an approximation
             // using the fieldnorm
-            let fieldnorms_reader = reader.get_fieldnorms_reader(field);
+            let mut fieldnorms_reader = reader.get_fieldnorms_reader(field);
             for doc in reader.doc_ids_alive() {
                 let fieldnorm_id = fieldnorms_reader.fieldnorm_id(doc);
                 count[fieldnorm_id as usize] += 1;
@@ -174,7 +174,7 @@ impl IndexMerger {
         for field in fields {
             fieldnorms_data.clear();
             for reader in &self.readers {
-                let fieldnorms_reader = reader.get_fieldnorms_reader(field);
+                let mut fieldnorms_reader = reader.get_fieldnorms_reader(field);
                 for doc_id in reader.doc_ids_alive() {
                     let fieldnorm_id = fieldnorms_reader.fieldnorm_id(doc_id);
                     fieldnorms_data.push(fieldnorm_id);
@@ -662,14 +662,14 @@ impl IndexMerger {
 
     fn write_storable_fields(&self, store_writer: &mut StoreWriter) -> Result<()> {
         for reader in &self.readers {
-            let store_reader = reader.get_store_reader();
+            let mut store_reader = reader.get_store_reader();
             if reader.num_deleted_docs() > 0 {
                 for doc_id in reader.doc_ids_alive() {
                     let doc = store_reader.get(doc_id)?;
                     store_writer.store(&doc)?;
                 }
             } else {
-                store_writer.stack(&store_reader)?;
+                store_writer.stack(&mut store_reader)?;
             }
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,11 +430,11 @@ mod tests {
             let searcher = index_reader.searcher();
             let reader = searcher.segment_reader(0);
             {
-                let fieldnorm_reader = reader.get_fieldnorms_reader(text_field);
+                let mut fieldnorm_reader = reader.get_fieldnorms_reader(text_field);
                 assert_eq!(fieldnorm_reader.fieldnorm(0), 3);
             }
             {
-                let fieldnorm_reader = reader.get_fieldnorms_reader(title_field);
+                let mut fieldnorm_reader = reader.get_fieldnorms_reader(title_field);
                 assert_eq!(fieldnorm_reader.fieldnorm_id(0), 0);
             }
         }
@@ -465,7 +465,7 @@ mod tests {
             let reader = index.reader().unwrap();
             let searcher = reader.searcher();
             let segment_reader: &SegmentReader = searcher.segment_reader(0);
-            let fieldnorms_reader = segment_reader.get_fieldnorms_reader(text_field);
+            let mut fieldnorms_reader = segment_reader.get_fieldnorms_reader(text_field);
             assert_eq!(fieldnorms_reader.fieldnorm(0), 3);
             assert_eq!(fieldnorms_reader.fieldnorm(1), 0);
             assert_eq!(fieldnorms_reader.fieldnorm(2), 2);

--- a/src/positions/mod.rs
+++ b/src/positions/mod.rs
@@ -40,6 +40,7 @@ pub mod tests {
     use super::{PositionReader, PositionSerializer};
     use crate::directory::ReadOnlySource;
     use crate::positions::COMPRESSION_BLOCK_SIZE;
+    use crate::common::HasLen;
     use std::iter;
 
     fn create_stream_buffer(vals: &[u32]) -> (ReadOnlySource, ReadOnlySource) {

--- a/src/positions/mod.rs
+++ b/src/positions/mod.rs
@@ -38,9 +38,9 @@ const LONG_SKIP_INTERVAL: u64 = (LONG_SKIP_IN_BLOCKS * COMPRESSION_BLOCK_SIZE) a
 pub mod tests {
 
     use super::{PositionReader, PositionSerializer};
+    use crate::common::HasLen;
     use crate::directory::ReadOnlySource;
     use crate::positions::COMPRESSION_BLOCK_SIZE;
-    use crate::common::HasLen;
     use std::iter;
 
     fn create_stream_buffer(vals: &[u32]) -> (ReadOnlySource, ReadOnlySource) {

--- a/src/postings/mod.rs
+++ b/src/postings/mod.rs
@@ -257,7 +257,7 @@ pub mod tests {
         {
             let segment_reader = SegmentReader::open(&segment).unwrap();
             {
-                let fieldnorm_reader = segment_reader.get_fieldnorms_reader(text_field);
+                let mut fieldnorm_reader = segment_reader.get_fieldnorms_reader(text_field);
                 assert_eq!(fieldnorm_reader.fieldnorm(0), 8 + 5);
                 assert_eq!(fieldnorm_reader.fieldnorm(1), 2);
                 for i in 2..1000 {

--- a/src/postings/segment_postings.rs
+++ b/src/postings/segment_postings.rs
@@ -1,6 +1,7 @@
 use crate::common::BitSet;
 use crate::common::HasLen;
 use crate::common::{BinarySerializable, VInt};
+use crate::directory::AdvancingReadOnlySource;
 use crate::docset::{DocSet, SkipResult};
 use crate::positions::PositionReader;
 use crate::postings::compression::{compressed_block_size, AlignedBuffer};
@@ -12,7 +13,6 @@ use crate::postings::Postings;
 use crate::postings::SkipReader;
 use crate::postings::USE_SKIP_INFO_LIMIT;
 use crate::schema::IndexRecordOption;
-use crate::directory::AdvancingReadOnlySource;
 use crate::DocId;
 use std::cmp::Ordering;
 use std::io::Read;
@@ -467,13 +467,12 @@ impl BlockSegmentPostings {
                 let block_len = compressed_block_size(num_bits);
 
                 let mut data_buf = vec![0u8; block_len];
-                self.remaining_data.read_exact(&mut data_buf).expect("Can't read remaining data");
+                self.remaining_data
+                    .read_exact(&mut data_buf)
+                    .expect("Can't read remaining data");
 
-                self.doc_decoder.uncompress_block_sorted(
-                    &data_buf,
-                    self.doc_offset,
-                    num_bits,
-                );
+                self.doc_decoder
+                    .uncompress_block_sorted(&data_buf, self.doc_offset, num_bits);
 
                 let tf_num_bits = self.skip_reader.tf_num_bits();
                 match self.freq_reading_option {
@@ -485,8 +484,11 @@ impl BlockSegmentPostings {
                     FreqReadingOption::ReadFreq => {
                         let block_len = compressed_block_size(tf_num_bits);
                         let mut data_buf = vec![0u8; block_len];
-                        self.remaining_data.read_exact(&mut data_buf).expect("Can't read remaining data");
-                        self.freq_decoder.uncompress_block_unsorted(&data_buf, tf_num_bits);
+                        self.remaining_data
+                            .read_exact(&mut data_buf)
+                            .expect("Can't read remaining data");
+                        self.freq_decoder
+                            .uncompress_block_unsorted(&data_buf, tf_num_bits);
                     }
                 }
                 self.doc_offset = self.skip_reader.doc();
@@ -504,7 +506,9 @@ impl BlockSegmentPostings {
             // TODO is there a better way to know how much data the decoder
             // needs.
             let mut data_buf = vec![0u8; self.num_vint_docs * 2];
-            self.remaining_data.read_without_advancing(&mut data_buf).expect("Can't read remaining data");
+            self.remaining_data
+                .read_without_advancing(&mut data_buf)
+                .expect("Can't read remaining data");
 
             let num_compressed_bytes = self.doc_decoder.uncompress_vint_sorted(
                 &data_buf,
@@ -518,7 +522,9 @@ impl BlockSegmentPostings {
                     // TODO is there a better way to know how much data the decoder
                     // needs.
                     let mut data_buf = vec![0u8; self.num_vint_docs * 2];
-                    self.remaining_data.read_without_advancing(&mut data_buf).expect("Can't read remaining data");
+                    self.remaining_data
+                        .read_without_advancing(&mut data_buf)
+                        .expect("Can't read remaining data");
                     self.freq_decoder
                         .uncompress_vint_unsorted(&data_buf, self.num_vint_docs);
                 }
@@ -548,8 +554,11 @@ impl BlockSegmentPostings {
 
             let block_len = compressed_block_size(num_bits);
             let mut data_buf = vec![0u8; block_len];
-            self.remaining_data.read_exact(&mut data_buf).expect("Can't read remaining data");
-            self.doc_decoder.uncompress_block_sorted(&data_buf, self.doc_offset, num_bits);
+            self.remaining_data
+                .read_exact(&mut data_buf)
+                .expect("Can't read remaining data");
+            self.doc_decoder
+                .uncompress_block_sorted(&data_buf, self.doc_offset, num_bits);
 
             let tf_num_bits = self.skip_reader.tf_num_bits();
             match self.freq_reading_option {
@@ -561,8 +570,11 @@ impl BlockSegmentPostings {
                 FreqReadingOption::ReadFreq => {
                     let block_len = compressed_block_size(tf_num_bits);
                     let mut data_buf = vec![0u8; block_len];
-                    self.remaining_data.read_exact(&mut data_buf).expect("Can't read remaining data");
-                    self.freq_decoder.uncompress_block_unsorted(&data_buf, tf_num_bits);
+                    self.remaining_data
+                        .read_exact(&mut data_buf)
+                        .expect("Can't read remaining data");
+                    self.freq_decoder
+                        .uncompress_block_unsorted(&data_buf, tf_num_bits);
                 }
             }
             // it will be used as the next offset.
@@ -572,7 +584,9 @@ impl BlockSegmentPostings {
             // TODO is there a better way to know how much data the decoder
             // needs.
             let mut data_buf = vec![0u8; self.num_vint_docs * 2];
-            self.remaining_data.read_without_advancing(&mut data_buf).expect("Can't read remaining data");
+            self.remaining_data
+                .read_without_advancing(&mut data_buf)
+                .expect("Can't read remaining data");
 
             let num_compressed_bytes = self.doc_decoder.uncompress_vint_sorted(
                 &data_buf,
@@ -586,7 +600,9 @@ impl BlockSegmentPostings {
                     // TODO is there a better way to know how much data the decoder
                     // needs.
                     let mut data_buf = vec![0u8; self.num_vint_docs * 2];
-                    self.remaining_data.read_without_advancing(&mut data_buf).expect("Can't read remaining data");
+                    self.remaining_data
+                        .read_without_advancing(&mut data_buf)
+                        .expect("Can't read remaining data");
                     self.freq_decoder
                         .uncompress_vint_unsorted(&data_buf, self.num_vint_docs);
                 }
@@ -611,7 +627,10 @@ impl BlockSegmentPostings {
             doc_freq: 0,
 
             remaining_data: AdvancingReadOnlySource::empty(),
-            skip_reader: SkipReader::new(AdvancingReadOnlySource::empty(), IndexRecordOption::Basic),
+            skip_reader: SkipReader::new(
+                AdvancingReadOnlySource::empty(),
+                IndexRecordOption::Basic,
+            ),
         }
     }
 }

--- a/src/postings/skip.rs
+++ b/src/postings/skip.rs
@@ -1,8 +1,8 @@
 use crate::common::BinarySerializable;
+use crate::directory::AdvancingReadOnlySource;
 use crate::postings::compression::COMPRESSION_BLOCK_SIZE;
 use crate::schema::IndexRecordOption;
 use crate::DocId;
-use crate::directory::AdvancingReadOnlySource;
 
 pub struct SkipSerializer {
     buffer: Vec<u8>,
@@ -119,8 +119,7 @@ impl SkipReader {
                 IndexRecordOption::WithFreqsAndPositions => {
                     self.tf_num_bits = self.data.get(1);
                     self.data.advance(2);
-                    self.tf_sum =
-                        u32::deserialize(&mut self.data).expect("Failed reading tf_sum");
+                    self.tf_sum = u32::deserialize(&mut self.data).expect("Failed reading tf_sum");
                 }
             }
             true
@@ -131,9 +130,9 @@ impl SkipReader {
 #[cfg(test)]
 mod tests {
 
+    use super::AdvancingReadOnlySource;
     use super::IndexRecordOption;
     use super::{SkipReader, SkipSerializer};
-    use super::AdvancingReadOnlySource;
 
     #[test]
     fn test_skip_with_freq() {
@@ -145,7 +144,10 @@ mod tests {
             skip_serializer.write_term_freq(2u8);
             skip_serializer.data().to_owned()
         };
-        let mut skip_reader = SkipReader::new(AdvancingReadOnlySource::from(buf), IndexRecordOption::WithFreqs);
+        let mut skip_reader = SkipReader::new(
+            AdvancingReadOnlySource::from(buf),
+            IndexRecordOption::WithFreqs,
+        );
         assert!(skip_reader.advance());
         assert_eq!(skip_reader.doc(), 1u32);
         assert_eq!(skip_reader.doc_num_bits(), 2u8);
@@ -165,7 +167,8 @@ mod tests {
             skip_serializer.write_doc(5u32, 5u8);
             skip_serializer.data().to_owned()
         };
-        let mut skip_reader = SkipReader::new(AdvancingReadOnlySource::from(buf), IndexRecordOption::Basic);
+        let mut skip_reader =
+            SkipReader::new(AdvancingReadOnlySource::from(buf), IndexRecordOption::Basic);
         assert!(skip_reader.advance());
         assert_eq!(skip_reader.doc(), 1u32);
         assert_eq!(skip_reader.doc_num_bits(), 2u8);

--- a/src/query/phrase_query/phrase_weight.rs
+++ b/src/query/phrase_query/phrase_weight.rs
@@ -101,7 +101,7 @@ impl Weight for PhraseWeight {
         if scorer.skip_next(doc) != SkipResult::Reached {
             return Err(does_not_match(doc));
         }
-        let fieldnorm_reader = self.fieldnorm_reader(reader);
+        let mut fieldnorm_reader = self.fieldnorm_reader(reader);
         let fieldnorm_id = fieldnorm_reader.fieldnorm_id(doc);
         let phrase_count = scorer.phrase_count();
         let mut explanation = Explanation::new("Phrase Scorer", scorer.score());

--- a/src/query/term_query/term_scorer.rs
+++ b/src/query/term_query/term_scorer.rs
@@ -33,11 +33,11 @@ impl TermScorer {
         self.postings.term_freq()
     }
 
-    pub fn fieldnorm_id(&self) -> u8 {
+    pub fn fieldnorm_id(&mut self) -> u8 {
         self.fieldnorm_reader.fieldnorm_id(self.doc())
     }
 
-    pub fn explain(&self) -> Explanation {
+    pub fn explain(&mut self) -> Explanation {
         let fieldnorm_id = self.fieldnorm_id();
         let term_freq = self.term_freq();
         self.similarity_weight.explain(fieldnorm_id, term_freq)

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -3,16 +3,16 @@ use crate::Result;
 use super::decompress;
 use super::skiplist::SkipList;
 use crate::common::BinarySerializable;
+use crate::common::HasLen;
 use crate::common::VInt;
 use crate::directory::ReadOnlySource;
 use crate::schema::Document;
 use crate::space_usage::StoreSpaceUsage;
 use crate::DocId;
-use crate::common::HasLen;
 use std::cell::RefCell;
 use std::io;
-use std::mem::size_of;
 use std::io::Read;
+use std::mem::size_of;
 
 /// Reads document off tantivy's [`Store`](./index.html)
 #[derive(Clone)]
@@ -56,7 +56,9 @@ impl StoreReader {
         let mut buffer_slice = self.data.slice_from(addr);
         let block_len = u32::deserialize(&mut buffer_slice).expect("") as usize;
         let mut block = vec![0u8; block_len];
-        buffer_slice.read_exact(&mut block).expect("Can't read compressed block");
+        buffer_slice
+            .read_exact(&mut block)
+            .expect("Can't read compressed block");
         block
     }
 

--- a/src/store/skiplist/mod.rs
+++ b/src/store/skiplist/mod.rs
@@ -17,7 +17,7 @@ mod tests {
         let mut skip_list_builder: SkipListBuilder<u32> = SkipListBuilder::new(8);
         skip_list_builder.insert(2, &3).unwrap();
         skip_list_builder.write::<Vec<u8>>(&mut output).unwrap();
-        let mut skip_list: SkipList<'_, u32> = SkipList::from(output.as_slice());
+        let mut skip_list: SkipList<u32> = SkipList::from(output);
         assert_eq!(skip_list.next(), Some((2, 3)));
     }
 
@@ -26,7 +26,7 @@ mod tests {
         let mut output: Vec<u8> = Vec::new();
         let skip_list_builder: SkipListBuilder<u32> = SkipListBuilder::new(8);
         skip_list_builder.write::<Vec<u8>>(&mut output).unwrap();
-        let mut skip_list: SkipList<'_, u32> = SkipList::from(output.as_slice());
+        let mut skip_list: SkipList<u32> = SkipList::from(output);
         assert_eq!(skip_list.next(), None);
     }
 
@@ -40,7 +40,7 @@ mod tests {
         skip_list_builder.insert(7, &()).unwrap();
         skip_list_builder.insert(9, &()).unwrap();
         skip_list_builder.write::<Vec<u8>>(&mut output).unwrap();
-        let mut skip_list: SkipList<'_, ()> = SkipList::from(output.as_slice());
+        let mut skip_list: SkipList<()> = SkipList::from(output);
         assert_eq!(skip_list.next().unwrap(), (2, ()));
         assert_eq!(skip_list.next().unwrap(), (3, ()));
         assert_eq!(skip_list.next().unwrap(), (5, ()));
@@ -59,7 +59,7 @@ mod tests {
         skip_list_builder.insert(7, &()).unwrap();
         skip_list_builder.insert(9, &()).unwrap();
         skip_list_builder.write::<Vec<u8>>(&mut output).unwrap();
-        let mut skip_list: SkipList<'_, ()> = SkipList::from(output.as_slice());
+        let mut skip_list: SkipList<()> = SkipList::from(output);
         assert_eq!(skip_list.next().unwrap(), (2, ()));
         skip_list.seek(5);
         assert_eq!(skip_list.next().unwrap(), (5, ()));
@@ -77,7 +77,7 @@ mod tests {
         skip_list_builder.insert(5, &()).unwrap();
         skip_list_builder.insert(6, &()).unwrap();
         skip_list_builder.write::<Vec<u8>>(&mut output).unwrap();
-        let mut skip_list: SkipList<'_, ()> = SkipList::from(output.as_slice());
+        let mut skip_list: SkipList<()> = SkipList::from(output);
         assert_eq!(skip_list.next().unwrap(), (2, ()));
         skip_list.seek(6);
         assert_eq!(skip_list.next().unwrap(), (6, ()));
@@ -94,7 +94,7 @@ mod tests {
         skip_list_builder.insert(7, &()).unwrap();
         skip_list_builder.insert(9, &()).unwrap();
         skip_list_builder.write::<Vec<u8>>(&mut output).unwrap();
-        let mut skip_list: SkipList<'_, ()> = SkipList::from(output.as_slice());
+        let mut skip_list: SkipList<()> = SkipList::from(output);
         assert_eq!(skip_list.next().unwrap(), (2, ()));
         skip_list.seek(10);
         assert_eq!(skip_list.next(), None);
@@ -109,7 +109,7 @@ mod tests {
         }
         skip_list_builder.insert(1004, &()).unwrap();
         skip_list_builder.write::<Vec<u8>>(&mut output).unwrap();
-        let mut skip_list: SkipList<'_, ()> = SkipList::from(output.as_slice());
+        let mut skip_list: SkipList<()> = SkipList::from(output);
         assert_eq!(skip_list.next().unwrap(), (0, ()));
         skip_list.seek(431);
         assert_eq!(skip_list.next().unwrap(), (431, ()));

--- a/src/store/skiplist/skiplist.rs
+++ b/src/store/skiplist/skiplist.rs
@@ -1,8 +1,8 @@
 use crate::common::{BinarySerializable, VInt};
 use crate::directory::ReadOnlySource;
 use std::cmp::max;
-use std::marker::PhantomData;
 use std::io::{Seek, SeekFrom};
+use std::marker::PhantomData;
 
 struct Layer<T> {
     data: ReadOnlySource,
@@ -110,7 +110,9 @@ impl<T: BinarySerializable> SkipList<T> {
 
 impl<T: BinarySerializable> From<ReadOnlySource> for SkipList<T> {
     fn from(mut data: ReadOnlySource) -> SkipList<T> {
-        let data_pos = data.seek(SeekFrom::Current(0)).expect("Can't seek in skiplist");
+        let data_pos = data
+            .seek(SeekFrom::Current(0))
+            .expect("Can't seek in skiplist");
         let offsets: Vec<u64> = Vec::<VInt>::deserialize(&mut data)
             .unwrap()
             .into_iter()
@@ -118,7 +120,9 @@ impl<T: BinarySerializable> From<ReadOnlySource> for SkipList<T> {
             .collect();
         let num_layers = offsets.len();
 
-        let new_pos = data.seek(SeekFrom::Current(0)).expect("Can't seek in skiplist");
+        let new_pos = data
+            .seek(SeekFrom::Current(0))
+            .expect("Can't seek in skiplist");
         let slice_length = new_pos - data_pos;
         let layers_data = data.slice_from(slice_length as usize);
 

--- a/src/store/writer.rs
+++ b/src/store/writer.rs
@@ -65,7 +65,7 @@ impl StoreWriter {
     /// This method is an optimization compared to iterating over the documents
     /// in the store and adding them one by one, as the store's data will
     /// not be decompressed and then recompressed.
-    pub fn stack(&mut self, store_reader: &StoreReader) -> io::Result<()> {
+    pub fn stack(&mut self, store_reader: &mut StoreReader) -> io::Result<()> {
         if !self.current_block.is_empty() {
             self.write_and_compress_block()?;
             self.offset_index_writer
@@ -75,7 +75,7 @@ impl StoreWriter {
         let start_offset = self.writer.written_bytes() as u64;
 
         // just bulk write all of the block of the given reader.
-        self.writer.write_all(store_reader.block_data())?;
+        self.writer.write_all(&store_reader.block_data())?;
 
         // concatenate the index of the `store_reader`, after translating
         // its start doc id and its start file offset.

--- a/src/termdict/term_info_store.rs
+++ b/src/termdict/term_info_store.rs
@@ -124,16 +124,22 @@ impl TermInfoStore {
 
     pub fn get(&self, term_ord: TermOrdinal) -> TermInfo {
         let block_id = (term_ord as usize) / BLOCK_LEN;
-        let mut block_data = self.block_meta_source.slice_from(block_id * TermInfoBlockMeta::SIZE_IN_BYTES);
+        let mut block_data = self
+            .block_meta_source
+            .slice_from(block_id * TermInfoBlockMeta::SIZE_IN_BYTES);
         let term_info_block_data = TermInfoBlockMeta::deserialize(&mut block_data)
             .expect("Failed to deserialize terminfoblockmeta");
         let inner_offset = (term_ord as usize) % BLOCK_LEN;
         if inner_offset == 0 {
             term_info_block_data.ref_term_info
         } else {
-            let mut term_info_data = self.term_info_source.slice_from(term_info_block_data.offset as usize);
+            let mut term_info_data = self
+                .term_info_source
+                .slice_from(term_info_block_data.offset as usize);
             term_info_block_data.deserialize_term_info(
-                &term_info_data.read_all().expect("Can't read term info data"),
+                &term_info_data
+                    .read_all()
+                    .expect("Can't read term info data"),
                 inner_offset - 1,
             )
         }

--- a/src/termdict/termdict.rs
+++ b/src/termdict/termdict.rs
@@ -2,11 +2,11 @@ use super::term_info_store::{TermInfoStore, TermInfoStoreWriter};
 use super::{TermStreamer, TermStreamerBuilder};
 use crate::common::BinarySerializable;
 use crate::common::CountingWriter;
+use crate::common::HasLen;
 use crate::directory::ReadOnlySource;
 use crate::postings::TermInfo;
 use crate::schema::FieldType;
 use crate::termdict::TermOrdinal;
-use crate::common::HasLen;
 use std::io::{self, Write};
 use tantivy_fst;
 use tantivy_fst::raw::Fst;
@@ -89,7 +89,8 @@ where
 }
 
 fn open_fst_index(mut source: ReadOnlySource) -> tantivy_fst::Map<Vec<u8>> {
-    let fst = Fst::new(source.read_all().expect("Can't read source")).expect("FST data is corrupted");
+    let fst =
+        Fst::new(source.read_all().expect("Can't read source")).expect("FST data is corrupted");
     tantivy_fst::Map::from(fst)
 }
 


### PR DESCRIPTION
This PR implements what was briefly discussed on Gitter, a `ReadOnlySource` implementation that uses a `Read + Seek` based API.

Please do note that this is for now a initial implementation, a proof of concept. Plenty of places do questionable things or are a bit sloppy and need to be improved but, it can serve for us as a starting point for discussion. That being said it does work correctly with the current `Directory` implementations and passes all tests.

The motivation for a `Read + Seek` based implementation is [this](https://github.com/matrix-org/seshat/blob/master/src/encrypted_dir.rs#L564) `Directory` implementation that transparently encrypts/decrypts files that Tantivy reads/writes. This could be quite important for client applications that provide full text search over sensitive data.

I am sure that there are more use-cases for such an `Read + Seek` based API, and making the `Directory` more flexible is a welcome improvement.

A downside of this API is that allocating memory buffers and copying data is necessary instead of the direct access that we get with the slice based approach.