### PR TITLE
Low level Query boost_by

### DIFF
--- a/src/query/bm25.rs
+++ b/src/query/bm25.rs
@@ -34,7 +34,7 @@ pub struct BM25Weight {
 }
 
 impl BM25Weight {
-    pub fn for_terms(searcher: &Searcher, terms: &[Term]) -> BM25Weight {
+    pub fn for_terms(searcher: &Searcher, terms: &[Term], boost: f32) -> BM25Weight {
         assert!(!terms.is_empty(), "BM25 requires at least one term");
         let field = terms[0].field();
         for term in &terms[1..] {
@@ -75,11 +75,11 @@ impl BM25Weight {
                 .sum::<f32>();
             idf_explain = Explanation::new("idf", idf);
         }
-        BM25Weight::new(idf_explain, average_fieldnorm)
+        BM25Weight::new(idf_explain, average_fieldnorm, boost)
     }
 
-    fn new(idf_explain: Explanation, average_fieldnorm: f32) -> BM25Weight {
-        let weight = idf_explain.value() * (1f32 + K1);
+    fn new(idf_explain: Explanation, average_fieldnorm: f32, boost: f32) -> BM25Weight {
+        let weight = idf_explain.value() * (1f32 + K1) * boost;
         BM25Weight {
             idf_explain,
             weight,

--- a/src/query/phrase_query/phrase_query.rs
+++ b/src/query/phrase_query/phrase_query.rs
@@ -27,6 +27,7 @@ use std::collections::BTreeSet;
 pub struct PhraseQuery {
     field: Field,
     phrase_terms: Vec<(usize, Term)>,
+    boost: f32,
 }
 
 impl PhraseQuery {
@@ -57,7 +58,13 @@ impl PhraseQuery {
         PhraseQuery {
             field,
             phrase_terms: terms,
+            boost: 1.0,
         }
+    }
+
+    /// Boost the query score by the given factor.
+    pub fn boost_by(self, boost: f32) -> Self {
+        Self { boost, ..self }
     }
 
     /// The `Field` this `PhraseQuery` is targeting.
@@ -97,7 +104,7 @@ impl PhraseQuery {
             )));
         }
         let terms = self.phrase_terms();
-        let bm25_weight = BM25Weight::for_terms(searcher, &terms);
+        let bm25_weight = BM25Weight::for_terms(searcher, &terms, self.boost);
         Ok(PhraseWeight::new(
             self.phrase_terms.clone(),
             bm25_weight,

--- a/src/query/regex_query.rs
+++ b/src/query/regex_query.rs
@@ -54,6 +54,7 @@ use tantivy_fst::Regex;
 pub struct RegexQuery {
     regex: Arc<Regex>,
     field: Field,
+    boost: f32,
 }
 
 impl RegexQuery {
@@ -69,11 +70,17 @@ impl RegexQuery {
         RegexQuery {
             regex: regex.into(),
             field,
+            boost: 1.0,
         }
     }
 
+    /// Boost the query score by the given factor.
+    pub fn boost_by(self, boost: f32) -> Self {
+        Self { boost, ..self }
+    }
+
     fn specialized_weight(&self) -> AutomatonWeight<Regex> {
-        AutomatonWeight::new(self.field, self.regex.clone())
+        AutomatonWeight::new(self.field, self.regex.clone()).boost_by(self.boost)
     }
 }
 

--- a/src/query/scorer.rs
+++ b/src/query/scorer.rs
@@ -56,6 +56,11 @@ impl<TDocSet: DocSet> ConstScorer<TDocSet> {
         }
     }
 
+    /// Creates a new `ConstScorer` with a custom score value
+    pub fn with_score(docset: TDocSet, score: f32) -> ConstScorer<TDocSet> {
+        ConstScorer { docset, score }
+    }
+
     /// Sets the constant score to a different value.
     pub fn set_score(&mut self, score: Score) {
         self.score = score;

--- a/src/query/term_query/term_query.rs
+++ b/src/query/term_query/term_query.rs
@@ -61,6 +61,7 @@ use std::fmt;
 pub struct TermQuery {
     term: Term,
     index_record_option: IndexRecordOption,
+    boost: f32,
 }
 
 impl fmt::Debug for TermQuery {
@@ -75,7 +76,13 @@ impl TermQuery {
         TermQuery {
             term,
             index_record_option: segment_postings_options,
+            boost: 1.0,
         }
+    }
+
+    /// Boost the query score by the given factor.
+    pub fn boost_by(self, boost: f32) -> Self {
+        Self { boost, ..self }
     }
 
     /// The `Term` this query is built out of.
@@ -90,7 +97,7 @@ impl TermQuery {
     /// This is useful for optimization purpose.
     pub fn specialized_weight(&self, searcher: &Searcher, scoring_enabled: bool) -> TermWeight {
         let term = self.term.clone();
-        let bm25_weight = BM25Weight::for_terms(searcher, &[term]);
+        let bm25_weight = BM25Weight::for_terms(searcher, &[term], self.boost);
         let index_record_option = if scoring_enabled {
             self.index_record_option
         } else {


### PR DESCRIPTION
My naive attempt at adding "low-level" query boosting.

Adds `boost_by(self, score: f32) -> Self` method to `TermQuery`, `PhraseQuery`, `RegexQuery`, `FuzzyQuery`. This style does not break API compatibility for the various queries. Some internal function signatures have changed.

#547 