### PR TITLE
add score mode into Inverted Index

### DIFF
--- a/examples/scored_tf.rs
+++ b/examples/scored_tf.rs
@@ -1,0 +1,89 @@
+// # Pre-tokenized text example
+//
+// This example shows how to use pre-tokenized text. Sometimes yout might
+// want to index and search through text which is already split into
+// tokens by some external tool.
+//
+// In this example we will:
+// - use tantivy tokenizer to create tokens and load them directly into tantivy,
+// - import tokenized text straight from json,
+// - perform a search on documents with pre-tokenized text
+
+use tantivy::collector::{Count, TopDocs};
+use tantivy::query::QueryParser;
+use tantivy::schema::*;
+use tantivy::{Index, ReloadPolicy};
+use tempfile::TempDir;
+
+
+fn main() -> tantivy::Result<()> {
+    let index_path = TempDir::new()?;
+
+    let mut schema_builder = Schema::builder();
+
+
+    let indexing = tantivy::schema::TextFieldIndexing::default()
+        .set_index_option(tantivy::schema::IndexRecordOption::WithScore);
+    let option = tantivy::schema::TextOptions::default().set_indexing_options(indexing).set_stored();
+    schema_builder.add_text_field("title", option);
+
+    let schema = schema_builder.build();
+
+    let index = Index::create_in_dir(&index_path, schema.clone())?;
+
+    let mut index_writer = index.writer(50_000_000)?;
+
+    // We can create a document manually, by setting the fields
+    // one by one in a Document object.
+    let title = schema.get_field("title").unwrap();
+
+    // Pretokenized text can also be fed as JSON
+    let short_man_json = r#"{
+        "title":[{
+            "text":"the old man",
+            "tokens":[
+                {"offset_from":0,"offset_to":3,"position":0,"text":"the","position_length":1, "score": 10},
+                {"offset_from":4,"offset_to":7,"position":1,"text":"old","position_length":1, "score": 100},
+                {"offset_from":8,"offset_to":11,"position":2,"text":"man","position_length":1, "score": 500}
+            ]
+        }]
+    }"#;
+
+    let short_man_doc = schema.parse_document(&short_man_json)?;
+
+    index_writer.add_document(short_man_doc);
+
+    // Let's commit changes
+    index_writer.commit()?;
+
+    // ... and now is the time to query our index
+
+    let reader = index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::OnCommit)
+        .try_into()?;
+
+    let searcher = reader.searcher();
+
+    // We want to get documents with token "Man", we will use TermQuery to do it
+    // Using PreTokenizedString means the tokens are stored as is avoiding stemming
+    // and lowercasing, which preserves full words in their original form
+    let query_parser = QueryParser::for_index(&index, vec![title]);
+    let query = query_parser.parse_query_with_method("the", "score")?;
+
+
+    let (top_docs, count) = searcher
+        .search(&query, &(TopDocs::with_limit(2), Count))
+        .unwrap();
+    count;
+
+    // Now let's print out the results.
+    // Note that the tokens are not stored along with the original text
+    // in the document store
+    for (_score, doc_address) in top_docs {
+        let retrieved_doc = searcher.doc(doc_address)?;
+        println!("{} Document: {}", _score, schema.to_json(&retrieved_doc));
+    }
+
+    Ok(())
+}

--- a/src/postings/skip.rs
+++ b/src/postings/skip.rs
@@ -179,7 +179,7 @@ impl SkipReader {
                     block_wand_term_freq: 0,
                 };
             }
