### PR TITLE
Fix panic in store reader raw document iterator during segment merge

### DIFF
--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1104,7 +1104,7 @@ mod tests {
     use crate::schema::IntOptions;
     use crate::schema::Term;
     use crate::schema::TextFieldIndexing;
-    use crate::schema::{Cardinality, TEXT};
+    use crate::schema::{Cardinality, TEXT, STORED};
     use crate::DocAddress;
     use crate::IndexSettings;
     use crate::IndexSortByField;
@@ -1260,6 +1260,54 @@ mod tests {
                 );
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_fuzzy_index_merger_with_deletes() -> crate::Result<()> {
+        let mut schema_builder = schema::Schema::builder();
+        let id_field = schema_builder.add_u64_field("id", INDEXED | FAST | STORED);
+        let title_field = schema_builder.add_text_field("title", TEXT | STORED);
+        let schema = schema_builder.build();
+
+        let index = Index::create_in_ram(schema);
+        let index_reader = index.reader().unwrap();
+        let mut index_writer = index.writer(50_000_000).unwrap();
+
+        let create_doc = |id: u64| -> Document {
+            let mut doc = Document::default();
+            doc.add_text(title_field, format!("Hello world {}", id));
+            doc.add_u64(id_field, id);
+            doc
+        };
+
+        let mut created = 0;
+        let mut deleted = 0;
+        let count_docs = || -> usize {
+            let searcher = index_reader.searcher();
+            searcher.search(&AllQuery, &Count).unwrap()
+        };
+
+        for i in 0..50 {
+            let start_id = i * 1000;
+
+            for a in 0..1000 {
+                let doc = create_doc(start_id + a);
+                index_writer.add_document(doc);
+                created += 1;
+            }
+            index_writer.commit().unwrap();
+
+            for a in 10..980 {
+                index_writer.delete_term(Term::from_field_u64(id_field, start_id + a));
+                deleted += 1;
+            }
+            index_writer.commit().unwrap();
+        }
+
+        index_reader.reload().unwrap();
+        assert_eq!(created - deleted, count_docs());
+
         Ok(())
     }
 

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1104,7 +1104,7 @@ mod tests {
     use crate::schema::IntOptions;
     use crate::schema::Term;
     use crate::schema::TextFieldIndexing;
-    use crate::schema::{Cardinality, TEXT, STORED};
+    use crate::schema::{Cardinality, STORED, TEXT};
     use crate::DocAddress;
     use crate::IndexSettings;
     use crate::IndexSortByField;

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1104,7 +1104,7 @@ mod tests {
     use crate::schema::IntOptions;
     use crate::schema::Term;
     use crate::schema::TextFieldIndexing;
-    use crate::schema::{Cardinality, STORED, TEXT};
+    use crate::schema::{Cardinality, TEXT};
     use crate::DocAddress;
     use crate::IndexSettings;
     use crate::IndexSortByField;

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -224,10 +224,6 @@ impl StoreReader {
                         break doc_length;
                     } else {
                         block_start_pos += doc_length;
-                        if block_start_pos > block[0..].len() {
-                            println!("Hmm");
-                        }
-
                         cursor = &block[block_start_pos..];
                     }
                 };

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -166,6 +166,7 @@ impl StoreReader {
             .map(|checkpoint| self.read_block(&checkpoint).map_err(|e| e.kind())); // map error in order to enable cloning
         let mut block_start_pos = 0;
         let mut num_skipped = 0;
+        let mut reset_block_pos = false;
         (0..last_docid)
             .filter_map(move |doc_id| {
                 // filter_map is only used to resolve lifetime issues between the two closures on
@@ -175,8 +176,8 @@ impl StoreReader {
                     // we keep the number of skipped documents to move forward in the map block
                     num_skipped += 1;
                 }
+
                 // check move to next checkpoint
-                let mut reset_block_pos = false;
                 if doc_id >= curr_checkpoint.as_ref().unwrap().doc_range.end {
                     curr_checkpoint = checkpoint_block_iter.next();
                     curr_block = curr_checkpoint
@@ -190,6 +191,7 @@ impl StoreReader {
                     let ret = Some((curr_block.clone(), num_skipped, reset_block_pos));
                     // the map block will move over the num_skipped, so we reset to 0
                     num_skipped = 0;
+                    reset_block_pos = false;
                     ret
                 } else {
                     None
@@ -222,6 +224,10 @@ impl StoreReader {
                         break doc_length;
                     } else {
                         block_start_pos += doc_length;
+                        if block_start_pos > block[0..].len() {
+                            println!("Hmm");
+                        }
+
                         cursor = &block[block_start_pos..];
                     }
                 };


### PR DESCRIPTION
The store reader raw document iterator fails when the first document of a block past a new checkpoint has been deleted. This was caused by the `reset_block_pos` flag used to reset `block_start_pos` being discarded when the current document isn't alive.

Depending on the state of the segments, I could triggered two different panics related to the varint deserialization in the iterator. See [this](https://gist.github.com/appaquet/ee5b9b8611832a80f65db17d4f7c8757). One involves a bit shifting overflow in the `Vint` deserialization itself, and one involves reading a wrong and huge doc length, leading to a out of range slice. In all cases, another thread also panics after dropping a `RamDirectory`'s `VecWriter` without flushing it, caused by a `VInt` deserialization error in [`IndexMerger.write`](https://github.com/tantivy-search/tantivy/blob/6e4b61154f501b0fee16b61042d4f45dbf4a96ec/src/indexer/merger.rs#L1084), making the function return before closing writers.

Unfortunately, this is the minimal test I could find to reproduce the issue... I would have liked a straightforward test, but it seems like a few merges, with enough data per segment, need to happen to trigger the bug. Because of that, the test is slower than what I'd consider acceptable for a unit test (~10s on my machine). 

Let me know what you want to do about the test, or if you have a better idea to test the issue.