### PR TITLE
Implements merge split

### DIFF
--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -24,6 +24,7 @@ pub use self::prepared_commit::PreparedCommit;
 pub use self::segment_entry::SegmentEntry;
 pub use self::segment_manager::SegmentManager;
 pub use self::segment_serializer::SegmentSerializer;
+pub use self::segment_updater::merge_segments;
 pub use self::segment_writer::SegmentWriter;
 
 /// Alias for the default merge policy, which is the `LogMergePolicy`.

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -154,9 +154,10 @@ pub fn merge_segments(indices: &[Index], output_directory: PathBuf) -> crate::Re
     let mut segments: Vec<Segment> = vec![];
     for index in indices {
         segments.extend(
-            index.searchable_segments()?
+            index
+                .searchable_segments()?
                 .iter()
-                .map(|segment| merged_index.segment(segment.meta().clone()))
+                .map(|segment| merged_index.segment(segment.meta().clone())),
         );
     }
 
@@ -169,7 +170,8 @@ pub fn merge_segments(indices: &[Index], output_directory: PathBuf) -> crate::Re
 
     let mut segment_metas: Vec<SegmentMeta> = segments
         .iter()
-        .map(|segment| segment.meta().clone()).collect();
+        .map(|segment| segment.meta().clone())
+        .collect();
     segment_metas.push(segment_meta);
 
     let opstamp = 0u64; //? should be set
@@ -187,20 +189,22 @@ pub fn merge_segments(indices: &[Index], output_directory: PathBuf) -> crate::Re
 }
 
 fn is_same_schema(schemas: &[Schema]) -> crate::Result<Schema> {
-    let first = schemas
-        .first()
-        .ok_or(crate::TantivyError::InvalidArgument("Empty schema set provided".to_string()))?;
-    
+    let first = schemas.first().ok_or(crate::TantivyError::InvalidArgument(
+        "Empty schema set provided".to_string(),
+    ))?;
+
     let first_json = serde_json::to_string(&first)?;
 
-    let is_not_same = schemas.iter().skip(1).any(|next| {
-        serde_json::to_string(next)
-        .map_or(true, |next_json| next_json != first_json)
-    });
+    let is_not_same = schemas
+        .iter()
+        .skip(1)
+        .any(|next| serde_json::to_string(next).map_or(true, |next_json| next_json != first_json));
 
     match is_not_same {
-        true => Err(crate::TantivyError::InvalidArgument("Attempt to merge different schema indices".to_string())),
-        false => Ok(first.clone())
+        true => Err(crate::TantivyError::InvalidArgument(
+            "Attempt to merge different schema indices".to_string(),
+        )),
+        false => Ok(first.clone()),
     }
 }
 
@@ -604,10 +608,10 @@ impl SegmentUpdater {
 #[cfg(test)]
 mod tests {
 
+    use super::is_same_schema;
     use crate::indexer::merge_policy::tests::MergeWheneverPossible;
     use crate::schema::*;
     use crate::Index;
-    use super::is_same_schema;
 
     #[test]
     fn test_delete_during_merge() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@ pub use crate::core::{Executor, SegmentComponent};
 pub use crate::core::{Index, IndexMeta, Searcher, Segment, SegmentId, SegmentMeta};
 pub use crate::core::{InvertedIndexReader, SegmentReader};
 pub use crate::directory::Directory;
+pub use crate::indexer::merge_segments;
 pub use crate::indexer::operation::UserOperation;
 pub use crate::indexer::IndexWriter;
 pub use crate::postings::Postings;

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -192,7 +192,7 @@ impl SchemaBuilder {
         }))
     }
 }
-
+#[derive(Debug)]
 struct InnerSchema {
     fields: Vec<FieldEntry>,
     fields_map: HashMap<String, Field>, // transient
@@ -226,7 +226,7 @@ impl Eq for InnerSchema {}
 /// let schema = schema_builder.build();
 ///
 /// ```
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Schema(Arc<InnerSchema>);
 
 impl Schema {


### PR DESCRIPTION
https://github.com/tantivy-search/tantivy/issues/1005

Implements merge split from different dirs into one single index.
I found that `Schema` already implements `PartialEq` so we are currently making use of it.
only question remaining is: Is this the impl we want? 
