### PR TITLE
Bugfix.

### DIFF
--- a/examples/iterating_docs_and_positions.rs
+++ b/examples/iterating_docs_and_positions.rs
@@ -117,11 +117,16 @@ fn main() -> tantivy::Result<()> {
         if let Some(mut block_segment_postings) =
             inverted_index.read_block_postings(&term_the, IndexRecordOption::Basic)
         {
-            while block_segment_postings.advance() {
+            loop {
+                let docs = block_segment_postings.docs();
+                if docs.is_empty() {
+                    break;
+                }
                 // Once again these docs MAY contains deleted documents as well.
                 let docs = block_segment_postings.docs();
                 // Prints `Docs [0, 2].`
                 println!("Docs {:?}", docs);
+                block_segment_postings.advance();
             }
         }
     }

--- a/src/postings/compression/mod.rs
+++ b/src/postings/compression/mod.rs
@@ -109,6 +109,7 @@ impl BlockDecoder {
     }
 
     pub fn clear(&mut self) {
+        self.output_len = 0;
         self.output.0.iter_mut().for_each(|el| *el = TERMINATED);
     }
 }
@@ -242,6 +243,19 @@ pub mod tests {
         for i in 0..n {
             assert_eq!(vals[i], decoder.output(i));
         }
+    }
+
+    #[test]
+    fn test_clearing() {
+        let mut encoder = BlockEncoder::new();
+        let vals = (0u32..128u32).map(|i| i * 3).collect::<Vec<_>>();
+        let (num_bits, compressed) = encoder.compress_block_sorted(&vals[..], 0u32);
+        let mut decoder = BlockDecoder::default();
+        decoder.uncompress_block_sorted(compressed, 0u32, num_bits);
+        assert_eq!(decoder.output_len, 128);
+        assert_eq!(decoder.output_array(), &vals[..]);
+        decoder.clear();
+        assert!(decoder.output_array().is_empty());
     }
 
     #[test]

--- a/src/postings/segment_postings.rs
+++ b/src/postings/segment_postings.rs
@@ -100,14 +100,15 @@ impl DocSet for SegmentPostings {
     }
 
     fn seek(&mut self, target: DocId) -> DocId {
-        if self.doc() == target {
-            return target;
+        debug_assert!(self.doc() <= target);
+        if self.doc() >= target {
+            return self.doc();
         }
+
         self.block_cursor.seek(target);
 
         // At this point we are on the block, that might contain our document.
         let output = self.block_cursor.docs_aligned();
-
         self.cur = self.block_searcher.search_in_block(&output, target);
 
         // The last block is not full and padded with the value TERMINATED,
@@ -123,6 +124,7 @@ impl DocSet for SegmentPostings {
         // After the search, the cursor should point to the first value of TERMINATED.
         let doc = output.0[self.cur];
         debug_assert!(doc >= target);
+        debug_assert_eq!(doc, self.doc());
         doc
     }
 

--- a/src/query/boolean_query/mod.rs
+++ b/src/query/boolean_query/mod.rs
@@ -141,7 +141,6 @@ mod tests {
                 .map(|doc| doc.1)
                 .collect::<Vec<DocId>>()
         };
-
         {
             let boolean_query = BooleanQuery::from(vec![(Occur::Must, make_term_query("a"))]);
             assert_eq!(matching_docs(&boolean_query), vec![0, 1, 3]);

--- a/src/query/intersection.rs
+++ b/src/query/intersection.rs
@@ -53,7 +53,8 @@ pub struct Intersection<TDocSet: DocSet, TOtherDocSet: DocSet = Box<dyn Scorer>>
 }
 
 fn go_to_first_doc<TDocSet: DocSet>(docsets: &mut [TDocSet]) -> DocId {
-    let mut candidate = 0;
+    assert!(!docsets.is_empty());
+    let mut candidate = docsets.iter().map(TDocSet::doc).max().unwrap();
     'outer: loop {
         for docset in docsets.iter_mut() {
             let seek_doc = docset.seek(candidate);
@@ -119,6 +120,9 @@ impl<TDocSet: DocSet, TOtherDocSet: DocSet> DocSet for Intersection<TDocSet, TOt
                 }
             }
 
+            assert_eq!(candidate, self.left.doc());
+            assert_eq!(candidate, self.right.doc());
+            assert!(self.others.iter().all(|docset| docset.doc() == candidate));
             return candidate;
         }
     }
@@ -129,7 +133,12 @@ impl<TDocSet: DocSet, TOtherDocSet: DocSet> DocSet for Intersection<TDocSet, TOt
         for docset in &mut self.others {
             docsets.push(docset);
         }
