### PR TITLE
Change from serde::export to std::marker

### DIFF
--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -2,7 +2,7 @@ use crate::DocAddress;
 use crate::DocId;
 use crate::SegmentLocalId;
 use crate::SegmentReader;
-use serde::export::PhantomData;
+use std::marker::PhantomData;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 


### PR DESCRIPTION
For some reason under a docker build I get a build error under docker only saying that `serde::export` is private. This fixes it for me.

```
error[E0603]: module `export` is private
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/tantivy-0.13.2/src/collector/top_collector.rs:5:12
    |
5   | use serde::export::PhantomData;
    |            ^^^^^^ private module
    |
note: the module `export` is defined here
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.119/src/lib.rs:275:5
    |
275 | use self::__private as export;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
```