### PR TITLE
Facet topk lexicographic tie break

### DIFF
--- a/src/collector/facet_collector.rs
+++ b/src/collector/facet_collector.rs
@@ -692,10 +692,7 @@ mod tests {
             let facets: Vec<(&Facet, u64)> = counts.top_k("/facet", 2);
             assert_eq!(
                 facets,
-                vec![
-                    (&Facet::from("/facet/c"), 4),
-                    (&Facet::from("/facet/a"), 2),
-                ]
+                vec![(&Facet::from("/facet/c"), 4), (&Facet::from("/facet/a"), 2)]
             );
         }
     }

--- a/src/collector/facet_collector.rs
+++ b/src/collector/facet_collector.rs
@@ -37,10 +37,10 @@ impl<'a> PartialOrd<Hit<'a>> for Hit<'a> {
 
 impl<'a> Ord for Hit<'a> {
     fn cmp(&self, other: &Self) -> Ordering {
-        match other.count.cmp(&self.count) {
-            Ordering::Equal => self.facet.cmp(other.facet),
-            x => x,
-        }
+        other
+            .count
+            .cmp(&self.count)
+            .then(self.facet.cmp(other.facet))
     }
 }
 

--- a/src/collector/facet_collector.rs
+++ b/src/collector/facet_collector.rs
@@ -37,7 +37,10 @@ impl<'a> PartialOrd<Hit<'a>> for Hit<'a> {
 
 impl<'a> Ord for Hit<'a> {
     fn cmp(&self, other: &Self) -> Ordering {
-        other.count.cmp(&self.count)
+        match other.count.cmp(&self.count) {
+            Ordering::Equal => self.facet.cmp(other.facet),
+            x => x,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- top_k in FacetCollector, when choosing between facets with equal counts will break tie in lexicographical order of facet. 
- changes the implementation of the `Ord` trait of `Hit` in order to support order by count and in case of a tie, order by facet.

## Checks

- [x] all tests pass
- [x] new tests for changed functionality added  

closes (#357)