### PR TITLE
Make field methods const fns

### DIFF
--- a/src/schema/field.rs
+++ b/src/schema/field.rs
@@ -12,13 +12,13 @@ pub struct Field(u32);
 
 impl Field {
     /// Create a new field object for the given FieldId.
-    pub fn from_field_id(field_id: u32) -> Field {
+    pub const fn from_field_id(field_id: u32) -> Field {
         Field(field_id)
     }
 
     /// Returns a u32 identifying uniquely a field within a schema.
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn field_id(&self) -> u32 {
+    pub const fn field_id(&self) -> u32 {
         self.0
     }
 }


### PR DESCRIPTION
This PR makes `Field::from_field_id` and `Field::field_id` `const` functions. This is useful for creating const Field with unchanging Ids:
```
const TITLE: Field = Field::from_field_id(0);
```
Closes #821 