### PR TITLE
Clippy lint

### DIFF
--- a/src/fastfield/multivalued/writer.rs
+++ b/src/fastfield/multivalued/writer.rs
@@ -143,7 +143,7 @@ impl MultiValueIntFastFieldWriter {
                             .iter()
                             .map(|val| *mapping.get(val).expect("Missing term ordinal"));
                         doc_vals.extend(remapped_vals);
-                        doc_vals.sort();
+                        doc_vals.sort_unstable();
                         for &val in &doc_vals {
                             value_serializer.add_val(val)?;
                         }

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -450,9 +450,8 @@ impl SegmentUpdater {
             .into_iter()
             .map(|merge_candidate: MergeCandidate| {
                 MergeOperation::new(&self.merge_operations, commit_opstamp, merge_candidate.0)
-            })
-            .collect::<Vec<_>>();
-        merge_candidates.extend(committed_merge_candidates.into_iter());
+            });
+        merge_candidates.extend(committed_merge_candidates);
 
         for merge_operation in merge_candidates {
             if let Err(err) = self.start_merge(merge_operation) {

--- a/src/schema/value.rs
+++ b/src/schema/value.rs
@@ -7,7 +7,7 @@ use std::{cmp::Ordering, fmt};
 
 /// Value represents the value of a any field.
 /// It is an enum over all over all of the possible field type.
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     /// The str type is used for any text information.
     Str(String),
@@ -28,6 +28,11 @@ pub enum Value {
 }
 
 impl Eq for Value {}
+impl PartialOrd for Value {
+    fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 impl Ord for Value {
     fn cmp(&self, other: &Self) -> Ordering {
         match (self, other) {


### PR DESCRIPTION
Firstly, there is a fix for a bug I accidently introduced while was making change requests in Brotli PR:(
Cursor is required because compress and decompress routines require mutable Read object. I hope after doing #904 this code will be covered by tests.
 
Also, I've launched clippy linter and it had highlighted some points. Most of them is obvious. Manual PartialOrd implementation is explained here:
https://rust-lang.github.io/rust-clippy/master/index.html#derive_ord_xor_partial_ord

Fixes seem reasonable for me.