### PR TITLE
Replaced RawDocument by OwnedBytes

### DIFF
--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -354,10 +354,8 @@ fn write(
                 .open_read(SegmentComponent::TempStore)?,
         )?;
         for old_doc_id in doc_id_map.iter_old_doc_ids() {
-            let raw_doc = store_read.get_raw(*old_doc_id)?;
-            serializer
-                .get_store_writer()
-                .store_bytes(raw_doc.get_bytes())?;
+            let doc_bytes = store_read.get_document_bytes(*old_doc_id)?;
+            serializer.get_store_writer().store_bytes(&doc_bytes)?;
         }
         // TODO delete temp store
     }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -36,7 +36,6 @@ and should rely on either
 mod index;
 mod reader;
 mod writer;
-pub use self::reader::RawDocument;
 pub use self::reader::StoreReader;
 pub use self::writer::StoreWriter;
 


### PR DESCRIPTION
This PR removes RawDocument and uses OwnedBytes instead.

OwnedBytes is a self referring struct that offers a slice of data (&[u8]) and its ownership.
It is similar in many ways to RawDocument.

It implements Read. 