### PR TITLE
Switch fst dependency to git

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ byteorder = "1.0"
 crc32fast = "1.2.0"
 once_cell = "1.0"
 regex ={version = "1.3.0", default-features = false, features = ["std"]}
-tantivy-fst = {path="../tantivy-fst", version="0.3"}
+tantivy-fst = {git = "https://github.com/tantivy-search/fst", version="0.3"}
 memmap = {version = "0.7", optional=true}
 lz4 = {version="1.20", optional=true}
 snap = "1"


### PR DESCRIPTION
This allows the package to be built without first cloning the
tantivy-search/fst repo into the expected place. This should fix CI.