### PR TITLE
add iterator over documents in docstore

### DIFF
--- a/src/indexer/merger_sorted_index_test.rs
+++ b/src/indexer/merger_sorted_index_test.rs
@@ -281,6 +281,22 @@ mod tests {
             assert_eq!(do_search("blubber"), vec![3]);
             assert_eq!(do_search("biggest"), vec![5]);
         }
+
+        // access doc store
+        {
+            let doc = searcher.doc(DocAddress::new(0, 0)).unwrap();
+            assert_eq!(doc.get_first(int_field).unwrap().u64_value(), Some(1));
+            let doc = searcher.doc(DocAddress::new(0, 1)).unwrap();
+            assert_eq!(doc.get_first(int_field).unwrap().u64_value(), Some(2));
+            let doc = searcher.doc(DocAddress::new(0, 2)).unwrap();
+            assert_eq!(doc.get_first(int_field).unwrap().u64_value(), Some(3));
+            let doc = searcher.doc(DocAddress::new(0, 3)).unwrap();
+            assert_eq!(doc.get_first(int_field).unwrap().u64_value(), Some(10));
+            let doc = searcher.doc(DocAddress::new(0, 4)).unwrap();
+            assert_eq!(doc.get_first(int_field).unwrap().u64_value(), Some(20));
+            let doc = searcher.doc(DocAddress::new(0, 5)).unwrap();
+            assert_eq!(doc.get_first(int_field).unwrap().u64_value(), Some(1_000));
+        }
     }
 }
 

--- a/src/store/index/mod.rs
+++ b/src/store/index/mod.rs
@@ -18,7 +18,7 @@ pub use self::skip_index_builder::SkipIndexBuilder;
 /// All of the intervals here defined are semi-open.
 /// The checkpoint describes that the block within the `byte_range`
 /// and spans over the `doc_range`.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Default)]
 pub struct Checkpoint {
     pub doc_range: Range<DocId>,
     pub byte_range: Range<usize>,

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -145,7 +145,7 @@ impl StoreReader {
     /// Iterator over all RawDocuments in their order as they are stored in the doc store.
     /// Use this, if you want to extract all Documents from the doc store.
     /// The delete_bitset has to be forwarded from the `SegmentReader` or the results maybe wrong.
-    pub fn iter_raw<'a: 'b, 'b>(
+    pub(crate) fn iter_raw<'a: 'b, 'b>(
         &'b self,
         delete_bitset: Option<&'a DeleteBitSet>,
     ) -> impl Iterator<Item = crate::Result<RawDocument>> + 'b {


### PR DESCRIPTION
When profiling, I saw that around 8% of the time in a merge was spent in look-ups into the skip index. Since the documents in the merge case are read continuously, we can replace the random access with an iterator over the documents.

Merge Time on Sorted Index Before/After:
24s / 19s

Merge Time on Unsorted Index Before/After:
15s / 13,5s

So we can expect 10-20% faster merges.
This iterator is also important if we add sorting based on a field in the documents.