### PR TITLE
Accept dash within field names.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ owning_ref = "0.4"
 stable_deref_trait = "1.0.0"
 rust-stemmers = "1.2"
 downcast-rs = { version="1.0" }
-tantivy-query-grammar = { version="0.13", path="./query-grammar" }
+tantivy-query-grammar = { version="0.14.0-dev", path="./query-grammar" }
 bitpacking = {version="0.8", default-features = false, features=["bitpacker4x"]}
 census = "0.4"
 fnv = "1.0.6"

--- a/query-grammar/Cargo.toml
+++ b/query-grammar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy-query-grammar"
-version = "0.13.0"
+version = "0.14.0-dev"
 authors = ["Paul Masurel <paul.masurel@gmail.com>"]
 license = "MIT"
 categories = ["database-implementations", "data-structures"]

--- a/src/schema/field_entry.rs
+++ b/src/schema/field_entry.rs
@@ -1,5 +1,5 @@
-use crate::schema::IntOptions;
 use crate::schema::TextOptions;
+use crate::schema::{is_valid_field_name, IntOptions};
 
 use crate::schema::FieldType;
 use serde::de::{self, MapAccess, Visitor};
@@ -24,6 +24,7 @@ impl FieldEntry {
     /// Creates a new u64 field entry in the schema, given
     /// a name, and some options.
     pub fn new_text(field_name: String, text_options: TextOptions) -> FieldEntry {
+        assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,
             field_type: FieldType::Str(text_options),
@@ -33,6 +34,7 @@ impl FieldEntry {
     /// Creates a new u64 field entry in the schema, given
     /// a name, and some options.
     pub fn new_u64(field_name: String, field_type: IntOptions) -> FieldEntry {
+        assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,
             field_type: FieldType::U64(field_type),
@@ -42,6 +44,7 @@ impl FieldEntry {
     /// Creates a new i64 field entry in the schema, given
     /// a name, and some options.
     pub fn new_i64(field_name: String, field_type: IntOptions) -> FieldEntry {
+        assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,
             field_type: FieldType::I64(field_type),
@@ -51,6 +54,7 @@ impl FieldEntry {
     /// Creates a new f64 field entry in the schema, given
     /// a name, and some options.
     pub fn new_f64(field_name: String, field_type: IntOptions) -> FieldEntry {
+        assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,
             field_type: FieldType::F64(field_type),
@@ -60,6 +64,7 @@ impl FieldEntry {
     /// Creates a new date field entry in the schema, given
     /// a name, and some options.
     pub fn new_date(field_name: String, field_type: IntOptions) -> FieldEntry {
+        assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,
             field_type: FieldType::Date(field_type),
@@ -68,6 +73,7 @@ impl FieldEntry {
 
     /// Creates a field entry for a facet.
     pub fn new_facet(field_name: String) -> FieldEntry {
+        assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,
             field_type: FieldType::HierarchicalFacet,
@@ -76,6 +82,7 @@ impl FieldEntry {
 
     /// Creates a field entry for a bytes field
     pub fn new_bytes(field_name: String) -> FieldEntry {
+        assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,
             field_type: FieldType::Bytes,
@@ -267,6 +274,12 @@ mod tests {
     use super::*;
     use crate::schema::TEXT;
     use serde_json;
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_field_name_should_panic() {
+        FieldEntry::new_text("-hello".to_string(), TEXT);
+    }
 
     #[test]
     fn test_json_serialization() {

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -149,14 +149,16 @@ pub use self::int_options::IntOptions;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+/// Regular expression representing the restriction on a valid field names.
+pub const FIELD_NAME_PATTERN: &'static str = r#"^[_a-zA-Z][_\-a-zA-Z0-9]*$"#;
+
 /// Validator for a potential `field_name`.
 /// Returns true iff the name can be use for a field name.
 ///
 /// A field name must start by a letter `[a-zA-Z]`.
 /// The other characters can be any alphanumic character `[a-ZA-Z0-9]` or `_`.
 pub fn is_valid_field_name(field_name: &str) -> bool {
-    static FIELD_NAME_PTN: Lazy<Regex> =
-        Lazy::new(|| Regex::new("^[a-zA-Z][_a-zA-Z0-9]*$").unwrap());
+    static FIELD_NAME_PTN: Lazy<Regex> = Lazy::new(|| Regex::new(FIELD_NAME_PATTERN).unwrap());
     FIELD_NAME_PTN.is_match(field_name)
 }
 
@@ -170,6 +172,11 @@ mod tests {
         assert!(is_valid_field_name("text"));
         assert!(is_valid_field_name("text0"));
         assert!(!is_valid_field_name("0text"));
+        assert!(is_valid_field_name("field-name"));
+        assert!(is_valid_field_name("field_name"));
+        assert!(!is_valid_field_name("field!name"));
+        assert!(!is_valid_field_name("-fieldname"));
+        assert!(is_valid_field_name("_fieldname"));
         assert!(!is_valid_field_name(""));
         assert!(!is_valid_field_name("シャボン玉"));
         assert!(is_valid_field_name("my_text_field"));


### PR DESCRIPTION
Accept dash in field names and enforce field names constraint at the
creation of the schema.

Closes #796