### PR TITLE
Fix incorrect SimpleTokenizer link in documentation

### DIFF
--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -113,7 +113,7 @@ fn trim_ast(logical_ast: LogicalAST) -> Option<LogicalAST> {
 /// The language covered by the current parser is extremely simple.
 ///
 /// * simple terms: "e.g.: `Barack Obama` are simply tokenized using
-///   tantivy's [`SimpleTokenizer`](tantivy::tokenizer::SimpleTokenizer), hence
+///   tantivy's [`SimpleTokenizer`](../tokenizer/struct.SimpleTokenizer.html), hence
 ///   becoming `["barack", "obama"]`. The terms are then searched within
 ///   the default terms of the query parser.
 ///


### PR DESCRIPTION
Small patch to fix a warning when running `cargo doc`:

```
warning: `[tantivy::tokenizer::SimpleTokenizer]` cannot be resolved, ignoring it.
   --> src/query/query_parser/query_parser.rs:116:37
    |
116 | ///   tantivy's [`SimpleTokenizer`](tantivy::tokenizer::SimpleTokenizer), hence
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
```

Succeeds and links properly after the patch is applied with no warnings remaining.