### PR TITLE
Fixing unit tests.

### DIFF
--- a/src/directory/tests.rs
+++ b/src/directory/tests.rs
@@ -211,19 +211,19 @@ fn test_watch(directory: &mut dyn Directory) {
         .unwrap();
 
     for i in 0..10 {
-        assert_eq!(i, counter.load(SeqCst));
+        assert!(i <= counter.load(SeqCst));
         assert!(directory
             .atomic_write(Path::new("meta.json"), b"random_test_data_2")
             .is_ok());
         assert_eq!(receiver.recv_timeout(Duration::from_millis(500)), Ok(i));
-        assert_eq!(i + 1, counter.load(SeqCst));
+        assert!(i + 1 <= counter.load(SeqCst)); // notify can trigger more than once.
     }
     mem::drop(watch_handle);
     assert!(directory
         .atomic_write(Path::new("meta.json"), b"random_test_data")
         .is_ok());
     assert!(receiver.recv_timeout(Duration::from_millis(500)).is_ok());
-    assert_eq!(10, counter.load(SeqCst));
+    assert!(10 <= counter.load(SeqCst));
 }
 
 fn test_lock_non_blocking(directory: &mut dyn Directory) {


### PR DESCRIPTION
There was a unit test failing when notify was sending more
than one event on atomicwrites.

It was observed on MacOS CI.