### PR TITLE
demux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Tantivy 0.16.1
 ========================
 - Major Bugfix on multivalued fastfield.  #1151
+- Demux operation (@PSeitz)
 
 Tantivy 0.16.0
 =========================

--- a/common/src/bitset.rs
+++ b/common/src/bitset.rs
@@ -247,12 +247,12 @@ impl BitSet {
     }
 
     /// Intersect with serialized bitset
-    pub fn intersect_with(&mut self, other: &ReadSerializedBitSet) {
-        self.intersect_with_iter(other.iter_tinysets());
+    pub fn intersect_update(&mut self, other: &ReadSerializedBitSet) {
+        self.intersect_update_with_iter(other.iter_tinysets());
     }
 
     /// Intersect with tinysets
-    pub fn intersect_with_iter(&mut self, other: impl Iterator<Item = TinySet>) {
+    fn intersect_update_with_iter(&mut self, other: impl Iterator<Item = TinySet>) {
         self.len = 0;
         for (left, right) in self.tinysets.iter_mut().zip(other) {
             *left = left.intersect(right);
@@ -430,7 +430,7 @@ mod tests {
 
         let mut bitset = BitSet::with_max_value_and_full(5);
         bitset.remove(1);
-        bitset.intersect_with(&bitset_serialized);
+        bitset.intersect_update(&bitset_serialized);
 
         assert!(bitset.contains(0));
         assert!(!bitset.contains(1));
@@ -438,7 +438,7 @@ mod tests {
         assert!(!bitset.contains(3));
         assert!(bitset.contains(4));
 
-        bitset.intersect_with_iter(vec![TinySet::singleton(0)].into_iter());
+        bitset.intersect_update_with_iter(vec![TinySet::singleton(0)].into_iter());
 
         assert!(bitset.contains(0));
         assert!(!bitset.contains(1));
@@ -447,7 +447,7 @@ mod tests {
         assert!(!bitset.contains(4));
         assert_eq!(bitset.len(), 1);
 
-        bitset.intersect_with_iter(vec![TinySet::singleton(1)].into_iter());
+        bitset.intersect_update_with_iter(vec![TinySet::singleton(1)].into_iter());
         assert!(!bitset.contains(0));
         assert!(!bitset.contains(1));
         assert!(!bitset.contains(2));

--- a/common/src/bitset.rs
+++ b/common/src/bitset.rs
@@ -349,7 +349,7 @@ impl ReadSerializedBitSet {
     /// Iterate the tinyset on the fly from serialized data.
     ///
     #[inline]
-    fn iter_tinysets<'a>(&'a self) -> impl Iterator<Item = TinySet> + 'a {
+    fn iter_tinysets(&self) -> impl Iterator<Item = TinySet> + '_ {
         assert!((self.data.len()) % 8 == 0);
         self.data.chunks_exact(8).map(move |chunk| {
             let tinyset: TinySet = TinySet::deserialize(chunk.try_into().unwrap()).unwrap();

--- a/common/src/bitset.rs
+++ b/common/src/bitset.rs
@@ -248,6 +248,7 @@ impl BitSet {
     }
 
     /// Returns the number of elements in the `BitSet`.
+    #[inline]
     pub fn len(&self) -> usize {
         self.len as usize
     }
@@ -297,6 +298,7 @@ impl BitSet {
             .map(|delta_bucket| bucket + delta_bucket as u32)
     }
 
+    #[inline]
     pub fn max_value(&self) -> u32 {
         self.max_value
     }

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -439,7 +439,7 @@ impl Index {
     /// Creates a multithreaded writer
     ///
     /// Tantivy will automatically define the number of threads to use, but
-    /// no more than [`MAX_NUM_THREAD`] threads.
+    /// no more than 8 threads.
     /// `overall_heap_size_in_bytes` is the total target memory usage that will be split
     /// between a given number of threads.
     ///

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -88,7 +88,7 @@ impl Searcher {
         &self.segment_readers
     }
 
-    /// Returns the segment_reader associated with the given segment_ordinal
+    /// Returns the segment_reader associated with the given segment_ord
     pub fn segment_reader(&self, segment_ord: u32) -> &SegmentReader {
         &self.segment_readers[segment_ord as usize]
     }

--- a/src/core/segment_reader.rs
+++ b/src/core/segment_reader.rs
@@ -70,19 +70,6 @@ impl SegmentReader {
         &self.schema
     }
 
-    /// Merges the passed bitset with the existing one.
-    pub fn apply_alive_bitset(&mut self, alive_bitset: AliveBitSet) -> crate::Result<()> {
-        if let Some(existing_bitset) = self.alive_bitset_opt.as_mut() {
-            let merged_bitset = union_alive_bitset(&alive_bitset, existing_bitset)?;
-            self.num_docs = merged_bitset.num_alive_docs() as u32;
-            self.alive_bitset_opt = Some(merged_bitset);
-        } else {
-            self.num_docs = alive_bitset.num_alive_docs() as u32;
-            self.alive_bitset_opt = Some(alive_bitset);
-        }
-        Ok(())
-    }
-
     /// Return the number of documents that have been
     /// deleted in the segment.
     pub fn num_deleted_docs(&self) -> DocId {

--- a/src/core/segment_reader.rs
+++ b/src/core/segment_reader.rs
@@ -184,6 +184,7 @@ impl SegmentReader {
             let mut alive_bitset = AliveBitSet::open(delete_data.read_bytes()?);
 
             if let Some(provided_bitset) = custom_bitset {
+                assert_eq!(max_doc, provided_bitset.bitset().max_value());
                 alive_bitset = union_alive_bitset(&alive_bitset, &provided_bitset)?;
                 num_docs = alive_bitset.num_alive_docs() as u32;
             }

--- a/src/fastfield/alive_bitset.rs
+++ b/src/fastfield/alive_bitset.rs
@@ -7,19 +7,17 @@ use std::io;
 use std::io::Write;
 
 /// Merges (intersects) two AliveBitSet in a new one.
-pub fn merge_alive_bitset(left: &AliveBitSet, right: &AliveBitSet) -> crate::Result<AliveBitSet> {
-    let (mut merged_bitset, other) = if left.space_usage() > right.space_usage() {
-        (BitSet::deserialize(left.data().as_slice())?, right)
-    } else {
-        (BitSet::deserialize(right.data().as_slice())?, left)
-    };
+/// The two bitsets need to have the same max_value.
+pub fn union_alive_bitset(left: &AliveBitSet, right: &AliveBitSet) -> crate::Result<AliveBitSet> {
+    assert_eq!(left.bitset().max_value(), right.bitset().max_value());
 
-    merged_bitset.intersect_with(other.bitset());
+    let mut merged_bitset = BitSet::deserialize(left.data().as_slice())?;
+    merged_bitset.intersect_with(right.bitset());
 
-    let mut out = vec![];
-    write_alive_bitset(&merged_bitset, &mut out)?;
+    let mut alive_bitset_buffer = vec![];
+    write_alive_bitset(&merged_bitset, &mut alive_bitset_buffer)?;
 
-    Ok(AliveBitSet::open(OwnedBytes::new(out)))
+    Ok(AliveBitSet::open(OwnedBytes::new(alive_bitset_buffer)))
 }
 
 /// Write a alive `BitSet`

--- a/src/fastfield/alive_bitset.rs
+++ b/src/fastfield/alive_bitset.rs
@@ -12,7 +12,7 @@ pub fn union_alive_bitset(left: &AliveBitSet, right: &AliveBitSet) -> crate::Res
     assert_eq!(left.bitset().max_value(), right.bitset().max_value());
 
     let mut merged_bitset = BitSet::deserialize(left.data().as_slice())?;
-    merged_bitset.intersect_with(right.bitset());
+    merged_bitset.intersect_update(right.bitset());
 
     let mut alive_bitset_buffer = vec![];
     write_alive_bitset(&merged_bitset, &mut alive_bitset_buffer)?;

--- a/src/fastfield/alive_bitset.rs
+++ b/src/fastfield/alive_bitset.rs
@@ -55,8 +55,7 @@ impl AliveBitSet {
 
     pub(crate) fn from_bitset(bitset: &BitSet) -> AliveBitSet {
         let mut out = vec![];
-        write_alive_bitset(&bitset, &mut out).unwrap();
-
+        write_alive_bitset(bitset, &mut out).unwrap();
         AliveBitSet::open(OwnedBytes::new(out))
     }
 
@@ -84,7 +83,7 @@ impl AliveBitSet {
         !self.is_alive(doc)
     }
 
-    /// Iterate over the alive docids.
+    /// Iterate over the alive doc_ids.
     #[inline]
     pub fn iter_alive(&self) -> impl Iterator<Item = DocId> + '_ {
         self.bitset.iter()

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -23,7 +23,7 @@ values stored.
 Read access performance is comparable to that of an array lookup.
 */
 
-pub use self::alive_bitset::merge_alive_bitset;
+pub use self::alive_bitset::union_alive_bitset;
 pub use self::alive_bitset::write_alive_bitset;
 pub use self::alive_bitset::AliveBitSet;
 pub use self::bytes::{BytesFastFieldReader, BytesFastFieldWriter};

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -23,10 +23,10 @@ values stored.
 Read access performance is comparable to that of an array lookup.
 */
 
+pub use self::alive_bitset::merge_alive_bitset;
 pub use self::alive_bitset::write_alive_bitset;
 pub use self::alive_bitset::AliveBitSet;
 pub use self::bytes::{BytesFastFieldReader, BytesFastFieldWriter};
-pub use self::delete::merge_delete_bitset;
 pub use self::error::{FastFieldNotAvailableError, Result};
 pub use self::facet_reader::FacetReader;
 pub use self::multivalued::{MultiValuedFastFieldReader, MultiValuedFastFieldWriter};

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -26,6 +26,7 @@ Read access performance is comparable to that of an array lookup.
 pub use self::alive_bitset::write_alive_bitset;
 pub use self::alive_bitset::AliveBitSet;
 pub use self::bytes::{BytesFastFieldReader, BytesFastFieldWriter};
+pub use self::delete::merge_delete_bitset;
 pub use self::error::{FastFieldNotAvailableError, Result};
 pub use self::facet_reader::FacetReader;
 pub use self::multivalued::{MultiValuedFastFieldReader, MultiValuedFastFieldWriter};

--- a/src/indexer/demuxer.rs
+++ b/src/indexer/demuxer.rs
@@ -25,6 +25,8 @@ pub struct DemuxMapping {
 }
 
 /// DocidToSegmentOrdinal maps from docid within a segment to the new segment ordinal for demuxing.
+///
+/// For every source segment there is a `DocidToSegmentOrdinal` to distribute its docids.
 #[derive(Debug, Default)]
 pub struct DocidToSegmentOrdinal {
     docid_index_to_segment_ordinal: Vec<SegmentOrdinal>,
@@ -111,7 +113,7 @@ fn get_delete_bitsets(
 /// Demux the segments according to `demux_mapping`. See `DemuxMapping`.
 /// The number of output_directories need to match max new segment ordinal from `demux_mapping`.
 ///
-/// The ordinal of `segments` need to match the ordinals in `demux_mapping`.
+/// The ordinal of `segments` need to match the ordinals provided in `demux_mapping`.
 pub fn demux<Dir: Directory>(
     segments: &[Segment],
     demux_mapping: &DemuxMapping,

--- a/src/indexer/demuxer.rs
+++ b/src/indexer/demuxer.rs
@@ -1,0 +1,339 @@
+use common::BitSet;
+use itertools::Itertools;
+
+use crate::fastfield::DeleteBitSet;
+use crate::{merge_filtered_segments, Directory, Index, IndexSettings, Segment, SegmentOrdinal};
+
+/// DemuxMapping can be used to reorganize data from multiple segments.
+/// e.g. if you have two tenant ids TENANT_A and TENANT_B and two segments with
+/// the documents (simplified)
+/// Seg 1 [TENANT_A, TENANT_B]
+/// Seg 2 [TENANT_A, TENANT_B]
+///
+/// You may want to group your documents to
+/// Seg 1 [TENANT_A, TENANT_A]
+/// Seg 2 [TENANT_B, TENANT_B]
+///
+/// Demuxing is the tool for that.
+/// Semantically you can define a mapping from [old segment ordinal, old docid] -> [new segment ordinal].
+#[derive(Debug, Default)]
+pub struct DemuxMapping {
+    /// [index old segment ordinal] -> [index docid] = new segment ordinal
+    mapping: Vec<DocidToSegmentOrdinal>,
+}
+
+/// DocidToSegmentOrdinal maps from docid within a segment to the new segment ordinal for demuxing.
+#[derive(Debug, Default)]
+pub struct DocidToSegmentOrdinal {
+    docid_index_to_segment_ordinal: Vec<SegmentOrdinal>,
+}
+
+impl DocidToSegmentOrdinal {
+    /// Creates a new DocidToSegmentOrdinal with size of num_docids.
+    /// Initially all docids point to segment ordinal 0 and need to be set
+    /// the via `set` method.
+    pub fn new(num_docids: usize) -> Self {
+        let mut vec = vec![];
+        vec.resize(num_docids, 0);
+
+        DocidToSegmentOrdinal {
+            docid_index_to_segment_ordinal: vec,
+        }
+    }
+
+    /// Associated a docids with a the new SegmentOrdinal.
+    pub fn set(&mut self, docid: u32, segment_ordinal: SegmentOrdinal) {
+        self.docid_index_to_segment_ordinal[docid as usize] = segment_ordinal;
+    }
+
+    /// Iterates over the new SegmentOrdinal in the order of the docid.
+    pub fn iter(&self) -> impl Iterator<Item = &SegmentOrdinal> {
+        self.docid_index_to_segment_ordinal.iter()
+    }
+}
+
+impl DemuxMapping {
+    /// Creates a new empty DemuxMapping.
+    pub fn empty() -> Self {
+        DemuxMapping {
+            mapping: Default::default(),
+        }
+    }
+
+    /// Creates a DemuxMapping from existing mapping data.
+    pub fn new(mapping: Vec<DocidToSegmentOrdinal>) -> Self {
+        DemuxMapping { mapping }
+    }
+
+    /// Adds a DocidToSegmentOrdinal. The order of the pus calls
+    /// defines the old segment ordinal. e.g. first push = ordinal 0.
+    pub fn add(&mut self, segment_mapping: DocidToSegmentOrdinal) {
+        self.mapping.push(segment_mapping);
+    }
+
+    /// Returns the old number of segments.
+    pub fn get_old_num_segments(&self) -> usize {
+        self.mapping.len()
+    }
+}
+
+fn get_delete_bitsets(
+    demux_mapping: &DemuxMapping,
+    target_segment_ordinal: SegmentOrdinal,
+    max_value_per_segment: &[u32],
+) -> Vec<DeleteBitSet> {
+    let mut bitsets: Vec<_> = max_value_per_segment
+        .iter()
+        .map(|max_value| BitSet::with_max_value(*max_value))
+        .collect();
+
+    for (old_segment_ordinal, docid_to_new_segment) in demux_mapping.mapping.iter().enumerate() {
+        let bitset_for_segment = &mut bitsets[old_segment_ordinal];
+        for docid in docid_to_new_segment
+            .iter()
+            .enumerate()
+            .filter(|(_docid, new_segment_ordinal)| **new_segment_ordinal != target_segment_ordinal)
+            .map(|(docid, _)| docid)
+        {
+            // mark document as deleted if segment ordinal is not target segment ordinal
+            bitset_for_segment.insert(docid as u32);
+        }
+    }
+
+    bitsets
+        .iter()
+        .map(|bitset| DeleteBitSet::from_bitset(bitset, bitset.max_value()))
+        .collect_vec()
+}
+
+/// Demux the segments according to `demux_mapping`. See `DemuxMapping`.
+/// The number of output_directories need to match max new segment ordinal from `demux_mapping`.
+///
+/// The ordinal of `segments` need to match the ordinals in `demux_mapping`.
+pub fn demux<Dir: Directory>(
+    segments: &[Segment],
+    demux_mapping: &DemuxMapping,
+    target_settings: IndexSettings,
+    mut output_directories: Vec<Dir>,
+) -> crate::Result<Vec<Index>> {
+    output_directories.reverse();
+    let max_value_per_segment = segments
+        .iter()
+        .map(|seg| seg.meta().max_doc())
+        .collect_vec();
+
+    let mut indices = vec![];
+    for target_segment_ordinal in 0..output_directories.len() {
+        let delete_bitsets = get_delete_bitsets(
+            demux_mapping,
+            target_segment_ordinal as u32,
+            &max_value_per_segment,
+        )
+        .into_iter()
+        .map(|bitset| Some(bitset))
+        .collect_vec();
+
+        let index = merge_filtered_segments(
+            segments,
+            target_settings.clone(),
+            delete_bitsets,
+            output_directories
+                .pop()
+                .expect("no enough output_directories provided"),
+        )?;
+        indices.push(index);
+    }
+    Ok(indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        collector::TopDocs,
+        directory::RamDirectory,
+        query::QueryParser,
+        schema::{Schema, TEXT},
+        DocAddress, Term,
+    };
+
+    use super::*;
+
+    #[test]
+    fn demux_map_to_deletebitset_test() {
+        let max_value = 2;
+        let mut demux_mapping = DemuxMapping::default();
+        //segment ordinal 0 mapping
+        let mut docid_to_segment = DocidToSegmentOrdinal::new(max_value);
+        docid_to_segment.set(0, 1);
+        docid_to_segment.set(1, 0);
+        demux_mapping.add(docid_to_segment);
+
+        //segment ordinal 1 mapping
+        let mut docid_to_segment = DocidToSegmentOrdinal::new(max_value);
+        docid_to_segment.set(0, 1);
+        docid_to_segment.set(1, 1);
+        demux_mapping.add(docid_to_segment);
+        {
+            let bit_sets_for_demuxing_to_segment_ordinal_0 =
+                get_delete_bitsets(&demux_mapping, 0, &[max_value as u32, max_value as u32]);
+
+            assert_eq!(
+                bit_sets_for_demuxing_to_segment_ordinal_0[0].is_deleted(0),
+                true
+            );
+            assert_eq!(
+                bit_sets_for_demuxing_to_segment_ordinal_0[0].is_deleted(1),
+                false
+            );
+            assert_eq!(
+                bit_sets_for_demuxing_to_segment_ordinal_0[1].is_deleted(0),
+                true
+            );
+            assert_eq!(
+                bit_sets_for_demuxing_to_segment_ordinal_0[1].is_deleted(1),
+                true
+            );
+        }
+
+        {
+            let bit_sets_for_demuxing_to_segment_ordinal_1 =
+                get_delete_bitsets(&demux_mapping, 1, &[max_value as u32, max_value as u32]);
+
+            assert_eq!(
+                bit_sets_for_demuxing_to_segment_ordinal_1[0].is_deleted(0),
+                false
+            );
+            assert_eq!(
+                bit_sets_for_demuxing_to_segment_ordinal_1[0].is_deleted(1),
+                true
+            );
+            assert_eq!(
+                bit_sets_for_demuxing_to_segment_ordinal_1[1].is_deleted(0),
+                false
+            );
+            assert_eq!(
+                bit_sets_for_demuxing_to_segment_ordinal_1[1].is_deleted(1),
+                false
+            );
+        }
+    }
+
+    #[test]
+    fn test_demux_segments() -> crate::Result<()> {
+        let first_index = {
+            let mut schema_builder = Schema::builder();
+            let text_field = schema_builder.add_text_field("text", TEXT);
+            let index = Index::create_in_ram(schema_builder.build());
+            let mut index_writer = index.writer_for_tests()?;
+            index_writer.add_document(doc!(text_field=>"texto1"));
+            index_writer.add_document(doc!(text_field=>"texto2"));
+            index_writer.commit()?;
+            index
+        };
+
+        let second_index = {
+            let mut schema_builder = Schema::builder();
+            let text_field = schema_builder.add_text_field("text", TEXT);
+            let index = Index::create_in_ram(schema_builder.build());
+            let mut index_writer = index.writer_for_tests()?;
+            index_writer.add_document(doc!(text_field=>"texto3"));
+            index_writer.add_document(doc!(text_field=>"texto4"));
+            index_writer.delete_term(Term::from_field_text(text_field, "4"));
+
+            index_writer.commit()?;
+            index
+        };
+
+        let mut segments: Vec<Segment> = Vec::new();
+        segments.extend(first_index.searchable_segments()?);
+        segments.extend(second_index.searchable_segments()?);
+
+        let target_settings = first_index.settings().clone();
+
+        let mut demux_mapping = DemuxMapping::default();
+        {
+            let max_value = 2;
+            //segment ordinal 0 mapping
+            let mut docid_to_segment = DocidToSegmentOrdinal::new(max_value);
+            docid_to_segment.set(0, 1);
+            docid_to_segment.set(1, 0);
+            demux_mapping.add(docid_to_segment);
+
+            //segment ordinal 1 mapping
+            let mut docid_to_segment = DocidToSegmentOrdinal::new(max_value);
+            docid_to_segment.set(0, 1);
+            docid_to_segment.set(1, 1);
+            demux_mapping.add(docid_to_segment);
+        }
+        assert_eq!(demux_mapping.get_old_num_segments(), 2);
+
+        let demuxed_indices = demux(
+            &segments,
+            &demux_mapping,
+            target_settings,
+            vec![RamDirectory::default(), RamDirectory::default()],
+        )?;
+
+        {
+            let index = &demuxed_indices[0];
+
+            let segments = index.searchable_segments()?;
+            assert_eq!(segments.len(), 1);
+
+            let segment_metas = segments[0].meta();
+            assert_eq!(segment_metas.num_deleted_docs(), 0);
+            assert_eq!(segment_metas.num_docs(), 1);
+
+            let searcher = index.reader().unwrap().searcher();
+            {
+                let text_field = index.schema().get_field("text").unwrap();
+
+                let do_search = |term: &str| {
+                    let query = QueryParser::for_index(&index, vec![text_field])
+                        .parse_query(term)
+                        .unwrap();
+                    let top_docs: Vec<(f32, DocAddress)> =
+                        searcher.search(&query, &TopDocs::with_limit(3)).unwrap();
+
+                    top_docs.iter().map(|el| el.1.doc_id).collect::<Vec<_>>()
+                };
+
+                assert_eq!(do_search("texto1"), vec![] as Vec<u32>);
+                assert_eq!(do_search("texto2"), vec![0]);
+            }
+        }
+
+        {
+            let index = &demuxed_indices[1];
+
+            let segments = index.searchable_segments()?;
+            assert_eq!(segments.len(), 1);
+
+            let segment_metas = segments[0].meta();
+            assert_eq!(segment_metas.num_deleted_docs(), 0);
+            assert_eq!(segment_metas.num_docs(), 3);
+
+            let searcher = index.reader().unwrap().searcher();
+            {
+                let text_field = index.schema().get_field("text").unwrap();
+
+                let do_search = |term: &str| {
+                    let query = QueryParser::for_index(&index, vec![text_field])
+                        .parse_query(term)
+                        .unwrap();
+                    let top_docs: Vec<(f32, DocAddress)> =
+                        searcher.search(&query, &TopDocs::with_limit(3)).unwrap();
+
+                    top_docs.iter().map(|el| el.1.doc_id).collect::<Vec<_>>()
+                };
+
+                assert_eq!(do_search("texto1"), vec![0]);
+                assert_eq!(do_search("texto2"), vec![] as Vec<u32>);
+                assert_eq!(do_search("texto3"), vec![1]);
+                assert_eq!(do_search("texto4"), vec![2]);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/indexer/demuxer.rs
+++ b/src/indexer/demuxer.rs
@@ -2,7 +2,9 @@ use common::BitSet;
 use itertools::Itertools;
 
 use crate::fastfield::DeleteBitSet;
-use crate::{merge_filtered_segments, Directory, Index, IndexSettings, Segment, SegmentOrdinal};
+use crate::{
+    merge_filtered_segments, Directory, Index, IndexSettings, Segment, SegmentOrdinal, TantivyError,
+};
 
 /// DemuxMapping can be used to reorganize data from multiple segments.
 /// e.g. if you have two tenant ids TENANT_A and TENANT_B and two segments with
@@ -137,9 +139,9 @@ pub fn demux<Dir: Directory>(
             segments,
             target_settings.clone(),
             delete_bitsets,
-            output_directories
-                .pop()
-                .expect("no enough output_directories provided"),
+            output_directories.pop().ok_or_else(|| {
+                TantivyError::InvalidArgument("not enough output_directories provided".to_string())
+            })?,
         )?;
         indices.push(index);
     }

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -11,12 +11,12 @@ use std::{cmp::Reverse, ops::Index};
 
 /// Struct to provide mapping from new doc_id to old doc_id and segment.
 #[derive(Clone)]
-pub(crate) struct SegmentDocidMapping {
+pub(crate) struct SegmentDocIdMapping {
     new_doc_id_to_old_and_segment: Vec<(DocId, SegmentOrdinal)>,
     is_trivial: bool,
 }
 
-impl SegmentDocidMapping {
+impl SegmentDocIdMapping {
     pub(crate) fn new(
         new_doc_id_to_old_and_segment: Vec<(DocId, SegmentOrdinal)>,
         is_trivial: bool,
@@ -40,14 +40,14 @@ impl SegmentDocidMapping {
         self.is_trivial
     }
 }
-impl Index<usize> for SegmentDocidMapping {
+impl Index<usize> for SegmentDocIdMapping {
     type Output = (DocId, SegmentOrdinal);
 
     fn index(&self, idx: usize) -> &Self::Output {
         &self.new_doc_id_to_old_and_segment[idx]
     }
 }
-impl IntoIterator for SegmentDocidMapping {
+impl IntoIterator for SegmentDocIdMapping {
     type Item = (DocId, SegmentOrdinal);
     type IntoIter = std::vec::IntoIter<Self::Item>;
 

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -164,15 +164,8 @@ pub(crate) fn advance_deletes(
         target_opstamp,
     )?;
 
-    // TODO optimize
-    // It should be possible to do something smarter by manipulation bitsets directly
-    // to compute this union.
     if let Some(seg_alive_bitset) = segment_reader.alive_bitset() {
-        for doc in 0u32..max_doc {
-            if seg_alive_bitset.is_deleted(doc) {
-                alive_bitset.remove(doc);
-            }
-        }
+        alive_bitset.intersect_with(seg_alive_bitset.bitset());
     }
 
     let num_alive_docs: u32 = alive_bitset.len() as u32;

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -165,7 +165,7 @@ pub(crate) fn advance_deletes(
     )?;
 
     if let Some(seg_alive_bitset) = segment_reader.alive_bitset() {
-        alive_bitset.intersect_with(seg_alive_bitset.bitset());
+        alive_bitset.intersect_update(seg_alive_bitset.bitset());
     }
 
     let num_alive_docs: u32 = alive_bitset.len() as u32;

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -167,6 +167,10 @@ impl IndexMerger {
     // will be merged with the existing bit set. Make sure the index
     // corresponds to the segment index.
     //
+    // If `None` is provided for custom alive set, the regular alive set will be used.
+    // If a delete_bitsets is provided, the union between the provided and regular
+    // alive set will be used.
+    //
     // This can be used to merge but also apply an additional filter.
     // One use case is demux, which is basically taking a list of
     // segments and partitions them e.g. by a value in a field.

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -10,7 +10,7 @@ use crate::fastfield::MultiValuedFastFieldReader;
 use crate::fieldnorm::FieldNormsSerializer;
 use crate::fieldnorm::FieldNormsWriter;
 use crate::fieldnorm::{FieldNormReader, FieldNormReaders};
-use crate::indexer::doc_id_mapping::SegmentDocidMapping;
+use crate::indexer::doc_id_mapping::SegmentDocIdMapping;
 use crate::indexer::SegmentSerializer;
 use crate::postings::Postings;
 use crate::postings::{InvertedIndexSerializer, SegmentPostings};
@@ -236,7 +236,7 @@ impl IndexMerger {
     fn write_fieldnorms(
         &self,
         mut fieldnorms_serializer: FieldNormsSerializer,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
     ) -> crate::Result<()> {
         let fields = FieldNormsWriter::fields_with_fieldnorm(&self.schema);
         let mut fieldnorms_data = Vec::with_capacity(self.max_doc as usize);
@@ -264,7 +264,7 @@ impl IndexMerger {
         &self,
         fast_field_serializer: &mut CompositeFastFieldSerializer,
         mut term_ord_mappings: HashMap<Field, TermOrdinalMapping>,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
     ) -> crate::Result<()> {
         debug_time!("write_fast_fields");
 
@@ -315,7 +315,7 @@ impl IndexMerger {
         &self,
         field: Field,
         fast_field_serializer: &mut CompositeFastFieldSerializer,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
     ) -> crate::Result<()> {
         let (min_value, max_value) = self.readers.iter().map(|reader|{
                 let u64_reader: DynamicFastFieldReader<u64> = reader
@@ -347,17 +347,17 @@ impl IndexMerger {
             num_vals: doc_id_mapping.len() as u64,
         };
         #[derive(Clone)]
-        struct SortedDocidFieldAccessProvider<'a> {
-            doc_id_mapping: &'a SegmentDocidMapping,
+        struct SortedDocIdFieldAccessProvider<'a> {
+            doc_id_mapping: &'a SegmentDocIdMapping,
             fast_field_readers: &'a Vec<DynamicFastFieldReader<u64>>,
         }
-        impl<'a> FastFieldDataAccess for SortedDocidFieldAccessProvider<'a> {
+        impl<'a> FastFieldDataAccess for SortedDocIdFieldAccessProvider<'a> {
             fn get_val(&self, doc: u64) -> u64 {
                 let (doc_id, reader_ordinal) = self.doc_id_mapping[doc as usize];
                 self.fast_field_readers[reader_ordinal as usize].get(doc_id)
             }
         }
-        let fastfield_accessor = SortedDocidFieldAccessProvider {
+        let fastfield_accessor = SortedDocIdFieldAccessProvider {
             doc_id_mapping,
             fast_field_readers: &fast_field_readers,
         };
@@ -439,7 +439,7 @@ impl IndexMerger {
     pub(crate) fn generate_doc_id_mapping(
         &self,
         sort_by_field: &IndexSortByField,
-    ) -> crate::Result<SegmentDocidMapping> {
+    ) -> crate::Result<SegmentDocIdMapping> {
         let reader_ordinal_and_field_accessors =
             self.get_reader_with_sort_field_accessor(sort_by_field)?;
         // Loading the field accessor on demand causes a 15x regression
@@ -482,7 +482,7 @@ impl IndexMerger {
                 })
                 .map(|(doc_id, reader_with_id, _)| (doc_id, reader_with_id)),
         );
-        Ok(SegmentDocidMapping::new(sorted_doc_ids, false))
+        Ok(SegmentDocIdMapping::new(sorted_doc_ids, false))
     }
 
     // Creating the index file to point into the data, generic over `BytesFastFieldReader` and
@@ -491,7 +491,7 @@ impl IndexMerger {
     fn write_1_n_fast_field_idx_generic<T: MultiValueLength>(
         field: Field,
         fast_field_serializer: &mut CompositeFastFieldSerializer,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
         reader_and_field_accessors: &[(&SegmentReader, T)],
     ) -> crate::Result<Vec<u64>> {
         let mut total_num_vals = 0u64;
@@ -550,7 +550,7 @@ impl IndexMerger {
         &self,
         field: Field,
         fast_field_serializer: &mut CompositeFastFieldSerializer,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
     ) -> crate::Result<Vec<u64>> {
         let reader_ordinal_and_field_accessors = self.readers.iter().map(|reader|{
             let u64s_reader: MultiValuedFastFieldReader<u64> = reader.fast_fields()
@@ -572,7 +572,7 @@ impl IndexMerger {
         field: Field,
         term_ordinal_mappings: &TermOrdinalMapping,
         fast_field_serializer: &mut CompositeFastFieldSerializer,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
     ) -> crate::Result<()> {
         debug_time!("write_hierarchical_facet_field");
 
@@ -621,7 +621,7 @@ impl IndexMerger {
 
     /// Creates a mapping if the segments are stacked. this is helpful to merge codelines between index
     /// sorting and the others
-    pub(crate) fn get_doc_id_from_concatenated_data(&self) -> crate::Result<SegmentDocidMapping> {
+    pub(crate) fn get_doc_id_from_concatenated_data(&self) -> crate::Result<SegmentDocIdMapping> {
         let total_num_new_docs = self
             .readers
             .iter()
@@ -641,13 +641,13 @@ impl IndexMerger {
                 })
                 .flatten(),
         );
-        Ok(SegmentDocidMapping::new(mapping, true))
+        Ok(SegmentDocIdMapping::new(mapping, true))
     }
     fn write_multi_fast_field(
         &self,
         field: Field,
         fast_field_serializer: &mut CompositeFastFieldSerializer,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
     ) -> crate::Result<()> {
         // Multifastfield consists in 2 fastfields.
         // The first serves as an index into the second one and is stricly increasing.
@@ -703,16 +703,16 @@ impl IndexMerger {
             min_value,
         };
 
-        struct SortedDocidMultiValueAccessProvider<'a> {
-            doc_id_mapping: &'a SegmentDocidMapping,
+        struct SortedDocIdMultiValueAccessProvider<'a> {
+            doc_id_mapping: &'a SegmentDocIdMapping,
             fast_field_readers: &'a Vec<MultiValuedFastFieldReader<u64>>,
             offsets: Vec<u64>,
         }
-        impl<'a> FastFieldDataAccess for SortedDocidMultiValueAccessProvider<'a> {
+        impl<'a> FastFieldDataAccess for SortedDocIdMultiValueAccessProvider<'a> {
             fn get_val(&self, pos: u64) -> u64 {
                 // use the offsets index to find the doc_id which will contain the position.
                 // the offsets are stricly increasing so we can do a simple search on it.
-                let new_docid = self
+                let new_doc_id = self
                     .offsets
                     .iter()
                     .position(|&offset| offset > pos)
@@ -720,10 +720,10 @@ impl IndexMerger {
                     - 1;
 
                 // now we need to find the position of `pos` in the multivalued bucket
-                let num_pos_covered_until_now = self.offsets[new_docid];
+                let num_pos_covered_until_now = self.offsets[new_doc_id];
                 let pos_in_values = pos - num_pos_covered_until_now;
 
-                let (old_doc_id, reader_ordinal) = self.doc_id_mapping[new_docid as usize];
+                let (old_doc_id, reader_ordinal) = self.doc_id_mapping[new_doc_id as usize];
                 let num_vals = self.fast_field_readers[reader_ordinal as usize].get_len(old_doc_id);
                 assert!(num_vals >= pos_in_values);
                 let mut vals = vec![];
@@ -732,7 +732,7 @@ impl IndexMerger {
                 vals[pos_in_values as usize]
             }
         }
-        let fastfield_accessor = SortedDocidMultiValueAccessProvider {
+        let fastfield_accessor = SortedDocIdMultiValueAccessProvider {
             doc_id_mapping,
             fast_field_readers: &ff_readers,
             offsets,
@@ -771,7 +771,7 @@ impl IndexMerger {
         &self,
         field: Field,
         fast_field_serializer: &mut CompositeFastFieldSerializer,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
     ) -> crate::Result<()> {
         let reader_and_field_accessors = self
             .readers
@@ -807,7 +807,7 @@ impl IndexMerger {
         field_type: &FieldType,
         serializer: &mut InvertedIndexSerializer,
         fieldnorm_reader: Option<FieldNormReader>,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
     ) -> crate::Result<Option<TermOrdinalMapping>> {
         debug_time!("write_postings_for_field");
         let mut positions_buffer: Vec<u32> = Vec::with_capacity(1_000);
@@ -846,8 +846,8 @@ impl IndexMerger {
                 segment_local_map
             })
             .collect();
-        for (new_doc_id, (old_doc_id, segment_ordinal)) in doc_id_mapping.iter().enumerate() {
-            let segment_map = &mut merged_doc_id_map[*segment_ordinal as usize];
+        for (new_doc_id, (old_doc_id, segment_ord)) in doc_id_mapping.iter().enumerate() {
+            let segment_map = &mut merged_doc_id_map[*segment_ord as usize];
             segment_map[*old_doc_id as usize] = Some(new_doc_id as DocId);
         }
 
@@ -889,7 +889,7 @@ impl IndexMerger {
             let mut total_doc_freq = 0;
 
             // Let's compute the list of non-empty posting lists
-            for (segment_ord, term_info) in merged_terms.current_segment_ordinals_and_term_infos() {
+            for (segment_ord, term_info) in merged_terms.current_segment_ords_and_term_infos() {
                 let segment_reader = &self.readers[segment_ord];
                 let inverted_index: &InvertedIndexReader = &*field_readers[segment_ord];
                 let segment_postings = inverted_index
@@ -939,9 +939,9 @@ impl IndexMerger {
                         // there is at least one document.
                         let term_freq = segment_postings.term_freq();
                         segment_postings.positions(&mut positions_buffer);
-                        // if doc_id_mapping exists, the docids are reordered, they are
+                        // if doc_id_mapping exists, the doc_ids are reordered, they are
                         // not just stacked. The field serializer expects monotonically increasing
-                        // docids, so we collect and sort them first, before writing.
+                        // doc_ids, so we collect and sort them first, before writing.
                         //
                         // I think this is not strictly necessary, it would be possible to
                         // avoid the loading into a vec via some form of kmerge, but then the merge
@@ -981,7 +981,7 @@ impl IndexMerger {
         &self,
         serializer: &mut InvertedIndexSerializer,
         fieldnorm_readers: FieldNormReaders,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
     ) -> crate::Result<HashMap<Field, TermOrdinalMapping>> {
         let mut term_ordinal_mappings = HashMap::new();
         for (field, field_entry) in self.schema.fields() {
@@ -1004,7 +1004,7 @@ impl IndexMerger {
     fn write_storable_fields(
         &self,
         store_writer: &mut StoreWriter,
-        doc_id_mapping: &SegmentDocidMapping,
+        doc_id_mapping: &SegmentDocIdMapping,
     ) -> crate::Result<()> {
         debug_time!("write_storable_fields");
 
@@ -1596,7 +1596,7 @@ mod tests {
 
     #[test]
     fn test_merge_facets_sort_asc() {
-        // In the merge case this will go through the docid mapping code
+        // In the merge case this will go through the doc_id mapping code
         test_merge_facets(
             Some(IndexSettings {
                 sort_by_field: Some(IndexSortByField {
@@ -1607,7 +1607,7 @@ mod tests {
             }),
             true,
         );
-        // In the merge case this will not go through the docid mapping code, because the data is
+        // In the merge case this will not go through the doc_id mapping code, because the data is
         // sorted and disjunct
         test_merge_facets(
             Some(IndexSettings {
@@ -1623,7 +1623,7 @@ mod tests {
 
     #[test]
     fn test_merge_facets_sort_desc() {
-        // In the merge case this will go through the docid mapping code
+        // In the merge case this will go through the doc_id mapping code
         test_merge_facets(
             Some(IndexSettings {
                 sort_by_field: Some(IndexSortByField {
@@ -1634,7 +1634,7 @@ mod tests {
             }),
             true,
         );
-        // In the merge case this will not go through the docid mapping code, because the data is
+        // In the merge case this will not go through the doc_id mapping code, because the data is
         // sorted and disjunct
         test_merge_facets(
             Some(IndexSettings {

--- a/src/indexer/merger_sorted_index_test.rs
+++ b/src/indexer/merger_sorted_index_test.rs
@@ -554,7 +554,7 @@ mod bench_sorted_index_merge {
                 .expect("Failed to find a reader for single fast field. This is a tantivy bug and it should never happen.");
                 (doc_id, reader, u64_reader)
             });
-            // add values in order of the new docids
+            // add values in order of the new doc_ids
             let mut val = 0;
             for (doc_id, _reader, field_reader) in sorted_doc_ids {
                 val = field_reader.get(*doc_id);
@@ -567,7 +567,7 @@ mod bench_sorted_index_merge {
         Ok(())
     }
     #[bench]
-    fn create_sorted_index_create_docid_mapping(b: &mut Bencher) -> crate::Result<()> {
+    fn create_sorted_index_create_doc_id_mapping(b: &mut Bencher) -> crate::Result<()> {
         let sort_by_field = IndexSortByField {
             field: "intval".to_string(),
             order: Order::Desc,

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -26,7 +26,7 @@ pub use self::prepared_commit::PreparedCommit;
 pub use self::segment_entry::SegmentEntry;
 pub use self::segment_manager::SegmentManager;
 pub use self::segment_serializer::SegmentSerializer;
-pub use self::segment_updater::merge_segments;
+pub use self::segment_updater::merge_indices;
 pub use self::segment_writer::SegmentWriter;
 
 /// Alias for the default merge policy, which is the `LogMergePolicy`.

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1,5 +1,6 @@
 pub mod delete_queue;
 
+pub mod demuxer;
 pub mod doc_id_mapping;
 mod doc_opstamp_mapping;
 pub mod index_writer;
@@ -26,6 +27,7 @@ pub use self::prepared_commit::PreparedCommit;
 pub use self::segment_entry::SegmentEntry;
 pub use self::segment_manager::SegmentManager;
 pub use self::segment_serializer::SegmentSerializer;
+pub use self::segment_updater::merge_filtered_segments;
 pub use self::segment_updater::merge_indices;
 pub use self::segment_writer::SegmentWriter;
 

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -7,6 +7,7 @@ use crate::core::SegmentId;
 use crate::core::SegmentMeta;
 use crate::core::META_FILEPATH;
 use crate::directory::{Directory, DirectoryClone, GarbageCollectionResult};
+use crate::fastfield::DeleteBitSet;
 use crate::indexer::delete_queue::DeleteCursor;
 use crate::indexer::index_writer::advance_deletes;
 use crate::indexer::merge_operation::MergeOperationInventory;
@@ -161,6 +162,26 @@ fn merge(
 #[doc(hidden)]
 pub fn merge_segments<Dir: Directory>(
     indices: &[Index],
+    output_directory: Dir,
+) -> crate::Result<Index> {
+    merge_filtered_segments(indices, vec![], output_directory)
+}
+
+/// Advanced: Merges a list of segments from different indices in a new index.
+///
+/// Returns `TantivyError` if the the indices list is empty or their
+/// schemas don't match.
+///
+/// `output_directory`: is assumed to be empty.
+///
+/// # Warning
+/// This function does NOT check or take the `IndexWriter` is running. It is not
+/// meant to work if you have an IndexWriter running for the origin indices, or
+/// the destination Index.
+#[doc(hidden)]
+pub fn merge_filtered_segments<Dir: Directory>(
+    indices: &[Index],
+    _filter_docids: Vec<DeleteBitSet>,
     output_directory: Dir,
 ) -> crate::Result<Index> {
     if indices.is_empty() {

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -194,7 +194,7 @@ pub fn merge_indices<Dir: Directory>(
 }
 
 /// Advanced: Merges a list of segments from different indices in a new index.
-/// Additional you can provide a delete bitset for each segment to ignore docids.
+/// Additional you can provide a delete bitset for each segment to ignore doc_ids.
 ///
 /// Returns `TantivyError` if the the indices list is empty or their
 /// schemas don't match.
@@ -209,7 +209,7 @@ pub fn merge_indices<Dir: Directory>(
 pub fn merge_filtered_segments<Dir: Directory>(
     segments: &[Segment],
     target_settings: IndexSettings,
-    filter_docids: Vec<Option<AliveBitSet>>,
+    filter_doc_ids: Vec<Option<AliveBitSet>>,
     output_directory: Dir,
 ) -> crate::Result<Index> {
     if segments.is_empty() {
@@ -243,7 +243,7 @@ pub fn merge_filtered_segments<Dir: Directory>(
         merged_index.schema(),
         merged_index.settings().clone(),
         &segments[..],
-        filter_docids,
+        filter_doc_ids,
     )?;
     let segment_serializer = SegmentSerializer::for_segment(merged_segment, true)?;
     let num_docs = merger.write(segment_serializer)?;
@@ -1051,7 +1051,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_docid_filter_in_merger() -> crate::Result<()> {
+    fn test_apply_doc_id_filter_in_merger() -> crate::Result<()> {
         let first_index = {
             let mut schema_builder = Schema::builder();
             let text_field = schema_builder.add_text_field("text", TEXT);
@@ -1089,8 +1089,8 @@ mod tests {
                 filter_segments,
             )?;
 
-            let docids_alive: Vec<_> = merger.readers[0].doc_ids_alive().collect();
-            assert_eq!(docids_alive, vec![0, 2]);
+            let doc_ids_alive: Vec<_> = merger.readers[0].doc_ids_alive().collect();
+            assert_eq!(doc_ids_alive, vec![0, 2]);
         }
 
         {
@@ -1108,8 +1108,8 @@ mod tests {
                 filter_segments,
             )?;
 
-            let docids_alive: Vec<_> = merger.readers[0].doc_ids_alive().collect();
-            assert_eq!(docids_alive, vec![0, 1, 2]);
+            let doc_ids_alive: Vec<_> = merger.readers[0].doc_ids_alive().collect();
+            assert_eq!(doc_ids_alive, vec![0, 1, 2]);
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,8 @@ pub use crate::core::{
 };
 pub use crate::core::{InvertedIndexReader, SegmentReader};
 pub use crate::directory::Directory;
+pub use crate::indexer::demuxer::*;
+pub use crate::indexer::merge_filtered_segments;
 pub use crate::indexer::merge_indices;
 pub use crate::indexer::operation::UserOperation;
 pub use crate::indexer::IndexWriter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub use crate::core::{
 };
 pub use crate::core::{InvertedIndexReader, SegmentReader};
 pub use crate::directory::Directory;
-pub use crate::indexer::merge_segments;
+pub use crate::indexer::merge_indices;
 pub use crate::indexer::operation::UserOperation;
 pub use crate::indexer::IndexWriter;
 pub use crate::postings::Postings;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -112,9 +112,9 @@ pub mod tests {
     #[test]
     fn test_doc_store_iter_with_delete_bug_1077() -> crate::Result<()> {
         // this will cover deletion of the first element in a checkpoint
-        let deleted_docids = (200..300).collect::<Vec<_>>();
+        let deleted_doc_ids = (200..300).collect::<Vec<_>>();
         let alive_bitset =
-            AliveBitSet::for_test_from_deleted_docs(&deleted_docids, NUM_DOCS as u32);
+            AliveBitSet::for_test_from_deleted_docs(&deleted_doc_ids, NUM_DOCS as u32);
 
         let path = Path::new("store");
         let directory = RamDirectory::create();

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -151,7 +151,7 @@ impl StoreReader {
         &'b self,
         alive_bitset: Option<&'a AliveBitSet>,
     ) -> impl Iterator<Item = crate::Result<OwnedBytes>> + 'b {
-        let last_docid = self
+        let last_doc_id = self
             .block_checkpoints()
             .last()
             .map(|checkpoint| checkpoint.doc_range.end)
@@ -164,7 +164,7 @@ impl StoreReader {
         let mut block_start_pos = 0;
         let mut num_skipped = 0;
         let mut reset_block_pos = false;
-        (0..last_docid)
+        (0..last_doc_id)
             .filter_map(move |doc_id| {
                 // filter_map is only used to resolve lifetime issues between the two closures on
                 // the outer variables

--- a/src/termdict/merger.rs
+++ b/src/termdict/merger.rs
@@ -77,7 +77,7 @@ impl<'a> TermMerger<'a> {
     /// This method may be called
     /// iff advance() has been called before
     /// and "true" was returned.
-    pub fn current_segment_ordinals_and_term_infos<'b: 'a>(
+    pub fn current_segment_ords_and_term_infos<'b: 'a>(
         &'b self,
     ) -> impl 'b + Iterator<Item = (usize, TermInfo)> {
         self.current_segment_and_term_ordinals


### PR DESCRIPTION
Add support for demux operation (Reorder data from a list of segments to a new list of segments) by leveraging custom delete bitsets on merging.

- add merge for DeleteBitSet, allow custom DeleteBitSet on merge
- forward delete bitsets on merge, add tests
- add demux operation