### PR TITLE
Removing Inoperable 'Say Thanks' Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Build status](https://ci.appveyor.com/api/projects/status/r7nb13kj23u8m9pj/branch/master?svg=true)](https://ci.appveyor.com/project/fulmicoton/tantivy/branch/master)
 [![Crates.io](https://img.shields.io/crates/v/tantivy.svg)](https://crates.io/crates/tantivy)
-[![Say Thanks!](https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg)](https://saythanks.io/to/fulmicoton)
 
 ![Tantivy](https://tantivy-search.github.io/logo/tantivy-logo.png)
 
@@ -85,7 +84,7 @@ There are many ways to support this project.
 - Help with documentation by asking questions or submitting PRs
 - Contribute code (you can join [our Gitter](https://gitter.im/tantivy-search/tantivy))
 - Talk about Tantivy around you
-- Drop a word on on [![Say Thanks!](https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg)](https://saythanks.io/to/fulmicoton) or even [![Become a patron](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/fulmicoton)
+- [![Become a patron](https://c5.patreon.com/external/logo/become_a_patron_button.png)](https://www.patreon.com/fulmicoton)
 
 # Contributing code
 


### PR DESCRIPTION
Dearest Maintainer,

The say thanks project moved to email https://github.com/BlitzKraft/saythanks.io/issues/60.  I removed the links. You might want to use your email but at that point people could just email you thanks?

Anyway, Thanks for the hard work on the project. I am enjoying it.

Dictated but not reviewed,
Becker