### PR TITLE
Make TweakScore and CustomScore mutable at the segment level

### DIFF
--- a/examples/faceted_search_with_tweaked_score.rs
+++ b/examples/faceted_search_with_tweaked_score.rs
@@ -1,0 +1,98 @@
+use std::collections::HashSet;
+use tantivy::collector::TopDocs;
+use tantivy::doc;
+use tantivy::query::BooleanQuery;
+use tantivy::schema::*;
+use tantivy::{DocId, Index, Score, SegmentReader};
+
+fn main() -> tantivy::Result<()> {
+    let mut schema_builder = Schema::builder();
+
+    let title = schema_builder.add_text_field("title", STORED);
+    let ingredient = schema_builder.add_facet_field("ingredient");
+
+    let schema = schema_builder.build();
+    let index = Index::create_in_ram(schema.clone());
+
+    let mut index_writer = index.writer(30_000_000)?;
+
+    index_writer.add_document(doc!(
+        title => "Fried egg",
+        ingredient => Facet::from("/ingredient/egg"),
+        ingredient => Facet::from("/ingredient/oil"),
+    ));
+    index_writer.add_document(doc!(
+        title => "Scrambled egg",
+        ingredient => Facet::from("/ingredient/egg"),
+        ingredient => Facet::from("/ingredient/butter"),
+        ingredient => Facet::from("/ingredient/milk"),
+        ingredient => Facet::from("/ingredient/salt"),
+    ));
+    index_writer.add_document(doc!(
+        title => "Egg rolls",
+        ingredient => Facet::from("/ingredient/egg"),
+        ingredient => Facet::from("/ingredient/garlic"),
+        ingredient => Facet::from("/ingredient/salt"),
+        ingredient => Facet::from("/ingredient/oil"),
+        ingredient => Facet::from("/ingredient/tortilla-wrap"),
+        ingredient => Facet::from("/ingredient/mushroom"),
+    ));
+    index_writer.commit()?;
+
+    let reader = index.reader()?;
+    let searcher = reader.searcher();
+    {
+        let facets = vec![
+            Facet::from("/ingredient/egg"),
+            Facet::from("/ingredient/oil"),
+            Facet::from("/ingredient/garlic"),
+            Facet::from("/ingredient/mushroom"),
+        ];
+        let query = BooleanQuery::new_multiterms_query(
+            facets
+                .iter()
+                .map(|key| Term::from_facet(ingredient, &key))
+                .collect(),
+        );
+        let top_docs_by_custom_score =
+            TopDocs::with_limit(2).tweak_score(move |segment_reader: &SegmentReader| {
+                let mut ingredient_reader = segment_reader.facet_reader(ingredient).unwrap();
+                let facet_dict = ingredient_reader.facet_dict();
+
+                let query_ords: HashSet<u64> = facets
+                    .iter()
+                    .filter_map(|key| facet_dict.term_ord(key.encoded_str()))
+                    .collect();
+
+                let mut facet_ords_buffer: Vec<u64> = Vec::with_capacity(20);
+
+                move |doc: DocId, original_score: Score| {
+                    ingredient_reader.facet_ords(doc, &mut facet_ords_buffer);
+                    let missing_ingredients = facet_ords_buffer
+                        .iter()
+                        .filter(|ord| !query_ords.contains(ord))
+                        .count();
+                    let tweak = 1.0 / 4_f32.powi(missing_ingredients as i32);
+
+                    original_score * tweak
+                }
+            });
+        let top_docs = searcher.search(&query, &top_docs_by_custom_score)?;
+
+        let titles: Vec<String> = top_docs
+            .iter()
+            .map(|(_, doc_id)| {
+                searcher
+                    .doc(*doc_id)
+                    .unwrap()
+                    .get_first(title)
+                    .unwrap()
+                    .text()
+                    .unwrap()
+                    .to_owned()
+            })
+            .collect();
+        assert_eq!(titles, vec!["Fried egg", "Egg rolls"]);
+    }
+    Ok(())
+}

--- a/src/collector/custom_score_top_collector.rs
+++ b/src/collector/custom_score_top_collector.rs
@@ -28,7 +28,7 @@ where
 /// It is the segment local version of the [`CustomScorer`](./trait.CustomScorer.html).
 pub trait CustomSegmentScorer<TScore>: 'static {
     /// Computes the score of a specific `doc`.
-    fn score(&self, doc: DocId) -> TScore;
+    fn score(&mut self, doc: DocId) -> TScore;
 }
 
 /// `CustomScorer` makes it possible to define any kind of score.
@@ -117,9 +117,9 @@ where
 
 impl<F, TScore> CustomSegmentScorer<TScore> for F
 where
-    F: 'static + Sync + Send + Fn(DocId) -> TScore,
+    F: 'static + FnMut(DocId) -> TScore,
 {
-    fn score(&self, doc: DocId) -> TScore {
+    fn score(&mut self, doc: DocId) -> TScore {
         (self)(doc)
     }
 }

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -66,7 +66,7 @@ struct ScorerByFastFieldReader {
 }
 
 impl CustomSegmentScorer<u64> for ScorerByFastFieldReader {
-    fn score(&self, doc: DocId) -> u64 {
+    fn score(&mut self, doc: DocId) -> u64 {
         self.ff_reader.get_u64(u64::from(doc))
     }
 }

--- a/src/collector/tweak_score_top_collector.rs
+++ b/src/collector/tweak_score_top_collector.rs
@@ -29,7 +29,7 @@ where
 /// It is the segment local version of the [`ScoreTweaker`](./trait.ScoreTweaker.html).
 pub trait ScoreSegmentTweaker<TScore>: 'static {
     /// Tweak the given `score` for the document `doc`.
-    fn score(&self, doc: DocId, score: Score) -> TScore;
+    fn score(&mut self, doc: DocId, score: Score) -> TScore;
 }
 
 /// `ScoreTweaker` makes it possible to tweak the score
@@ -121,9 +121,9 @@ where
 
 impl<F, TScore> ScoreSegmentTweaker<TScore> for F
 where
-    F: 'static + Sync + Send + Fn(DocId, Score) -> TScore,
+    F: 'static + FnMut(DocId, Score) -> TScore,
 {
-    fn score(&self, doc: DocId, score: Score) -> TScore {
+    fn score(&mut self, doc: DocId, score: Score) -> TScore {
         (self)(doc, score)
     }
 }


### PR DESCRIPTION
Addresses issue #806

I have also added a test that shows using `tweak_score` with a facet. This is the problem I was originally describing when I raised this on Gitter. I'm not sure if this kind of test is wanted or whether this is the correct place for it. Would love some guidance on that.