-            IndexRecordOption::WithFreqs => {
+            IndexRecordOption::WithFreqs | IndexRecordOption::WithScore => {
                 let bytes = self.owned_read.as_slice();
                 let tf_num_bits = bytes[5];
                 let block_wand_fieldnorm_id = bytes[6];

--- a/src/query/term_query/term_weight.rs
+++ b/src/query/term_query/term_weight.rs
@@ -91,11 +91,21 @@ impl TermWeight {
         similarity_weight: BM25Weight,
         scoring_enabled: bool,
     ) -> TermWeight {
-        TermWeight {
-            term,
-            index_record_option,
-            similarity_weight,
-            scoring_enabled,
+        if index_record_option == IndexRecordOption::WithScore {
+            let similarity_weight = similarity_weight.set_bm25(false);
+            TermWeight {
+                term,
+                index_record_option,
+                similarity_weight,
+                scoring_enabled
+            }
+        } else {
+            TermWeight {
+                term,
+                index_record_option,
+                similarity_weight,
+                scoring_enabled
+            }
         }
     }
 

--- a/src/schema/index_record_option.rs
+++ b/src/schema/index_record_option.rs
@@ -28,6 +28,10 @@ pub enum IndexRecordOption {
     /// Positions are required to run [PhraseQueries](../query/struct.PhraseQuery.html).
     #[serde(rename = "position")]
     WithFreqsAndPositions,
+    /// Use a given term score instead of TF
+    /// The term score is computed via machine learning models
+    #[serde(rename = "score")]
+    WithScore,
 }
 
 impl IndexRecordOption {
@@ -36,7 +40,7 @@ impl IndexRecordOption {
     pub fn has_freq(self) -> bool {
         match self {
             IndexRecordOption::Basic => false,
-            IndexRecordOption::WithFreqs | IndexRecordOption::WithFreqsAndPositions => true,
+            IndexRecordOption::WithFreqs | IndexRecordOption::WithFreqsAndPositions | IndexRecordOption::WithScore=> true,
         }
     }
 
@@ -44,7 +48,7 @@ impl IndexRecordOption {
     ///  term positions.
     pub fn has_positions(self) -> bool {
         match self {
-            IndexRecordOption::Basic | IndexRecordOption::WithFreqs => false,
+            IndexRecordOption::Basic | IndexRecordOption::WithFreqs | IndexRecordOption::WithScore => false,
             IndexRecordOption::WithFreqsAndPositions => true,
         }
     }

--- a/src/tokenizer/raw_tokenizer.rs
+++ b/src/tokenizer/raw_tokenizer.rs
@@ -18,6 +18,7 @@ impl Tokenizer for RawTokenizer {
             position: 0,
             text: text.to_string(),
             position_length: 1,
+            score: 1
         };
         RawTokenStream {
             token,

--- a/src/tokenizer/token_stream_chain.rs
+++ b/src/tokenizer/token_stream_chain.rs
@@ -36,6 +36,7 @@ impl<'a> TokenStream for TokenStreamChain<'a> {
                 self.token.offset_from = token.offset_from + offset_offset;
                 self.token.offset_to = token.offset_to + offset_offset;
                 self.token.position = token.position + self.position_shift;
+                self.token.score = token.score + offset_offset;
                 self.token.text.clear();
                 self.token.text.push_str(token.text.as_str());
                 return true;

--- a/src/tokenizer/tokenized_string.rs
+++ b/src/tokenizer/tokenized_string.rs
@@ -105,6 +105,7 @@ mod tests {
                     position: 0,
                     text: String::from("A"),
                     position_length: 1,
+                    score: 1
                 },
                 Token {
                     offset_from: 2,
@@ -112,6 +113,7 @@ mod tests {
                     position: 1,
                     text: String::from("a"),
                     position_length: 1,
+                    score: 1
                 },
             ],
         };
@@ -136,6 +138,7 @@ mod tests {
                     position: 0,
                     text: String::from("A"),
                     position_length: 1,
+                    score: 1
                 },
                 Token {
                     offset_from: 2,
@@ -143,6 +146,7 @@ mod tests {
                     position: 1,
                     text: String::from("a"),
                     position_length: 1,
+                    score: 1
                 },
             ],
         };
@@ -158,6 +162,7 @@ mod tests {
                 position: 0,
                 text: String::from("A"),
                 position_length: 1,
+                score: 1
             },
             Token {
                 offset_from: 2,
@@ -165,6 +170,7 @@ mod tests {
                 position: 1,
                 text: String::from("a"),
                 position_length: 1,
+                score: 1
             },
             Token {
                 offset_from: 3,
@@ -172,6 +178,7 @@ mod tests {
                 position: 3,
                 text: String::from("A"),
                 position_length: 1,
+                score: 1
             },
             Token {
                 offset_from: 5,
@@ -179,6 +186,7 @@ mod tests {
                 position: 4,
                 text: String::from("a"),
                 position_length: 1,
+                score: 1
             },
         ];
 

--- a/src/tokenizer/tokenizer.rs
+++ b/src/tokenizer/tokenizer.rs
@@ -21,6 +21,8 @@ pub struct Token {
     pub text: String,
     /// Is the length expressed in term of number of original tokens.
     pub position_length: usize,
+    /// Is the weights of a token
+    pub score: usize,
 }
 
 impl Default for Token {
@@ -31,6 +33,7 @@ impl Default for Token {
             position: usize::max_value(),
             text: String::with_capacity(200),
             position_length: 1,
+            score: 1
         }
     }
 }
@@ -322,6 +325,7 @@ mod test {
             offset_to: 3,
             text: "abc".to_string(),
             position_length: 1,
+            score: 24
         };
         let t2 = t1.clone();
 


### PR DESCRIPTION
Add score mode into BM25 index to support ML based inverted index, e.g. Deep CT or SPARTA. 