### PR TITLE
Provide a means to deal with malformed facet text representation for the query parser

### DIFF
--- a/examples/faceted_search.rs
+++ b/examples/faceted_search.rs
@@ -92,7 +92,7 @@ fn main() -> tantivy::Result<()> {
 
     // Check the reference doc for different ways to create a `Facet` object.
     {
-        let facet = Facet::from_text("/Felidae/Pantherinae");
+        let facet = Facet::from("/Felidae/Pantherinae");
         let facet_term = Term::from_facet(classification, &facet);
         let facet_term_query = TermQuery::new(facet_term, IndexRecordOption::Basic);
         let mut facet_collector = FacetCollector::for_field(classification);

--- a/src/collector/facet_collector.rs
+++ b/src/collector/facet_collector.rs
@@ -539,10 +539,10 @@ mod tests {
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests().unwrap();
         index_writer.add_document(doc!(
-            facet_field => Facet::from_text(&"/subjects/A/a"),
-            facet_field => Facet::from_text(&"/subjects/B/a"),
-            facet_field => Facet::from_text(&"/subjects/A/b"),
-            facet_field => Facet::from_text(&"/subjects/B/b"),
+            facet_field => Facet::from_text(&"/subjects/A/a").unwrap(),
+            facet_field => Facet::from_text(&"/subjects/B/a").unwrap(),
+            facet_field => Facet::from_text(&"/subjects/A/b").unwrap(),
+            facet_field => Facet::from_text(&"/subjects/B/b").unwrap(),
         ));
         index_writer.commit().unwrap();
         let reader = index.reader().unwrap();
@@ -563,16 +563,16 @@ mod tests {
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests()?;
         index_writer.add_document(doc!(
-            facet_field => Facet::from_text(&"/A/A"),
+            facet_field => Facet::from_text(&"/A/A").unwrap(),
         ));
         index_writer.add_document(doc!(
-            facet_field => Facet::from_text(&"/A/B"),
+            facet_field => Facet::from_text(&"/A/B").unwrap(),
         ));
         index_writer.add_document(doc!(
-            facet_field => Facet::from_text(&"/A/C/A"),
+            facet_field => Facet::from_text(&"/A/C/A").unwrap(),
         ));
         index_writer.add_document(doc!(
-            facet_field => Facet::from_text(&"/D/C/A"),
+            facet_field => Facet::from_text(&"/D/C/A").unwrap(),
         ));
         index_writer.commit()?;
         let reader = index.reader()?;
@@ -580,7 +580,7 @@ mod tests {
         assert_eq!(searcher.num_docs(), 4);
 
         let count_facet = |facet_str: &str| {
-            let term = Term::from_facet(facet_field, &Facet::from_text(facet_str));
+            let term = Term::from_facet(facet_field, &Facet::from_text(facet_str).unwrap());
             searcher
                 .search(&TermQuery::new(term, IndexRecordOption::Basic), &Count)
                 .unwrap()

--- a/src/fastfield/facet_reader.rs
+++ b/src/fastfield/facet_reader.rs
@@ -95,7 +95,7 @@ mod tests {
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests()?;
-        index_writer.add_document(doc!(facet_field=>Facet::from_text("/a/b")));
+        index_writer.add_document(doc!(facet_field=>Facet::from_text("/a/b").unwrap()));
         index_writer.commit()?;
         let searcher = index.reader()?.searcher();
         let facet_reader = searcher
@@ -118,7 +118,7 @@ mod tests {
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests()?;
-        index_writer.add_document(doc!(facet_field=>Facet::from_text("/a/b")));
+        index_writer.add_document(doc!(facet_field=>Facet::from_text("/a/b").unwrap()));
         index_writer.commit()?;
         let searcher = index.reader()?.searcher();
         let facet_reader = searcher
@@ -141,7 +141,7 @@ mod tests {
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests()?;
-        index_writer.add_document(doc!(facet_field=>Facet::from_text("/a/b")));
+        index_writer.add_document(doc!(facet_field=>Facet::from_text("/a/b").unwrap()));
         index_writer.commit()?;
         let searcher = index.reader()?.searcher();
         let facet_reader = searcher
@@ -164,7 +164,7 @@ mod tests {
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests()?;
-        index_writer.add_document(doc!(facet_field=>Facet::from_text("/a/b")));
+        index_writer.add_document(doc!(facet_field=>Facet::from_text("/a/b").unwrap()));
         index_writer.commit()?;
         let searcher = index.reader()?.searcher();
         let facet_reader = searcher
@@ -187,7 +187,7 @@ mod tests {
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests()?;
-        index_writer.add_document(doc!(facet_field=>Facet::from_text("/a/b")));
+        index_writer.add_document(doc!(facet_field=>Facet::from_text("/a/b").unwrap()));
         index_writer.add_document(Document::default());
         index_writer.commit()?;
         let searcher = index.reader()?.searcher();

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -69,7 +69,7 @@ pub enum QueryParserError {
     #[error("The date field has an invalid format")]
     DateFormatError(chrono::ParseError),
     /// The format for the facet field is invalid.
-    #[error("The facet field is malformed")]
+    #[error("The facet field is malformed: {0}")]
     FacetFormatError(FacetParseError),
 }
 
@@ -1034,6 +1034,19 @@ mod test {
         assert!(query_parser
             .parse_query("date:\"1985-04-12T23:20:50.52Z\"")
             .is_ok());
+    }
+
+    #[test]
+    pub fn test_query_parser_expected_facet() {
+        let query_parser = make_query_parser();
+        match query_parser.parse_query("facet:INVALID") {
+            Ok(_) => panic!("should never succeed"),
+            Err(e) => assert_eq!(
+                "The facet field is malformed: Failed to parse the facet string: 'INVALID'",
+                format!("{}", e)
+            ),
+        }
+        assert!(query_parser.parse_query("facet:\"/foo/bar\"").is_ok());
     }
 
     #[test]

--- a/src/schema/facet.rs
+++ b/src/schema/facet.rs
@@ -24,7 +24,7 @@ pub const FACET_SEP_CHAR: char = '\u{0}';
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum FacetParseError {
     /// The facet text representation is unparsable.
-    #[error("Failed to parse the facet string: '{0:?}'")]
+    #[error("Failed to parse the facet string: '{0}'")]
     FacetParseError(String),
 }
 
@@ -238,7 +238,7 @@ impl Debug for Facet {
 #[cfg(test)]
 mod tests {
 
-    use super::Facet;
+    use super::{Facet, FacetParseError};
 
     #[test]
     fn test_root() {
@@ -299,5 +299,13 @@ mod tests {
         let v: Vec<&str> = vec![];
         let facet = Facet::from_path(v.iter());
         assert_eq!(facet.to_path_string(), "/");
+    }
+
+    #[test]
+    fn test_from_text() {
+        assert_eq!(
+            Err(FacetParseError::FacetParseError("INVALID".to_string())),
+            Facet::from_text("INVALID")
+        );
     }
 }

--- a/src/schema/facet.rs
+++ b/src/schema/facet.rs
@@ -85,27 +85,27 @@ impl Facet {
             Escaped,
             Idle,
         }
-        let path_ = path.as_ref();
-        if path_.is_empty() {
-            return Err(TantivyError::InvalidArgument(path_.to_string()));
+        let path_ref = path.as_ref();
+        if path_ref.is_empty() {
+            return Err(TantivyError::InvalidArgument(path_ref.to_string()));
         }
-        if !path_.starts_with('/') {
-            return Err(TantivyError::InvalidArgument(path_.to_string()));
+        if !path_ref.starts_with('/') {
+            return Err(TantivyError::InvalidArgument(path_ref.to_string()));
         }
         let mut facet_encoded = String::new();
         let mut state = State::Idle;
-        let path_bytes = path_.as_bytes();
+        let path_bytes = path_ref.as_bytes();
         let mut last_offset = 1;
         for i in 1..path_bytes.len() {
             let c = path_bytes[i];
             match (state, c) {
                 (State::Idle, ESCAPE_BYTE) => {
-                    facet_encoded.push_str(&path_[last_offset..i]);
+                    facet_encoded.push_str(&path_ref[last_offset..i]);
                     last_offset = i + 1;
                     state = State::Escaped
                 }
                 (State::Idle, SLASH_BYTE) => {
-                    facet_encoded.push_str(&path_[last_offset..i]);
+                    facet_encoded.push_str(&path_ref[last_offset..i]);
                     facet_encoded.push(FACET_SEP_CHAR);
                     last_offset = i + 1;
                 }
@@ -115,7 +115,7 @@ impl Facet {
                 (State::Idle, _any_char) => {}
             }
         }
-        facet_encoded.push_str(&path_[last_offset..]);
+        facet_encoded.push_str(&path_ref[last_offset..]);
         Ok(Facet(facet_encoded))
     }
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -128,6 +128,7 @@ pub use self::schema::{Schema, SchemaBuilder};
 pub use self::value::Value;
 
 pub use self::facet::Facet;
+pub use self::facet::FacetParseError;
 pub(crate) use self::facet::FACET_SEP_BYTE;
 pub use self::facet_options::FacetOptions;
 


### PR DESCRIPTION
**This patch requires API change.**

As `Facet::from_text` is not designed to return a `Result`, the query parser cannot handle invalid facet representations.   This patch enables it to do so by modifying `Facet::from_text()` to return a `Result<Facet, TantivyError>` instead of a bare Facet.  Also, I added a new error kind to `QueryParserError`.

BTW, I will agree to not insist any copyright on this patch.