### PR TITLE
Don't use overly-minimal dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,53 +14,53 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13"
-byteorder = "1"
-crc32fast = "1"
-once_cell = "1"
-regex ={version = "1", default-features = false, features = ["std"]}
+byteorder = "1.4.3"
+crc32fast = "1.2.1"
+once_cell = "1.7.2"
+regex ={ version = "1.5.4", default-features = false, features = ["std"] }
 tantivy-fst = "0.3"
 memmap = {version = "0.7", optional=true}
-lz4_flex = { version = "0.7", default-features = false, features = ["checked-decode"], optional=true }
-lz4 = {version="1", optional=true}
-brotli = {version="3.3.0", optional=true}
-snap = {version="1", optional=true}
-tempfile = {version="3", optional=true}
-log = "0.4"
-serde = {version="1", features=["derive"]}
-serde_json = "1"
-num_cpus = "1"
-fs2={version="0.4", optional=true}
+lz4_flex = { version = "0.7.5", default-features = false, features = ["checked-decode"], optional = true }
+lz4 = { version = "1.23.2", optional = true }
+brotli = { version = "3.3", optional = true }
+snap = { version = "1.0.5", optional = true }
+tempfile = { version = "3.2", optional = true }
+log = "0.4.14"
+serde = { version = "1.0.126", features = ["derive"] }
+serde_json = "1.0.64"
+num_cpus = "1.13"
+fs2={ version = "0.4.3", optional = true }
 levenshtein_automata = "0.2"
-uuid = { version = "0.8", features = ["v4", "serde"] }
+uuid = { version = "0.8.2", features = ["v4", "serde"] }
 crossbeam = "0.8"
-futures = {version = "0.3",  features=["thread-pool"] }
+futures = { version = "0.3.15", features = ["thread-pool"] }
 tantivy-query-grammar = { version="0.14.0", path="./query-grammar" }
 tantivy-bitpacker = { version="0.1", path="./bitpacker" }
-stable_deref_trait = "1"
-rust-stemmers = "1"
-downcast-rs = "1"
-bitpacking = {version="0.8", default-features = false, features=["bitpacker4x"]}
+stable_deref_trait = "1.2"
+rust-stemmers = "1.2"
+downcast-rs = "1.2"
+bitpacking = { version = "0.8.4", default-features = false, features = ["bitpacker4x"] }
 census = "0.4"
-fnv = "1"
-thiserror = "1.0"
-htmlescape = "0.3"
+fnv = "1.0.7"
+thiserror = "1.0.24"
+htmlescape = "0.3.1"
 fail = "0.4"
 murmurhash32 = "0.2"
-chrono = "0.4"
-smallvec = "1"
-rayon = "1"
-lru = "0.6"
+chrono = "0.4.19"
+smallvec = "1.6.1"
+rayon = "1.5"
+lru = "0.6.5"
 fastdivide = "0.3"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3"
+winapi = "0.3.9"
 
 [dev-dependencies]
-rand = "0.8"
-maplit = "1"
+rand = "0.8.3"
+maplit = "1.0.2"
 matches = "0.1.8"
 proptest = "1.0"
-criterion = "0.3"
+criterion = "0.3.4"
 
 [dev-dependencies.fail]
 version = "0.4"


### PR DESCRIPTION
I'm trying to get the crates ecosystem to work with `-Z minimal-versions` Cargo option, but many crates incorrectly specify required versions of their dependencies, including `tantivy`.

`tantivy` doesn't actually work with the versions of dependencies it specifies, and relies on them being implicitly upgraded to latest.

If actually old deps are used as specified in `Cargo.toml`, tantivy won't compile:

```
error[E0599]: no variant or associated item named `Norwegian` found for enum `Algorithm` in the current scope
  --> /Users/kornel/.cargo/registry/src/-10eda45d2c7a9533/tantivy-0.14.0/src/tokenizer/stemmer.rs:44:37
   |
44 |             Norwegian => Algorithm::Norwegian,
   |                                     ^^^^^^^^^ variant or associated item not found in `Algorithm`

error[E0277]: the trait bound `Algorithm: Clone` is not satisfied
  --> /Users/kornel/.cargo/registry/src/-10eda45d2c7a9533/tantivy-0.14.0/src/tokenizer/stemmer.rs:61:5
   |
61 |     stemmer_algorithm: Algorithm,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `Algorithm`
   |
```

I've upgraded all deps, because many of them have their own problems (especially in their older versions), and `tantivy` isn't tested in CI with minimal versions (it's impractical in the current state of the ecosystem), so it can't guarantee that old versions will remain to work.