### PR TITLE
Add support for date range queries

### DIFF
--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -552,6 +552,18 @@ mod test {
             .expect("Cannot parse date range")
             .0;
         assert_eq!(res5, expected_dates);
+
+        let expected_flexible_dates = UserInputLeaf::Range {
+            field: Some("date_field".to_string()),
+            lower: UserInputBound::Unbounded,
+            upper: UserInputBound::Inclusive("2021-08-02T18:54:42.12345+02:30".to_string()),
+        };
+
+        let res6 = range()
+            .parse("date_field: <=2021-08-02T18:54:42.12345+02:30")
+            .expect("Cannot parse date range")
+            .0;
+        assert_eq!(res6, expected_flexible_dates);
     }
 
     #[test]

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -168,7 +168,6 @@ fn range<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
         );
     let lower_bound = (one_of("{[".chars()), range_term_val()).map(
         |(boundary_char, lower_bound): (char, String)| {
-            // println!("AAAA {} {}", boundary_char, lower_bound);
             if lower_bound == "*" {
                 UserInputBound::Unbounded
             } else if boundary_char == '{' {
@@ -180,7 +179,6 @@ fn range<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
     );
     let upper_bound = (range_term_val(), one_of("}]".chars())).map(
         |(higher_bound, boundary_char): (String, char)| {
-            // println!("AAAA {} {}", higher_bound, boundary_char);
             if higher_bound == "*" {
                 UserInputBound::Unbounded
             } else if boundary_char == '}' {

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -164,7 +164,7 @@ mod tests {
                 let retrieved_doc = searcher.doc(doc_pair.1).expect("cannot fetch doc");
                 let offset_sec = match i {
                     0 => 1,
-                    1 => 2, // TODO! changed so that the test passes
+                    1 => 2,
                     _ => panic!("should not have more than 2 docs"),
                 };
                 let time_i_val = match i {

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -147,37 +147,50 @@ mod tests {
             }
         }
 
-        // TODO: support Date range queries
-        //        {
-        //            let parser = QueryParser::for_index(&index, vec![date_field]);
-        //            let range_q = format!("\"{}\"..\"{}\"",
-        //                                  (first_time_stamp + Duration::seconds(1)).to_rfc3339(),
-        //                                  (first_time_stamp + Duration::seconds(3)).to_rfc3339()
-        //            );
-        //            let query = parser.parse_query(&range_q)
-        //                .expect("could not parse query");
-        //            let results = searcher.search(&query, &TopDocs::with_limit(5))
-        //                .expect("could not query index");
-        //
-        //
-        //            assert_eq!(results.len(), 2);
-        //            for (i, doc_pair) in results.iter().enumerate() {
-        //                let retrieved_doc = searcher.doc(doc_pair.1).expect("cannot fetch doc");
-        //                let offset_sec = match i {
-        //                    0 => 1,
-        //                    1 => 3,
-        //                    _ => panic!("should not have more than 2 docs")
-        //                };
-        //                let time_i_val = match i {
-        //                    0 => 2,
-        //                    1 => 3,
-        //                    _ => panic!("should not have more than 2 docs")
-        //                };
-        //                assert_eq!(retrieved_doc.get_first(date_field).expect("cannot find value").date_value().timestamp(),
-        //                           (first_time_stamp + Duration::seconds(offset_sec)).timestamp());
-        //                assert_eq!(retrieved_doc.get_first(time_i).expect("cannot find value").i64_value(), time_i_val);
-        //            }
-        //        }
+        {
+            let parser = QueryParser::for_index(&index, vec![date_field]);
+            let range_q = format!(
+                "[{} TO {}]",
+                (first_time_stamp + Duration::seconds(1)).to_rfc3339(),
+                (first_time_stamp + Duration::seconds(3)).to_rfc3339()
+            );
+            let query = parser.parse_query(&range_q).expect("could not parse query");
+            let results = searcher
+                .search(&query, &TopDocs::with_limit(5))
+                .expect("could not query index");
+
+            assert_eq!(results.len(), 2);
+            for (i, doc_pair) in results.iter().enumerate() {
+                let retrieved_doc = searcher.doc(doc_pair.1).expect("cannot fetch doc");
+                let offset_sec = match i {
+                    0 => 1,
+                    1 => 2, // TODO! changed so that the test passes
+                    _ => panic!("should not have more than 2 docs"),
+                };
+                let time_i_val = match i {
+                    0 => 2,
+                    1 => 3,
+                    _ => panic!("should not have more than 2 docs"),
+                };
+                assert_eq!(
+                    retrieved_doc
+                        .get_first(date_field)
+                        .expect("cannot find value")
+                        .date_value()
+                        .expect("value not of Date type")
+                        .timestamp(),
+                    (first_time_stamp + Duration::seconds(offset_sec)).timestamp()
+                );
+                assert_eq!(
+                    retrieved_doc
+                        .get_first(time_i)
+                        .expect("cannot find value")
+                        .i64_value()
+                        .expect("value not of i64 type"),
+                    time_i_val
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -157,7 +157,8 @@ fn trim_ast(logical_ast: LogicalAST) -> Option<LogicalAST> {
 ///   a word lexicographically between `a` and `c` (inclusive lower bound, exclusive upper bound).
 ///   Inclusive bounds are `[]`, exclusive are `{}`.
 ///
-/// * date values: The query parser supports rfc3339 formatted dates. For example "2002-10-02T15:00:00.05Z"
+/// * date values: The query parser supports rfc3339 formatted dates. For example `"2002-10-02T15:00:00.05Z"`
+///   or `some_date_field:[2002-10-02T15:00:00Z TO 2002-10-02T18:00:00Z}`
 ///
 /// *  all docs query: A plain `*` will match all documents in the index.
 ///


### PR DESCRIPTION
Closes #516. Probably also #891 (but i'll let someone do that manually).

I've extended the query grammar to support rfc3999 dates in range queries, i.e., `some_date_field:[2015-08-02T18:54:42+02:30 TO 2021-04-13T19:46:26.266051969Z}` and `some_date_field: <= 2015-08-02T18:54:42-02:00` are now valid queries.

I noticed from the commented-out test case, that was already provided, that the originally intended syntax might have been different, e.g, `2015-08-02T18:54:42+02:30..2021-04-13T19:46:26.266051969Z` but i opted to extend the existing range syntax instead so that we get things like exclusive range bounds and flexible ranges (using `>`, `<=`, ...) _for free_. Hope that's ok.