### PR TITLE
Entirely removes usage of failure and replace it with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,13 @@ bitpacking = {version="0.8", default-features = false, features=["bitpacker4x"]}
 census = "0.4"
 fnv = "1.0.6"
 owned-read = "0.4"
-failure = "0.1"
 htmlescape = "0.3.1"
 fail = "0.4"
 murmurhash32 = "0.2"
 chrono = "0.4"
 smallvec = "1.0"
 rayon = "1"
+thiserror = "1.0.20"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/src/directory/error.rs
+++ b/src/directory/error.rs
@@ -3,20 +3,19 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::io;
 use std::path::PathBuf;
+use thiserror::Error;
 
 /// Error while trying to acquire a directory lock.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum LockError {
     /// Failed to acquired a lock as it is already held by another
     /// client.
     /// - In the context of a blocking lock, this means the lock was not released within some `timeout` period.
     /// - In the context of a non-blocking lock, this means the lock was busy at the moment of the call.
-    #[fail(
-        display = "Could not acquire lock as it is already held, possibly by a different process."
-    )]
+    #[error("Could not acquire lock as it is already held, possibly by a different process.")]
     LockBusy,
     /// Trying to acquire a lock failed with an `IOError`
-    #[fail(display = "Failed to acquire the lock due to an io:Error.")]
+    #[error("Failed to acquire the lock due to an io:Error.")]
     IOError(io::Error),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ use crate::schema;
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::PoisonError;
+use thiserror::Error;
 
 pub struct DataCorruption {
     filepath: Option<PathBuf>,
@@ -44,43 +45,43 @@ impl fmt::Debug for DataCorruption {
 }
 
 /// The library's failure based error enum
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum TantivyError {
     /// Path does not exist.
-    #[fail(display = "Path does not exist: '{:?}'", _0)]
+    #[error("Path does not exist: '{:?}'", _0)]
     PathDoesNotExist(PathBuf),
     /// File already exists, this is a problem when we try to write into a new file.
-    #[fail(display = "File already exists: '{:?}'", _0)]
+    #[error("File already exists: '{:?}'", _0)]
     FileAlreadyExists(PathBuf),
     /// Index already exists in this directory
-    #[fail(display = "Index already exists")]
+    #[error("Index already exists")]
     IndexAlreadyExists,
     /// Failed to acquire file lock
-    #[fail(display = "Failed to acquire Lockfile: {:?}. {:?}", _0, _1)]
+    #[error("Failed to acquire Lockfile: {:?}. {:?}", _0, _1)]
     LockFailure(LockError, Option<String>),
     /// IO Error.
-    #[fail(display = "An IO error occurred: '{}'", _0)]
-    IOError(#[cause] IOError),
+    #[error("An IO error occurred: '{}'", _0)]
+    IOError(#[source] IOError),
     /// Data corruption.
-    #[fail(display = "{:?}", _0)]
+    #[error("{:?}", _0)]
     DataCorruption(DataCorruption),
     /// A thread holding the locked panicked and poisoned the lock.
-    #[fail(display = "A thread holding the locked panicked and poisoned the lock")]
+    #[error("A thread holding the lock panicked and poisoned the lock")]
     Poisoned,
     /// Invalid argument was passed by the user.
-    #[fail(display = "An invalid argument was passed: '{}'", _0)]
+    #[error("An invalid argument was passed: '{}'", _0)]
     InvalidArgument(String),
     /// An Error happened in one of the thread.
-    #[fail(display = "An error occurred in a thread: '{}'", _0)]
+    #[error("An error occurred in a thread: '{}'", _0)]
     ErrorInThread(String),
     /// An Error appeared related to the schema.
-    #[fail(display = "Schema error: '{}'", _0)]
+    #[error("Schema error: '{}'", _0)]
     SchemaError(String),
     /// System error. (e.g.: We failed spawning a new thread)
-    #[fail(display = "System error.'{}'", _0)]
+    #[error("System error.'{}'", _0)]
     SystemError(String),
     /// Index incompatible with current version of tantivy
-    #[fail(display = "{:?}", _0)]
+    #[error("{:?}", _0)]
     IncompatibleIndex(Incompatibility),
 }
 

--- a/src/fastfield/error.rs
+++ b/src/fastfield/error.rs
@@ -1,11 +1,12 @@
 use crate::schema::FieldEntry;
 use std::result;
+use thiserror::Error;
 
 /// `FastFieldNotAvailableError` is returned when the
 /// user requested for a fast field reader, and the field was not
 /// defined in the schema as a fast field.
-#[derive(Debug, Fail)]
-#[fail(display = "Fast field not available: '{:?}'", field_name)]
+#[derive(Debug, Error)]
+#[error("Fast field not available: '{:?}'", field_name)]
 pub struct FastFieldNotAvailableError {
     field_name: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,9 +104,6 @@ extern crate serde_json;
 #[macro_use]
 extern crate log;
 
-#[macro_use]
-extern crate failure;
-
 #[cfg(all(test, feature = "unstable"))]
 extern crate test;
 

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -18,53 +18,51 @@ use std::num::{ParseFloatError, ParseIntError};
 use std::ops::Bound;
 use std::str::FromStr;
 use tantivy_query_grammar::{UserInputAST, UserInputBound, UserInputLeaf};
+use thiserror::Error;
 
 /// Possible error that may happen when parsing a query.
-#[derive(Debug, PartialEq, Eq, Fail)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum QueryParserError {
     /// Error in the query syntax
-    #[fail(display = "Syntax Error")]
+    #[error("Syntax Error")]
     SyntaxError,
     /// `FieldDoesNotExist(field_name: String)`
     /// The query references a field that is not in the schema
-    #[fail(display = "File does not exists: '{:?}'", _0)]
+    #[error("File does not exists: '{:?}'", _0)]
     FieldDoesNotExist(String),
     /// The query contains a term for a `u64` or `i64`-field, but the value
     /// is neither.
-    #[fail(display = "Expected a valid integer: '{:?}'", _0)]
+    #[error("Expected a valid integer: '{:?}'", _0)]
     ExpectedInt(ParseIntError),
     /// The query contains a term for a `f64`-field, but the value
     /// is not a f64.
-    #[fail(display = "Invalid query: Only excluding terms given")]
+    #[error("Invalid query: Only excluding terms given")]
     ExpectedFloat(ParseFloatError),
     /// It is forbidden queries that are only "excluding". (e.g. -title:pop)
-    #[fail(display = "Invalid query: Only excluding terms given")]
+    #[error("Invalid query: Only excluding terms given")]
     AllButQueryForbidden,
     /// If no default field is declared, running a query without any
     /// field specified is forbbidden.
-    #[fail(display = "No default field declared and no field specified in query")]
+    #[error("No default field declared and no field specified in query")]
     NoDefaultFieldDeclared,
     /// The field searched for is not declared
     /// as indexed in the schema.
-    #[fail(display = "The field '{:?}' is not declared as indexed", _0)]
+    #[error("The field '{:?}' is not declared as indexed", _0)]
     FieldNotIndexed(String),
     /// A phrase query was requested for a field that does not
     /// have any positions indexed.
-    #[fail(display = "The field '{:?}' does not have positions indexed", _0)]
+    #[error("The field '{:?}' does not have positions indexed", _0)]
     FieldDoesNotHavePositionsIndexed(String),
     /// The tokenizer for the given field is unknown
     /// The two argument strings are the name of the field, the name of the tokenizer
-    #[fail(
-        display = "The tokenizer '{:?}' for the field '{:?}' is unknown",
-        _0, _1
-    )]
+    #[error("The tokenizer '{:?}' for the field '{:?}' is unknown", _0, _1)]
     UnknownTokenizer(String, String),
     /// The query contains a range query with a phrase as one of the bounds.
     /// Only terms can be used as bounds.
-    #[fail(display = "A range query cannot have a phrase as one of the bounds")]
+    #[error("A range query cannot have a phrase as one of the bounds")]
     RangeMustNotHavePhrase,
     /// The format for the date field is not RFC 3339 compliant.
-    #[fail(display = "The date field has an invalid format")]
+    #[error("The date field has an invalid format")]
     DateFormatError(chrono::ParseError),
 }
 

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -9,6 +9,7 @@ use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{self, Map as JsonObject, Value as JsonValue};
 use std::fmt;
+use thiserror::Error;
 
 /// Tantivy has a very strict schema.
 /// You need to specify in advance whether a field is indexed or not,
@@ -381,17 +382,17 @@ impl<'de> Deserialize<'de> for Schema {
 
 /// Error that may happen when deserializing
 /// a document from JSON.
-#[derive(Debug, Fail, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum DocParsingError {
     /// The payload given is not valid JSON.
-    #[fail(display = "The provided string is not valid JSON")]
+    #[error("The provided string is not valid JSON")]
     NotJSON(String),
     /// One of the value node could not be parsed.
-    #[fail(display = "The field '{:?}' could not be parsed: {:?}", _0, _1)]
+    #[error("The field '{:?}' could not be parsed: {:?}", _0, _1)]
     ValueError(String, ValueParsingError),
     /// The json-document contains a field that is not declared in the schema.
-    #[fail(
-        display = "The document contains a field that is not declared in the schema: {:?}",
+    #[error(
+        "The document contains a field that is not declared in the schema: {:?}",
         _0
     )]
     NoSuchFieldInSchema(String),


### PR DESCRIPTION
## What this PR does
This aims to fix #760 by removing the dependence on the now deprecated `failure` crate, and replacing it with `thiserror` error implementations instead. As an added bonus, this means that `TantivyErrors` now implement `std::error::Error`, meaning that downstream users aren't locked into using the `failure::Fail` trait, and can now use any error handling they like. 

## Test Plan 
* `./run-test.sh`