### PR TITLE
FacetCounts are now pub use in tantivy::collector (Closes #978)

### DIFF
--- a/src/collector/facet_collector.rs
+++ b/src/collector/facet_collector.rs
@@ -398,6 +398,8 @@ impl<'a> Iterator for FacetChildIterator<'a> {
 }
 
 impl FacetCounts {
+    /// Returns an iterator over all of the facet count pairs inside this result.
+    /// See the documentation for `FacetCollector` for a usage example.
     pub fn get<T>(&self, facet_from: T) -> FacetChildIterator<'_>
     where
         Facet: From<T>,
@@ -417,6 +419,8 @@ impl FacetCounts {
         FacetChildIterator { underlying }
     }
 
+    /// Returns a vector of top `k` facets with their counts, sorted highest-to-lowest by counts.
+    /// See the documentation for `FacetCollector` for a usage example.
     pub fn top_k<T>(&self, facet: T, k: usize) -> Vec<(&Facet, u64)>
     where
         Facet: From<T>,

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -109,6 +109,7 @@ pub use self::tweak_score_top_collector::{ScoreSegmentTweaker, ScoreTweaker};
 
 mod facet_collector;
 pub use self::facet_collector::FacetCollector;
+pub use self::facet_collector::FacetCounts;
 use crate::query::Weight;
 
 mod docset_collector;


### PR DESCRIPTION
Confirmed this helps me write a separate function for dealing with facet counts.
Added simple doc comments to the now public API of `FacetCounts` to calm down linter.

Closes #978 