### PR TITLE
add search_tokenizer on TextFieldIndexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Tantivy 0.16.0
+=========================
+- Allow defining a different tokenizer for search than indexing. (@mlvzk) #1074
+
 Tantivy 0.15.0
 =========================
 - API Changes. Using Range instead of (start, end) in the API and internals (`FileSlice`, `OwnedBytes`, `Snippets`, ...)

--- a/examples/search_tokenizer.rs
+++ b/examples/search_tokenizer.rs
@@ -1,0 +1,53 @@
+use tantivy::collector::TopDocs;
+use tantivy::query::QueryParser;
+use tantivy::schema::*;
+use tantivy::{doc, Index};
+
+fn main() -> tantivy::Result<()> {
+    let mut schema_builder = Schema::builder();
+
+    let text_field_indexing = TextFieldIndexing::default()
+        .set_tokenizer("default")
+        .set_search_tokenizer("raw")
+        .set_index_option(IndexRecordOption::WithFreqsAndPositions);
+    let text_options = TextOptions::default()
+        .set_indexing_options(text_field_indexing)
+        .set_stored();
+    let title = schema_builder.add_text_field("title", text_options);
+
+    let schema = schema_builder.build();
+
+    let index = Index::create_in_ram(schema.clone());
+
+    let mut index_writer = index.writer(50_000_000)?;
+    index_writer.add_document(doc!(
+        title => "The Old Man and the Sea",
+    ));
+    index_writer.add_document(doc!(
+        title => "Of Mice and Men",
+    ));
+    index_writer.add_document(doc!(
+        title => "Frankenstein",
+    ));
+    index_writer.commit()?;
+
+    let reader = index.reader()?;
+    let searcher = reader.searcher();
+
+    let query_parser = QueryParser::for_index(&index, vec![title]);
+
+    let query = query_parser.parse_query("mice")?;
+    let top_docs = searcher.search(&query, &TopDocs::with_limit(10))?;
+    assert_eq!(top_docs.len(), 1);
+    for (_, doc_address) in top_docs {
+        let retrieved_doc = searcher.doc(doc_address)?;
+        println!("{}", schema.to_json(&retrieved_doc));
+    }
+
+    // This would return 1 document if the tokenizer was "default"
+    let query = query_parser.parse_query("Mice")?;
+    let top_docs = searcher.search(&query, &TopDocs::with_limit(10))?;
+    assert_eq!(top_docs.len(), 0);
+
+    Ok(())
+}

--- a/src/core/index_meta.rs
+++ b/src/core/index_meta.rs
@@ -394,7 +394,7 @@ mod tests {
         let json = serde_json::ser::to_string(&index_metas).expect("serialization failed");
         assert_eq!(
             json,
-            r#"{"index_settings":{"sort_by_field":{"field":"text","order":"Asc"},"docstore_compression":"lz4"},"segments":[],"schema":[{"name":"text","type":"text","options":{"indexing":{"record":"position","tokenizer":"default"},"stored":false}}],"opstamp":0}"#
+            r#"{"index_settings":{"sort_by_field":{"field":"text","order":"Asc"},"docstore_compression":"lz4"},"segments":[],"schema":[{"name":"text","type":"text","options":{"indexing":{"record":"position","tokenizer":"default","search_tokenizer":null},"stored":false}}],"opstamp":0}"#
         );
     }
 }

