### PR TITLE
Modified `Directory::exists` API to return `Result<bool, OpenReadError>`

### DIFF
--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -131,7 +131,7 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     fn delete(&self, path: &Path) -> Result<(), DeleteError>;
 
     /// Returns true iff the file exists
-    fn exists(&self, path: &Path) -> bool;
+    fn exists(&self, path: &Path) -> Result<bool, OpenReadError>;
 
     /// Opens a writer for the *virtual file* associated with
     /// a Path.

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -370,9 +370,9 @@ impl Directory for MmapDirectory {
         }
     }
 
-    fn exists(&self, path: &Path) -> bool {
+    fn exists(&self, path: &Path) -> Result<bool, OpenReadError> {
         let full_path = self.resolve_path(path);
-        full_path.exists()
+        Ok(full_path.exists())
     }
 
     fn open_write(&self, path: &Path) -> Result<WritePtr, OpenWriteError> {

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -177,8 +177,15 @@ impl Directory for RAMDirectory {
         self.fs.write().unwrap().delete(path)
     }
 
-    fn exists(&self, path: &Path) -> bool {
-        self.fs.read().unwrap().exists(path)
+    fn exists(&self, path: &Path) -> Result<bool, OpenReadError> {
+        Ok(self
+            .fs
+            .read()
+            .map_err(|e| OpenReadError::IOError {
+                io_error: io::Error::new(io::ErrorKind::Other, e.to_string()),
+                filepath: path.to_path_buf(),
+            })?
+            .exists(path))
     }
 
     fn open_write(&self, path: &Path) -> Result<WritePtr, OpenWriteError> {

--- a/src/directory/tests.rs
+++ b/src/directory/tests.rs
@@ -130,7 +130,7 @@ fn ram_directory_panics_if_flush_forgotten() {
 fn test_simple(directory: &dyn Directory) -> crate::Result<()> {
     let test_path: &'static Path = Path::new("some_path_for_test");
     let mut write_file = directory.open_write(test_path)?;
-    assert!(directory.exists(test_path));
+    assert!(directory.exists(test_path).unwrap());
     write_file.write_all(&[4])?;
     write_file.write_all(&[3])?;
     write_file.write_all(&[7, 3, 5])?;
@@ -139,14 +139,14 @@ fn test_simple(directory: &dyn Directory) -> crate::Result<()> {
     assert_eq!(read_file.as_slice(), &[4u8, 3u8, 7u8, 3u8, 5u8]);
     mem::drop(read_file);
     assert!(directory.delete(test_path).is_ok());
-    assert!(!directory.exists(test_path));
+    assert!(!directory.exists(test_path).unwrap());
     Ok(())
 }
 
 fn test_rewrite_forbidden(directory: &dyn Directory) -> crate::Result<()> {
     let test_path: &'static Path = Path::new("some_path_for_test");
     directory.open_write(test_path)?;
-    assert!(directory.exists(test_path));
+    assert!(directory.exists(test_path).unwrap());
     assert!(directory.open_write(test_path).is_err());
     assert!(directory.delete(test_path).is_ok());
     Ok(())
@@ -157,7 +157,7 @@ fn test_write_create_the_file(directory: &dyn Directory) {
     {
         assert!(directory.open_read(test_path).is_err());
         let _w = directory.open_write(test_path).unwrap();
-        assert!(directory.exists(test_path));
+        assert!(directory.exists(test_path).unwrap());
         assert!(directory.open_read(test_path).is_ok());
         assert!(directory.delete(test_path).is_ok());
     }

--- a/tests/failpoints/mod.rs
+++ b/tests/failpoints/mod.rs
@@ -18,7 +18,7 @@ fn test_failpoints_managed_directory_gc_if_delete_fails() {
         .unwrap()
         .terminate()
         .unwrap();
-    assert!(managed_directory.exists(test_path));
+    assert!(managed_directory.exists(test_path).unwrap());
     // triggering gc and setting the delete operation to fail.
     //
     // We are checking that the gc operation is not removing the
@@ -29,12 +29,12 @@ fn test_failpoints_managed_directory_gc_if_delete_fails() {
     // lock file.
     fail::cfg("RAMDirectory::delete", "1*off->1*return").unwrap();
     assert!(managed_directory.garbage_collect(Default::default).is_ok());
-    assert!(managed_directory.exists(test_path));
+    assert!(managed_directory.exists(test_path).unwrap());
 
     // running the gc a second time should remove the file.
     assert!(managed_directory.garbage_collect(Default::default).is_ok());
     assert!(
-        !managed_directory.exists(test_path),
+        !managed_directory.exists(test_path).unwrap(),
         "The file should have been deleted"
     );
 }


### PR DESCRIPTION
`OpenReadError` does not implement `PartialEq` so I added a bunch of ugly `unwrap` calls in the unit tests.