### PR TITLE
Checksum validation using active files

### DIFF
--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -524,7 +524,7 @@ impl Index {
 
     /// Returns the set of corrupted files
     pub fn validate_checksum(&self) -> crate::Result<HashSet<PathBuf>> {
-        let managed_files = self.directory.list_files();
+        let managed_files = self.directory.list_managed_files();
         let active_segments_files: HashSet<PathBuf> = self
             .searchable_segment_metas()?
             .iter()

--- a/src/core/index_meta.rs
+++ b/src/core/index_meta.rs
@@ -112,10 +112,16 @@ impl SegmentMeta {
             .load(std::sync::atomic::Ordering::Relaxed)
         {
             SegmentComponent::iterator()
+                .filter(|comp| {
+                    !(*comp == &SegmentComponent::Delete && self.delete_opstamp().is_none())
+                })
                 .map(|component| self.relative_path(*component))
                 .collect::<HashSet<PathBuf>>()
         } else {
             SegmentComponent::iterator()
+                .filter(|comp| {
+                    !(*comp == &SegmentComponent::Delete && self.delete_opstamp().is_none())
+                })
                 .filter(|comp| *comp != &SegmentComponent::TempStore)
                 .map(|component| self.relative_path(*component))
                 .collect::<HashSet<PathBuf>>()

--- a/src/core/index_meta.rs
+++ b/src/core/index_meta.rs
@@ -101,6 +101,7 @@ impl SegmentMeta {
 
     /// Returns the list of files that
     /// are required for the segment meta.
+    /// Note: Some of the returned files may not exist depending on the state of the segment.
     ///
     /// This is useful as the way tantivy removes files
     /// is by removing all files that have been created by tantivy
@@ -112,16 +113,10 @@ impl SegmentMeta {
             .load(std::sync::atomic::Ordering::Relaxed)
         {
             SegmentComponent::iterator()
-                .filter(|comp| {
-                    !(*comp == &SegmentComponent::Delete && self.delete_opstamp().is_none())
-                })
                 .map(|component| self.relative_path(*component))
                 .collect::<HashSet<PathBuf>>()
         } else {
             SegmentComponent::iterator()
-                .filter(|comp| {
-                    !(*comp == &SegmentComponent::Delete && self.delete_opstamp().is_none())
-                })
                 .filter(|comp| *comp != &SegmentComponent::TempStore)
                 .map(|component| self.relative_path(*component))
                 .collect::<HashSet<PathBuf>>()

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -1,4 +1,4 @@
-use crate::core::{MANAGED_FILEPATH, META_FILEPATH};
+use crate::core::MANAGED_FILEPATH;
 use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
 use crate::directory::footer::{Footer, FooterProxy};
 use crate::directory::GarbageCollectionResult;
@@ -246,20 +246,6 @@ impl ManagedDirectory {
         hasher.update(bytes.as_slice());
         let crc = hasher.finalize();
         Ok(footer.crc() == crc)
-    }
-
-    /// List managed files for which checksum does not match content
-    pub fn list_damaged_files(&self) -> result::Result<HashSet<PathBuf>, OpenReadError> {
-        let mut managed_paths = self.list_managed_files();
-        managed_paths.remove(*META_FILEPATH);
-
-        let mut damaged_files = HashSet::new();
-        for path in managed_paths {
-            if !self.validate_checksum(&path)? {
-                damaged_files.insert(path);
-            }
-        }
-        Ok(damaged_files)
     }
 
     /// List all managed files

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -249,8 +249,8 @@ impl ManagedDirectory {
     }
 
     /// List managed files for which checksum does not match content
-    pub fn list_damaged(&self) -> result::Result<HashSet<PathBuf>, OpenReadError> {
-        let mut managed_paths = self.list_files();
+    pub fn list_damaged_files(&self) -> result::Result<HashSet<PathBuf>, OpenReadError> {
+        let mut managed_paths = self.list_managed_files();
         managed_paths.remove(*META_FILEPATH);
 
         let mut damaged_files = HashSet::new();
@@ -263,7 +263,7 @@ impl ManagedDirectory {
     }
 
     /// List all managed files
-    pub fn list_files(&self) -> HashSet<PathBuf> {
+    pub fn list_managed_files(&self) -> HashSet<PathBuf> {
         let managed_paths = self
             .meta_informations
             .read()
@@ -431,7 +431,7 @@ mod tests_mmap_specific {
 
         let read_file = managed_directory.open_read(test_path2)?.read_bytes()?;
         assert_eq!(read_file.as_slice(), &[3u8, 4u8, 5u8]);
-        assert!(managed_directory.list_damaged().unwrap().is_empty());
+        assert!(managed_directory.list_damaged_files().unwrap().is_empty());
 
         let mut corrupted_path = tempdir_path;
         corrupted_path.push(test_path2);
@@ -440,7 +440,7 @@ mod tests_mmap_specific {
         file.flush()?;
         drop(file);
 
-        let damaged = managed_directory.list_damaged()?;
+        let damaged = managed_directory.list_damaged_files()?;
         assert_eq!(damaged.len(), 1);
         assert!(damaged.contains(test_path2));
         Ok(())

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -248,15 +248,9 @@ impl ManagedDirectory {
         Ok(footer.crc() == crc)
     }
 
-    /// List files for which checksum does not match content
+    /// List managed files for which checksum does not match content
     pub fn list_damaged(&self) -> result::Result<HashSet<PathBuf>, OpenReadError> {
-        let mut managed_paths = self
-            .meta_informations
-            .read()
-            .expect("Managed directory rlock poisoned in list damaged.")
-            .managed_paths
-            .clone();
-
+        let mut managed_paths = self.list_files();
         managed_paths.remove(*META_FILEPATH);
 
         let mut damaged_files = HashSet::new();
@@ -266,6 +260,17 @@ impl ManagedDirectory {
             }
         }
         Ok(damaged_files)
+    }
+
+    /// List all managed files
+    pub fn list_files(&self) -> HashSet<PathBuf> {
+        let managed_paths = self
+            .meta_informations
+            .read()
+            .expect("Managed directory rlock poisoned in list damaged.")
+            .managed_paths
+            .clone();
+        managed_paths
     }
 }
 


### PR DESCRIPTION
added small changes to make sure checksum validation only checks active files instead of all managed files

@fulmicoton on https://github.com/tantivy-search/tantivy/blob/main/src/core/index_meta.rs#L139
Maybe we could change the api to only return `Option<PathBuf>`  that is if `delete_opstamp().is_some()  `xxx.del` files ?
To avoid listing a file that may not exist.

Closes https://github.com/tantivy-search/tantivy/issues/1127