### PR TITLE
Fix delete documents with sort by field

### DIFF
--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -1324,12 +1324,18 @@ mod tests {
         index_writer.commit().unwrap();
         index_reader.reload().unwrap();
 
-        // only non-deleted should be returned
         let searcher = index_reader.searcher();
-        let count = searcher
-            .search(&crate::query::AllQuery, &crate::collector::Count)
+        let results = searcher
+            .search(&crate::query::AllQuery, &TopDocs::with_limit(15))
             .unwrap();
-        assert_eq!(count, docs.len());
+
+        // only non-deleted should be returned
+        assert_eq!(results.len(), docs.len());
+        for (_, addr) in results {
+            let doc = searcher.doc(addr).unwrap();
+            let id = doc.get_first(id_field).unwrap().u64_value().unwrap();
+            assert!(docs.contains(&id));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Deleting documents in the same commit as they had been created in an index using the new `sort_by_field` was broken. Depending on the order of deletes, they may not have been applied.

The problem was that `doc_opstamps` returned by the segment writer's finalizer was in the original documents order as opposed to the `sort_by_field` order. Because of that, `compute_deleted_bitset` was discarding deletions because their opstamps were not correct.