### PR TITLE
Exposing min/max value interface on MultiValuedFastField Reader

### DIFF
--- a/src/fastfield/multivalued/reader.rs
+++ b/src/fastfield/multivalued/reader.rs
@@ -46,6 +46,24 @@ impl<Item: FastValue> MultiValuedFastFieldReader<Item> {
         self.vals_reader.get_range_u64(range.start, &mut vals[..]);
     }
 
+    /// Returns the minimum value for this fast field.
+    ///
+    /// The max value does not take in account of possible
+    /// deleted document, and should be considered as an upper bound
+    /// of the actual maximum value.
+    pub fn min_value(&self) -> Item {
+        self.vals_reader.max_value()
+    }
+
+    /// Returns the maximum value for this fast field.
+    ///
+    /// The max value does not take in account of possible
+    /// deleted document, and should be considered as an upper bound
+    /// of the actual maximum value.
+    pub fn max_value(&self) -> Item {
+        self.vals_reader.min_value()
+    }
+
     /// Returns the number of values associated with the document `DocId`.
     pub fn num_vals(&self, doc: DocId) -> usize {
         let range = self.range(doc);


### PR DESCRIPTION
Issue: as pointed out by @fmassot We want to avoid issues related to schema evolution in Quickwit. so currently fast fields are implicitly declared as multivalued.
We need the max/min value interface to be available for `MultiValuedFastFieldReader` as it is for  `FastFieldReader`
Currently, we need it to allow us to perform the timestamp filtering optimization. That is when a split time range is already within the user query bound, we should not attach filtering.