### PR TITLE
Make NamedFieldDocument deserializable

### DIFF
--- a/src/schema/named_field_document.rs
+++ b/src/schema/named_field_document.rs
@@ -1,5 +1,5 @@
 use crate::schema::Value;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 /// Internal representation of a document used for JSON
@@ -8,5 +8,5 @@ use std::collections::BTreeMap;
 /// A `NamedFieldDocument` is a simple representation of a document
 /// as a `BTreeMap<String, Vec<Value>>`.
 ///
-#[derive(Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct NamedFieldDocument(pub BTreeMap<String, Vec<Value>>);


### PR DESCRIPTION
I'm working on a program that uses gRPC to exchange Tantivy's search results between servers in JSON format.
It would be helpful if I could deserialize the NamedFieldDocument from JSON.

Closes #963 