--- a/src/query/more_like_this/more_like_this.rs
+++ b/src/query/more_like_this/more_like_this.rs
@@ -211,7 +211,7 @@ impl MoreLikeThis {
                             if let Some(tokenizer) = text_options
                                 .get_indexing_options()
                                 .map(|text_indexing_options| {
-                                    text_indexing_options.tokenizer().to_string()
+                                    text_indexing_options.search_tokenizer().to_string()
                                 })
                                 .and_then(|tokenizer_name| tokenizer_manager.get(&tokenizer_name))
                             {

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -324,15 +324,15 @@ impl QueryParser {
             }
             FieldType::Str(ref str_options) => {
                 if let Some(option) = str_options.get_indexing_options() {
-                    let tokenizer =
-                        self.tokenizer_manager
-                            .get(option.tokenizer())
-                            .ok_or_else(|| {
-                                QueryParserError::UnknownTokenizer(
-                                    field_entry.name().to_string(),
-                                    option.tokenizer().to_string(),
-                                )
-                            })?;
+                    let tokenizer = self
+                        .tokenizer_manager
+                        .get(option.search_tokenizer())
+                        .ok_or_else(|| {
+                            QueryParserError::UnknownTokenizer(
+                                field_entry.name().to_string(),
+                                option.search_tokenizer().to_string(),
+                            )
+                        })?;
                     let mut terms: Vec<(usize, Term)> = Vec::new();
                     let mut token_stream = tokenizer.token_stream(phrase);
                     token_stream.process(&mut |token| {

--- a/src/schema/field_entry.rs
+++ b/src/schema/field_entry.rs
@@ -294,7 +294,8 @@ mod tests {
   "options": {
     "indexing": {
       "record": "position",
-      "tokenizer": "default"
+      "tokenizer": "default",
+      "search_tokenizer": null
     },
     "stored": false
   }

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -448,7 +448,8 @@ mod tests {
     "options": {
       "indexing": {
         "record": "position",
-        "tokenizer": "default"
+        "tokenizer": "default",
+        "search_tokenizer": null
       },
       "stored": false
     }
@@ -459,7 +460,8 @@ mod tests {
     "options": {
       "indexing": {
         "record": "basic",
-        "tokenizer": "raw"
+        "tokenizer": "raw",
+        "search_tokenizer": null
       },
       "stored": false
     }
@@ -793,7 +795,8 @@ mod tests {
     "options": {
       "indexing": {
         "record": "basic",
-        "tokenizer": "raw"
+        "tokenizer": "raw",
+        "search_tokenizer": null
       },
       "stored": true
     }
@@ -813,7 +816,8 @@ mod tests {
     "options": {
       "indexing": {
         "record": "position",
-        "tokenizer": "default"
+        "tokenizer": "default",
+        "search_tokenizer": null
       },
       "stored": false
     }

--- a/src/schema/text_options.rs
+++ b/src/schema/text_options.rs
@@ -55,12 +55,14 @@ impl Default for TextOptions {
 pub struct TextFieldIndexing {
     record: IndexRecordOption,
     tokenizer: Cow<'static, str>,
+    search_tokenizer: Option<Cow<'static, str>>,
 }
 
 impl Default for TextFieldIndexing {
     fn default() -> TextFieldIndexing {
         TextFieldIndexing {
             tokenizer: Cow::Borrowed("default"),
+            search_tokenizer: None,
             record: IndexRecordOption::Basic,
         }
     }
@@ -73,9 +75,20 @@ impl TextFieldIndexing {
         self
     }
 
+    /// Sets the search tokenizer to be used for a given field.
+    pub fn set_search_tokenizer(mut self, tokenizer_name: &str) -> TextFieldIndexing {
+        self.search_tokenizer = Some(Cow::Owned(tokenizer_name.to_string()));
+        self
+    }
+
     /// Returns the tokenizer that will be used for this field.
     pub fn tokenizer(&self) -> &str {
         &self.tokenizer
+    }
+
+    /// Returns the search tokenizer that will be used for this field.
+    pub fn search_tokenizer(&self) -> &str {
+        self.search_tokenizer.as_ref().unwrap_or(&self.tokenizer)
     }
 
     /// Sets which information should be indexed with the tokens.
@@ -98,6 +111,7 @@ impl TextFieldIndexing {
 pub const STRING: TextOptions = TextOptions {
     indexing: Some(TextFieldIndexing {
         tokenizer: Cow::Borrowed("raw"),
+        search_tokenizer: None,
         record: IndexRecordOption::Basic,
     }),
     stored: false,
@@ -107,6 +121,7 @@ pub const STRING: TextOptions = TextOptions {
 pub const TEXT: TextOptions = TextOptions {
     indexing: Some(TextFieldIndexing {
         tokenizer: Cow::Borrowed("default"),
+        search_tokenizer: None,
         record: IndexRecordOption::WithFreqsAndPositions,
     }),
     stored: false,


### PR DESCRIPTION
This feature let's you define a different tokenizer for searching than indexing.
This doesn't break previous functionality, because it defaults to the indexing tokenizer if search_tokenizer was not specified.

This is called "search_analyzer" in Elasticsearch. https://www.elastic.co/guide/en/elasticsearch/reference/current/search-analyzer.html

That link also explains why it's useful:
> Sometimes, though, it can make sense to use a different analyzer at search time, such as when using the edge_ngram tokenizer for autocomplete or when using search-time synonyms.

Issue for this PR: #1074 