-        go_to_first_doc(&mut docsets[..])
+        let doc = go_to_first_doc(&mut docsets[..]);
+        for docset in docsets {
+            assert_eq!(docset.doc(), doc);
+        }
+        debug_assert!(doc >= target);
+        doc
     }
 
     fn doc(&self) -> DocId {

--- a/src/query/phrase_query/phrase_scorer.rs
+++ b/src/query/phrase_query/phrase_scorer.rs
@@ -239,6 +239,7 @@ impl<TPostings: Postings> DocSet for PhraseScorer<TPostings> {
     }
 
     fn seek(&mut self, target: DocId) -> DocId {
+        debug_assert!(target >= self.doc());
         let doc = self.intersection_docset.seek(target);
         if doc == TERMINATED || self.phrase_match() {
             return doc;
@@ -266,7 +267,6 @@ impl<TPostings: Postings> Scorer for PhraseScorer<TPostings> {
 
 #[cfg(test)]
 mod tests {
-
     use super::{intersection, intersection_count};
 
     fn test_intersection_sym(left: &[u32], right: &[u32], expected: &[u32]) {

--- a/src/query/range_query.rs
+++ b/src/query/range_query.rs
@@ -301,12 +301,14 @@ impl Weight for RangeWeight {
             let mut block_segment_postings = inverted_index
                 .read_block_postings_from_terminfo(term_info, IndexRecordOption::Basic);
             loop {
+                let docs = block_segment_postings.docs();
+                if docs.is_empty() {
+                    break;
+                }
                 for &doc in block_segment_postings.docs() {
                     doc_bitset.insert(doc);
                 }
-                if !block_segment_postings.advance() {
-                    break;
-                }
+                block_segment_postings.advance();
             }
         }
         let doc_bitset = BitSetDocSet::from(doc_bitset);

--- a/src/query/term_query/mod.rs
+++ b/src/query/term_query/mod.rs
@@ -11,11 +11,12 @@ mod tests {
 
     use crate::collector::TopDocs;
     use crate::docset::DocSet;
+    use crate::postings::compression::COMPRESSION_BLOCK_SIZE;
     use crate::query::{Query, QueryParser, Scorer, TermQuery};
     use crate::schema::{Field, IndexRecordOption, Schema, STRING, TEXT};
     use crate::tests::assert_nearly_equals;
-    use crate::Index;
     use crate::Term;
+    use crate::{Index, TERMINATED};
 
     #[test]
     pub fn test_term_query_no_freq() {
@@ -40,6 +41,41 @@ mod tests {
         let mut term_scorer = term_weight.scorer(segment_reader, 1.0f32).unwrap();
         assert_eq!(term_scorer.doc(), 0);
         assert_eq!(term_scorer.score(), 0.28768212);
+    }
+
+    #[test]
+    pub fn test_term_query_multiple_of_block_len() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", STRING);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        {
+            // writing the segment
+            let mut index_writer = index.writer_with_num_threads(1, 3_000_000)?;
+            for _ in 0..COMPRESSION_BLOCK_SIZE {
+                let doc = doc!(text_field => "a");
+                index_writer.add_document(doc);
+            }
+            index_writer.commit()?;
+        }
+        let searcher = index.reader()?.searcher();
+        let term_query = TermQuery::new(
+            Term::from_field_text(text_field, "a"),
+            IndexRecordOption::Basic,
+        );
+        let term_weight = term_query.weight(&searcher, true)?;
+        let segment_reader = searcher.segment_reader(0);
+        let mut term_scorer = term_weight.scorer(segment_reader, 1.0f32)?;
+        for i in 0u32..COMPRESSION_BLOCK_SIZE as u32 {
+            assert_eq!(term_scorer.doc(), i);
+            if i == COMPRESSION_BLOCK_SIZE as u32 - 1u32 {
+                assert_eq!(term_scorer.advance(), TERMINATED);
+            } else {
+                assert_eq!(term_scorer.advance(), i + 1);
+            }
+        }
+        assert_eq!(term_scorer.doc(), TERMINATED);
+        Ok(())
     }
 
     #[test]
@@ -110,6 +146,27 @@ mod tests {
         let term_query = TermQuery::new(term_a, IndexRecordOption::Basic);
         let reader = index.reader().unwrap();
         assert_eq!(term_query.count(&*reader.searcher()).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_term_query_simple_seek() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer = index.writer_with_num_threads(1, 3_000_000).unwrap();
+        index_writer.add_document(doc!(text_field=>"a"));
+        index_writer.add_document(doc!(text_field=>"a"));
+        index_writer.commit()?;
+        let term_a = Term::from_field_text(text_field, "a");
+        let term_query = TermQuery::new(term_a, IndexRecordOption::Basic);
+        let searcher = index.reader()?.searcher();
+        let term_weight = term_query.weight(&searcher, false)?;
+        let mut term_scorer = term_weight.scorer(searcher.segment_reader(0u32), 1.0f32)?;
+        assert_eq!(term_scorer.doc(), 0u32);
+        term_scorer.seek(1u32);
+        assert_eq!(term_scorer.doc(), 1u32);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
go_to_first_doc was typically calling seek with a target smaller than
doc.

Since SegmentPostings typically do a linear search on the full block,
regardless of the current position, it could have our segment postings
go backward.