### PR TITLE
[tantivy] Add brotli codec for row storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ regex ={version = "1", default-features = false, features = ["std"]}
 tantivy-fst = "0.3"
 memmap = {version = "0.7", optional=true}
 lz4 = {version="1", optional=true}
+brotli = {version="3.3.0", optional=true}
 snap = "1"
 tempfile = {version="3", optional=true}
 log = "0.4"
@@ -75,6 +76,7 @@ overflow-checks = true
 [features]
 default = ["mmap"]
 mmap = ["fs2", "tempfile", "memmap", "notify"]
+brotli-compression = ["brotli"]
 lz4-compression = ["lz4"]
 failpoints = ["fail/failpoints"]
 unstable = [] # useful for benches.

--- a/src/core/segment_component.rs
+++ b/src/core/segment_component.rs
@@ -20,7 +20,7 @@ pub enum SegmentComponent {
     /// Dictionary associating `Term`s to `TermInfo`s which is
     /// simply an address into the `postings` file and the `positions` file.
     TERMS,
-    /// Row-oriented, LZ4-compressed storage of the documents.
+    /// Row-oriented, compressed storage of the documents.
     /// Accessing a document from the store is relatively slow, as it
     /// requires to decompress the entire block it belongs to.
     STORE,

--- a/src/schema/flags.rs
+++ b/src/schema/flags.rs
@@ -8,7 +8,7 @@ pub struct StoredFlag;
 /// This flag can apply to any kind of field.
 ///
 /// A stored fields of a document can be retrieved given its `DocId`.
-/// Stored field are stored together and LZ4 compressed.
+/// Stored field are stored together and compressed.
 /// Reading the stored fields of a document is relatively slow.
 /// (~ 100 microsecs)
 ///

--- a/src/store/compression_brotli.rs
+++ b/src/store/compression_brotli.rs
@@ -10,12 +10,12 @@ pub fn compress(uncompressed: &[u8], compressed: &mut Vec<u8>) -> io::Result<()>
     params.quality = 5;
 
     compressed.clear();
-    brotli::BrotliCompress(&mut Cursor::new(uncompressed), compressed, &params)?;
+    brotli::BrotliCompress(uncompressed, compressed, &params)?;
     Ok(())
 }
 
 pub fn decompress(compressed: &[u8], decompressed: &mut Vec<u8>) -> io::Result<()> {
     decompressed.clear();
-    brotli::BrotliDecompress(&mut Cursor::new(compressed), decompressed)?;
+    brotli::BrotliDecompress(compressed, decompressed)?;
     Ok(())
 }

--- a/src/store/compression_brotli.rs
+++ b/src/store/compression_brotli.rs
@@ -1,0 +1,21 @@
+use std::io::{self, Cursor};
+
+/// Name of the compression scheme used in the doc store.
+///
+/// This name is appended to the version string of tantivy.
+pub const COMPRESSION: &'static str = "brotli";
+
+pub fn compress(uncompressed: &[u8], compressed: &mut Vec<u8>) -> io::Result<()> {
+    let mut params = brotli::enc::BrotliEncoderParams::default();
+    params.quality = 5;
+
+    compressed.clear();
+    brotli::BrotliCompress(&mut Cursor::new(uncompressed), compressed, &params)?;
+    Ok(())
+}
+
+pub fn decompress(compressed: &[u8], decompressed: &mut Vec<u8>) -> io::Result<()> {
+    decompressed.clear();
+    brotli::BrotliDecompress(&mut Cursor::new(compressed), decompressed)?;
+    Ok(())
+}

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -5,7 +5,7 @@ A field needs to be marked as stored in the schema in
 order to be handled in the `Store`.
 
 Internally, documents (or rather their stored fields) are serialized to a buffer.
-When the buffer exceeds 16K, the buffer is compressed using `LZ4`
+When the buffer exceeds 16K, the buffer is compressed using `brotli`, `LZ4` or `snappy`
 and the resulting block is written to disk.
 
 One can then request for a specific `DocId`.

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -40,7 +40,7 @@ pub use self::reader::StoreReader;
 pub use self::writer::StoreWriter;
 
 #[cfg(all(feature = "lz4", feature = "brotli"))]
-compile_error!("feature `lz4` or `brotli` shouldn't be enabled both.");
+compile_error!("feature `lz4` or `brotli` must not be enabled together.");
 
 #[cfg(feature = "lz4")]
 mod compression_lz4;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -39,6 +39,9 @@ mod writer;
 pub use self::reader::StoreReader;
 pub use self::writer::StoreWriter;
 
+#[cfg(all(feature = "lz4", feature = "brotli"))]
+compile_error!("feature `lz4` or `brotli` shouldn't be enabled both.");
+
 #[cfg(feature = "lz4")]
 mod compression_lz4;
 #[cfg(feature = "lz4")]
@@ -46,11 +49,18 @@ pub use self::compression_lz4::COMPRESSION;
 #[cfg(feature = "lz4")]
 use self::compression_lz4::{compress, decompress};
 
-#[cfg(not(feature = "lz4"))]
+#[cfg(feature = "brotli")]
+mod compression_brotli;
+#[cfg(feature = "brotli")]
+pub use self::compression_brotli::COMPRESSION;
+#[cfg(feature = "brotli")]
+use self::compression_brotli::{compress, decompress};
+
+#[cfg(not(any(feature = "lz4", feature = "brotli")))]
 mod compression_snap;
-#[cfg(not(feature = "lz4"))]
+#[cfg(not(any(feature = "lz4", feature = "brotli")))]
 pub use self::compression_snap::COMPRESSION;
-#[cfg(not(feature = "lz4"))]
+#[cfg(not(any(feature = "lz4", feature = "brotli")))]
 use self::compression_snap::{compress, decompress};
 
 #[cfg(test)]

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -69,7 +69,7 @@ impl StoreReader {
     /// Reads a given document.
     ///
     /// Calling `.get(doc)` is relatively costly as it requires
-    /// decompressing a LZ4-compressed block.
+    /// decompressing a compressed block.
     ///
     /// It should not be called to score documents
     /// for instance.


### PR DESCRIPTION
Hi, @fulmicoton 

What do you think about it? Until recently I had a Postgres golden copy of all my data that I had been indexing with Tantivy. Tantivy was used only for maintaining inverted index, without any `STORED` fields. Now I've faced with a very hostile environment of limited hard storage, so I would like to try to store all documents in Tantivy `store` and to compress them a little bit stronger than snappy/lz4.

There is a [great benchmark](https://quixdb.github.io/squash-benchmark/) I was looking at while considering different codecs. It looks that brotli could take a place of the slow and well-compressed codec in addition to fast and fat lz4.