### PR TITLE
Use dynamic fastfield codes for multivalues fixes #1093

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ rayon = "1.5"
 lru = "0.6.5"
 fastdivide = "0.3"
 itertools = "0.10.0"
-measure_time = "0.6.0"
+measure_time = "0.7.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ rayon = "1.5"
 lru = "0.6.5"
 fastdivide = "0.3"
 itertools = "0.10.0"
+measure_time = "0.6.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/fastfield_codecs/src/lib.rs
+++ b/fastfield_codecs/src/lib.rs
@@ -51,14 +51,14 @@ pub trait FastFieldCodecSerializer {
 
 /// FastFieldDataAccess is the trait to access fast field data during serialization and estimation.
 pub trait FastFieldDataAccess {
-    /// Return the value associated to the given document.
+    /// Return the value associated to the given position.
     ///
     /// Whenever possible use the Iterator passed to the fastfield creation instead, for performance reasons.
     ///
     /// # Panics
     ///
-    /// May panic if `doc` is greater than the segment
-    fn get(&self, doc: u32) -> u64;
+    /// May panic if `position` is greater than the index.
+    fn get_val(&self, position: u64) -> u64;
 }
 
 #[derive(Debug, Clone)]
@@ -69,20 +69,20 @@ pub struct FastFieldStats {
 }
 
 impl<'a> FastFieldDataAccess for &'a [u64] {
-    fn get(&self, doc: u32) -> u64 {
-        self[doc as usize]
+    fn get_val(&self, position: u64) -> u64 {
+        self[position as usize]
     }
 }
 
 impl<'a> FastFieldDataAccess for &'a Vec<u64> {
-    fn get(&self, doc: u32) -> u64 {
-        self[doc as usize]
+    fn get_val(&self, position: u64) -> u64 {
+        self[position as usize]
     }
 }
 
 impl FastFieldDataAccess for Vec<u64> {
-    fn get(&self, doc: u32) -> u64 {
-        self[doc as usize]
+    fn get_val(&self, position: u64) -> u64 {
+        self[position as usize]
     }
 }
 

--- a/fastfield_codecs/src/lib.rs
+++ b/fastfield_codecs/src/lib.rs
@@ -74,12 +74,6 @@ impl<'a> FastFieldDataAccess for &'a [u64] {
     }
 }
 
-impl<'a> FastFieldDataAccess for &'a Vec<u64> {
-    fn get_val(&self, position: u64) -> u64 {
-        self[position as usize]
-    }
-}
-
 impl FastFieldDataAccess for Vec<u64> {
     fn get_val(&self, position: u64) -> u64 {
         self[position as usize]

--- a/fastfield_codecs/src/linearinterpol.rs
+++ b/fastfield_codecs/src/linearinterpol.rs
@@ -123,8 +123,8 @@ impl FastFieldCodecSerializer for LinearInterpolFastFieldSerializer {
     ) -> io::Result<()> {
         assert!(stats.min_value <= stats.max_value);
 
-        let first_val = fastfield_accessor.get(0);
-        let last_val = fastfield_accessor.get(stats.num_vals as u32 - 1);
+        let first_val = fastfield_accessor.get_val(0);
+        let last_val = fastfield_accessor.get_val(stats.num_vals as u64 - 1);
         let slope = get_slope(first_val, last_val, stats.num_vals);
         // calculate offset to ensure all values are positive
         let mut offset = 0;
@@ -191,8 +191,8 @@ impl FastFieldCodecSerializer for LinearInterpolFastFieldSerializer {
     /// where the local maxima for the deviation of the calculated value are and
     /// the offset to shift all values to >=0 is also unknown.
     fn estimate(fastfield_accessor: &impl FastFieldDataAccess, stats: FastFieldStats) -> f32 {
-        let first_val = fastfield_accessor.get(0);
-        let last_val = fastfield_accessor.get(stats.num_vals as u32 - 1);
+        let first_val = fastfield_accessor.get_val(0);
+        let last_val = fastfield_accessor.get_val(stats.num_vals as u64 - 1);
         let slope = get_slope(first_val, last_val, stats.num_vals);
 
         // let's sample at 0%, 5%, 10% .. 95%, 100%
@@ -205,7 +205,7 @@ impl FastFieldCodecSerializer for LinearInterpolFastFieldSerializer {
             .iter()
             .map(|pos| {
                 let calculated_value = get_calculated_value(first_val, *pos as u64, slope);
-                let actual_value = fastfield_accessor.get(*pos as u32);
+                let actual_value = fastfield_accessor.get_val(*pos as u64);
                 distance(calculated_value, actual_value)
             })
             .max()

--- a/fastfield_codecs/src/multilinearinterpol.rs
+++ b/fastfield_codecs/src/multilinearinterpol.rs
@@ -196,8 +196,8 @@ impl FastFieldCodecSerializer for MultiLinearInterpolFastFieldSerializer {
     ) -> io::Result<()> {
         assert!(stats.min_value <= stats.max_value);
 
-        let first_val = fastfield_accessor.get(0);
-        let last_val = fastfield_accessor.get(stats.num_vals as u32 - 1);
+        let first_val = fastfield_accessor.get_val(0);
+        let last_val = fastfield_accessor.get_val(stats.num_vals as u64 - 1);
 
         let mut first_function = Function {
             end_pos: stats.num_vals,
@@ -309,9 +309,10 @@ impl FastFieldCodecSerializer for MultiLinearInterpolFastFieldSerializer {
     /// where the local maxima are for the deviation of the calculated value and
     /// the offset is also unknown.
     fn estimate(fastfield_accessor: &impl FastFieldDataAccess, stats: FastFieldStats) -> f32 {
-        let first_val_in_first_block = fastfield_accessor.get(0);
+        let first_val_in_first_block = fastfield_accessor.get_val(0);
         let last_elem_in_first_chunk = CHUNK_SIZE.min(stats.num_vals);
-        let last_val_in_first_block = fastfield_accessor.get(last_elem_in_first_chunk as u32 - 1);
+        let last_val_in_first_block =
+            fastfield_accessor.get_val(last_elem_in_first_chunk as u64 - 1);
         let slope = get_slope(
             first_val_in_first_block,
             last_val_in_first_block,
@@ -328,7 +329,7 @@ impl FastFieldCodecSerializer for MultiLinearInterpolFastFieldSerializer {
             .map(|pos| {
                 let calculated_value =
                     get_calculated_value(first_val_in_first_block, *pos as u64, slope);
-                let actual_value = fastfield_accessor.get(*pos as u32);
+                let actual_value = fastfield_accessor.get_val(*pos as u64);
                 distance(calculated_value, actual_value)
             })
             .max()

--- a/src/fastfield/delete.rs
+++ b/src/fastfield/delete.rs
@@ -91,6 +91,10 @@ impl DeleteBitSet {
         b & (1u8 << shift) != 0
     }
 
+    /// The number of deleted docs
+    pub fn num_deleted(&self) -> usize {
+        self.num_deleted
+    }
     /// Summarize total space usage of this bitset.
     pub fn space_usage(&self) -> ByteCount {
         self.data.len()

--- a/src/fastfield/reader.rs
+++ b/src/fastfield/reader.rs
@@ -44,7 +44,7 @@ pub trait FastFieldReader<Item: FastValue>: Clone {
     ///
     /// May panic if `start + output.len()` is greater than
     /// the segment's `maxdoc`.
-    fn get_range(&self, start: DocId, output: &mut [Item]);
+    fn get_range(&self, start: u64, output: &mut [Item]);
 
     /// Returns the minimum value for this fast field.
     ///
@@ -120,7 +120,7 @@ impl<Item: FastValue> FastFieldReader<Item> for DynamicFastFieldReader<Item> {
             Self::MultiLinearInterpol(reader) => reader.get(doc),
         }
     }
-    fn get_range(&self, start: DocId, output: &mut [Item]) {
+    fn get_range(&self, start: u64, output: &mut [Item]) {
         match self {
             Self::Bitpacked(reader) => reader.get_range(start, output),
             Self::LinearInterpol(reader) => reader.get_range(start, output),
@@ -226,8 +226,8 @@ impl<Item: FastValue, C: FastFieldCodecReader + Clone> FastFieldReader<Item>
     ///
     /// May panic if `start + output.len()` is greater than
     /// the segment's `maxdoc`.
-    fn get_range(&self, start: DocId, output: &mut [Item]) {
-        self.get_range_u64(u64::from(start), output);
+    fn get_range(&self, start: u64, output: &mut [Item]) {
+        self.get_range_u64(start, output);
     }
 
     /// Returns the minimum value for this fast field.

--- a/src/fastfield/readers.rs
+++ b/src/fastfield/readers.rs
@@ -99,12 +99,19 @@ impl FastFieldReaders {
         Ok(())
     }
 
+    pub(crate) fn typed_fast_field_reader_with_idx<TFastValue: FastValue>(
+        &self,
+        field: Field,
+        index: usize,
+    ) -> crate::Result<DynamicFastFieldReader<TFastValue>> {
+        let fast_field_slice = self.fast_field_data(field, index)?;
+        DynamicFastFieldReader::open(fast_field_slice)
+    }
     pub(crate) fn typed_fast_field_reader<TFastValue: FastValue>(
         &self,
         field: Field,
     ) -> crate::Result<DynamicFastFieldReader<TFastValue>> {
-        let fast_field_slice = self.fast_field_data(field, 0)?;
-        DynamicFastFieldReader::open(fast_field_slice)
+        self.typed_fast_field_reader_with_idx(field, 0)
     }
 
     pub(crate) fn typed_fast_field_multi_reader<TFastValue: FastValue>(
@@ -112,9 +119,7 @@ impl FastFieldReaders {
         field: Field,
     ) -> crate::Result<MultiValuedFastFieldReader<TFastValue>> {
         let idx_reader = self.typed_fast_field_reader(field)?;
-        let fast_field_slice_vals = self.fast_field_data(field, 1)?;
-        let vals_reader: BitpackedFastFieldReader<TFastValue> =
-            BitpackedFastFieldReader::open(fast_field_slice_vals)?;
+        let vals_reader = self.typed_fast_field_reader_with_idx(field, 1)?;
         Ok(MultiValuedFastFieldReader::open(idx_reader, vals_reader))
     }
 

--- a/src/fastfield/serializer/mod.rs
+++ b/src/fastfield/serializer/mod.rs
@@ -71,7 +71,26 @@ impl CompositeFastFieldSerializer {
         data_iter_1: impl Iterator<Item = u64>,
         data_iter_2: impl Iterator<Item = u64>,
     ) -> io::Result<()> {
-        let field_write = self.composite_write.for_field_with_idx(field, 0);
+        self.create_auto_detect_u64_fast_field_with_idx(
+            field,
+            stats,
+            fastfield_accessor,
+            data_iter_1,
+            data_iter_2,
+            0,
+        )
+    }
+    /// Serialize data into a new u64 fast field. The best compression codec will be chosen automatically.
+    pub fn create_auto_detect_u64_fast_field_with_idx(
+        &mut self,
+        field: Field,
+        stats: FastFieldStats,
+        fastfield_accessor: impl FastFieldDataAccess,
+        data_iter_1: impl Iterator<Item = u64>,
+        data_iter_2: impl Iterator<Item = u64>,
+        idx: usize,
+    ) -> io::Result<()> {
+        let field_write = self.composite_write.for_field_with_idx(field, idx);
 
         let mut estimations = vec![];
 

--- a/src/fastfield/writer.rs
+++ b/src/fastfield/writer.rs
@@ -7,7 +7,6 @@ use crate::indexer::doc_id_mapping::DocIdMapping;
 use crate::postings::UnorderedTermId;
 use crate::schema::{Cardinality, Document, Field, FieldEntry, FieldType, Schema};
 use crate::termdict::TermOrdinal;
-use crate::DocId;
 use fnv::FnvHashMap;
 use std::collections::HashMap;
 use std::io;
@@ -323,16 +322,17 @@ struct WriterFastFieldAccessProvider<'map, 'bitp> {
     vals: &'bitp BlockedBitpacker,
 }
 impl<'map, 'bitp> FastFieldDataAccess for WriterFastFieldAccessProvider<'map, 'bitp> {
-    /// Return the value associated to the given document.
+    /// Return the value associated to the given doc.
     ///
-    /// This accessor should return as fast as possible.
+    /// Whenever possible use the Iterator passed to the fastfield creation instead, for performance reasons.
     ///
     /// # Panics
     ///
-    /// May panic if `doc` is greater than the segment
-    fn get(&self, doc: DocId) -> u64 {
+    /// May panic if `doc` is greater than the index.
+    fn get_val(&self, doc: u64) -> u64 {
         if let Some(doc_id_map) = self.doc_id_map {
-            self.vals.get(doc_id_map.get_old_doc_id(doc) as usize) // consider extra FastFieldReader wrapper for non doc_id_map
+            self.vals
+                .get(doc_id_map.get_old_doc_id(doc as u32) as usize) // consider extra FastFieldReader wrapper for non doc_id_map
         } else {
             self.vals.get(doc as usize)
         }

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -32,6 +32,10 @@ impl<'a> SegmentDocidMapping<'a> {
     pub(crate) fn len(&self) -> usize {
         self.new_doc_id_to_old_and_segment.len()
     }
+    /// This flags means the segments are simply stacked in the order of their ordinal.
+    /// e.g. [(0, 1), .. (n, 1), (0, 2)..., (m, 2)]
+    ///
+    /// This allows for some optimization.
     pub(crate) fn is_trivial(&self) -> bool {
         self.is_trivial
     }

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -2,13 +2,57 @@
 //! to get mappings from old doc_id to new doc_id and vice versa, after sorting
 //!
 
-use super::SegmentWriter;
+use super::{merger::SegmentReaderWithOrdinal, SegmentWriter};
 use crate::{
     schema::{Field, Schema},
     DocId, IndexSortByField, Order, TantivyError,
 };
-use std::cmp::Reverse;
-/// Struct to provide mapping from old doc_id to new doc_id and vice versa
+use std::{cmp::Reverse, ops::Index};
+
+/// Struct to provide mapping from new doc_id to old doc_id and segment.
+#[derive(Clone)]
+pub(crate) struct SegmentDocidMapping<'a> {
+    new_doc_id_to_old_and_segment: Vec<(DocId, SegmentReaderWithOrdinal<'a>)>,
+    is_trivial: bool,
+}
+
+impl<'a> SegmentDocidMapping<'a> {
+    pub(crate) fn new(
+        new_doc_id_to_old_and_segment: Vec<(DocId, SegmentReaderWithOrdinal<'a>)>,
+        is_trivial: bool,
+    ) -> Self {
+        Self {
+            new_doc_id_to_old_and_segment,
+            is_trivial,
+        }
+    }
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &(DocId, SegmentReaderWithOrdinal)> {
+        self.new_doc_id_to_old_and_segment.iter()
+    }
+    pub(crate) fn len(&self) -> usize {
+        self.new_doc_id_to_old_and_segment.len()
+    }
+    pub(crate) fn is_trivial(&self) -> bool {
+        self.is_trivial
+    }
+}
+impl<'a> Index<usize> for SegmentDocidMapping<'a> {
+    type Output = (DocId, SegmentReaderWithOrdinal<'a>);
+
+    fn index(&self, idx: usize) -> &Self::Output {
+        &self.new_doc_id_to_old_and_segment[idx]
+    }
+}
+impl<'a> IntoIterator for SegmentDocidMapping<'a> {
+    type Item = (DocId, SegmentReaderWithOrdinal<'a>);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.new_doc_id_to_old_and_segment.into_iter()
+    }
+}
+
+/// Struct to provide mapping from old doc_id to new doc_id and vice versa within a segment.
 pub struct DocIdMapping {
     new_doc_id_to_old: Vec<DocId>,
     old_doc_id_to_new: Vec<DocId>,

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -572,7 +572,7 @@ impl IndexMerger {
     ) -> crate::Result<()> {
         debug_time!("write_hierarchical_facet_field");
 
-        // Multifastfield consists in 2 fastfields.
+        // Multifastfield consists of 2 fastfields.
         // The first serves as an index into the second one and is stricly increasing.
         // The second contains the actual values.
 
@@ -641,9 +641,6 @@ impl IndexMerger {
         fast_field_serializer: &mut CompositeFastFieldSerializer,
         doc_id_mapping: &SegmentDocidMapping,
     ) -> crate::Result<()> {
-        //if doc_id_mapping.is_none() {
-        //doc_id_mapping = &Some(self.get_doc_id_from_concatenated_data()?);
-        //}
         // Multifastfield consists in 2 fastfields.
         // The first serves as an index into the second one and is stricly increasing.
         // The second contains the actual values.

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -30,6 +30,7 @@ use crate::{
 };
 use crate::{DocId, InvertedIndexReader, SegmentComponent};
 use itertools::Itertools;
+use measure_time::debug_time;
 use std::cmp;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -535,7 +535,7 @@ impl IndexMerger {
         fast_field_serializer.create_auto_detect_u64_fast_field(
             field,
             stats,
-            &offsets,
+            &offsets[..],
             offsets.iter().cloned(),
             offsets.iter().cloned(),
         )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,8 @@
 
 #[cfg_attr(test, macro_use)]
 extern crate serde_json;
-
+#[macro_use]
+extern crate measure_time;
 #[macro_use]
 extern crate log;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,6 @@
 #[cfg_attr(test, macro_use)]
 extern crate serde_json;
 #[macro_use]
-extern crate measure_time;
-#[macro_use]
 extern crate log;
 
 #[macro_use]


### PR DESCRIPTION
Use dynamic fastfield codes for multivalues fixes (only sorting case covered)
Rename get to get_val due to conflict with Vec
use u64 precision instead of u32 for get_range, to allow use of existing fast field interface interface (actually not sure if it would be better have a different interface)