### PR TITLE
Fix corruption in store reader iterator, take 2

### DIFF
--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -133,11 +133,21 @@ pub mod tests {
                 format!("Doc {}", i)
             );
         }
+
         for (_, doc) in store.iter(Some(&delete_bitset)).enumerate() {
             let doc = doc?;
             let title_content = doc.get_first(field_title).unwrap().text().unwrap();
             if !title_content.starts_with("Doc ") {
                 panic!("unexpected title_content {}", title_content);
+            }
+
+            let id = title_content
+                .strip_prefix("Doc ")
+                .unwrap()
+                .parse::<u32>()
+                .unwrap();
+            if delete_bitset.is_deleted(id) {
+                panic!("unexpected deleted document {}", id);
             }
         }
 


### PR DESCRIPTION
This is a follow up from my previous bug fixed in [here](https://github.com/tantivy-search/tantivy/pull/1076). The fix resolved the different panics, but didn't solve the underlying issue when a deleted document is at the beginning of a checkpoint. What happened now is that if a deleted document was at the beginning of the block, we weren't taking it into consideration when skipping, causing the iterator to return deleted documents, and the merge to include deleted documents. 

Finding the bug was quite a challenge. At first I though it was another underlying issue in 0.15, but bisecting the commits pointed me to my previous fix 😬 You can see how I was consistently reproducing it with [gist](https://gist.github.com/appaquet/3b1e4abe1ad4f47f4ab72bf65646e91c), which is quite intensive. Running it a few times will eventually lead to corrupted results (searching for a term, but getting results that aren't for the term).

I tweaked the unit tests @PSeitz created to fail when a deleted document is returned by the iterator.