### PR TITLE
Expose UserOperation as a public type.

### DIFF
--- a/src/indexer/operation.rs
+++ b/src/indexer/operation.rs
@@ -19,6 +19,8 @@ pub struct AddOperation {
 /// UserOperation is an enum type that encapsulates other operation types.
 #[derive(Eq, PartialEq, Debug)]
 pub enum UserOperation {
+    /// Add operation
     Add(Document),
+    /// Delete operation
     Delete(Term),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,7 @@ pub use crate::core::{Index, IndexMeta, Searcher, Segment, SegmentId, SegmentMet
 pub use crate::core::{InvertedIndexReader, SegmentReader};
 pub use crate::directory::Directory;
 pub use crate::indexer::IndexWriter;
+pub use crate::indexer::operation::UserOperation;
 pub use crate::postings::Postings;
 pub use crate::reader::LeasedItem;
 pub use crate::schema::{Document, Term};


### PR DESCRIPTION
In order to make `IndexWriter::run` callable from outside of the create,
the `UserOperation` type needs to be publicly available.
Since the `indexer` module is private, we just export the `UserOperation`
type directly.