### PR TITLE
Add unit tests for tokenizers and filters

### DIFF
--- a/src/tokenizer/alphanum_only.rs
+++ b/src/tokenizer/alphanum_only.rs
@@ -61,3 +61,31 @@ impl<'a> TokenStream for AlphaNumOnlyFilterStream<'a> {
         self.tail.token_mut()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tokenizer::tests::assert_token;
+    use crate::tokenizer::{AlphaNumOnlyFilter, SimpleTokenizer, TextAnalyzer, Token};
+
+    #[test]
+    fn test_alphanum_only() {
+        let tokens = token_stream_helper("I am a cat. 我輩は猫である。(1906)");
+        assert_eq!(tokens.len(), 5);
+        assert_token(&tokens[0], 0, "I", 0, 1);
+        assert_token(&tokens[1], 1, "am", 2, 4);
+        assert_token(&tokens[2], 2, "a", 5, 6);
+        assert_token(&tokens[3], 3, "cat", 7, 10);
+        assert_token(&tokens[4], 5, "1906", 37, 41);
+    }
+
+    fn token_stream_helper(text: &str) -> Vec<Token> {
+        let a = TextAnalyzer::from(SimpleTokenizer).filter(AlphaNumOnlyFilter);
+        let mut token_stream = a.token_stream(text);
+        let mut tokens: Vec<Token> = vec![];
+        let mut add_token = |token: &Token| {
+            tokens.push(token.clone());
+        };
+        token_stream.process(&mut add_token);
+        tokens
+    }
+}

--- a/src/tokenizer/lower_caser.rs
+++ b/src/tokenizer/lower_caser.rs
@@ -56,31 +56,30 @@ impl<'a> TokenStream for LowerCaserTokenStream<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::tokenizer::{LowerCaser, SimpleTokenizer, TextAnalyzer};
+    use crate::tokenizer::tests::assert_token;
+    use crate::tokenizer::{LowerCaser, SimpleTokenizer, TextAnalyzer, Token};
 
     #[test]
     fn test_to_lower_case() {
-        assert_eq!(
-            lowercase_helper("Русский текст"),
-            vec!["русский".to_string(), "текст".to_string()]
-        );
+        let tokens = token_stream_helper("Tree");
+        assert_eq!(tokens.len(), 1);
+        assert_token(&tokens[0], 0, "tree", 0, 4);
+
+        let tokens = token_stream_helper("Русский текст");
+        assert_eq!(tokens.len(), 2);
+        assert_token(&tokens[0], 0, "русский", 0, 14);
+        assert_token(&tokens[1], 1, "текст", 15, 25);
     }
 
-    fn lowercase_helper(text: &str) -> Vec<String> {
-        let mut tokens = vec![];
+    fn token_stream_helper(text: &str) -> Vec<Token> {
         let mut token_stream = TextAnalyzer::from(SimpleTokenizer)
             .filter(LowerCaser)
             .token_stream(text);
-        while token_stream.advance() {
-            let token_text = token_stream.token().text.clone();
-            tokens.push(token_text);
-        }
+        let mut tokens = vec![];
+        let mut add_token = |token: &Token| {
+            tokens.push(token.clone());
+        };
+        token_stream.process(&mut add_token);
         tokens
-    }
-
-    #[test]
-    fn test_lowercaser() {
-        assert_eq!(lowercase_helper("Tree"), vec!["tree".to_string()]);
-        assert_eq!(lowercase_helper("Русский"), vec!["русский".to_string()]);
     }
 }

--- a/src/tokenizer/raw_tokenizer.rs
+++ b/src/tokenizer/raw_tokenizer.rs
@@ -42,3 +42,27 @@ impl TokenStream for RawTokenStream {
         &mut self.token
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tokenizer::tests::assert_token;
+    use crate::tokenizer::{RawTokenizer, TextAnalyzer, Token};
+
+    #[test]
+    fn test_raw_tokenizer() {
+        let tokens = token_stream_helper("Hello, happy tax payer!");
+        assert_eq!(tokens.len(), 1);
+        assert_token(&tokens[0], 0, "Hello, happy tax payer!", 0, 23);
+    }
+
+    fn token_stream_helper(text: &str) -> Vec<Token> {
+        let a = TextAnalyzer::from(RawTokenizer);
+        let mut token_stream = a.token_stream(text);
+        let mut tokens: Vec<Token> = vec![];
+        let mut add_token = |token: &Token| {
+            tokens.push(token.clone());
+        };
+        token_stream.process(&mut add_token);
+        tokens
+    }
+}

--- a/src/tokenizer/remove_long.rs
+++ b/src/tokenizer/remove_long.rs
@@ -70,3 +70,28 @@ impl<'a> TokenStream for RemoveLongFilterStream<'a> {
         self.tail.token_mut()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tokenizer::tests::assert_token;
+    use crate::tokenizer::{RemoveLongFilter, SimpleTokenizer, TextAnalyzer, Token};
+
+    #[test]
+    fn test_remove_long() {
+        let tokens = token_stream_helper("hello tantivy, happy searching!");
+        assert_eq!(tokens.len(), 2);
+        assert_token(&tokens[0], 0, "hello", 0, 5);
+        assert_token(&tokens[1], 2, "happy", 15, 20);
+    }
+
+    fn token_stream_helper(text: &str) -> Vec<Token> {
+        let a = TextAnalyzer::from(SimpleTokenizer).filter(RemoveLongFilter::limit(6));
+        let mut token_stream = a.token_stream(text);
+        let mut tokens: Vec<Token> = vec![];
+        let mut add_token = |token: &Token| {
+            tokens.push(token.clone());
+        };
+        token_stream.process(&mut add_token);
+        tokens
+    }
+}

--- a/src/tokenizer/simple_tokenizer.rs
+++ b/src/tokenizer/simple_tokenizer.rs
@@ -57,3 +57,30 @@ impl<'a> TokenStream for SimpleTokenStream<'a> {
         &mut self.token
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tokenizer::tests::assert_token;
+    use crate::tokenizer::{SimpleTokenizer, TextAnalyzer, Token};
+
+    #[test]
+    fn test_simple_tokenizer() {
+        let tokens = token_stream_helper("Hello, happy tax payer!");
+        assert_eq!(tokens.len(), 4);
+        assert_token(&tokens[0], 0, "Hello", 0, 5);
+        assert_token(&tokens[1], 1, "happy", 7, 12);
+        assert_token(&tokens[2], 2, "tax", 13, 16);
+        assert_token(&tokens[3], 3, "payer", 17, 22);
+    }
+
+    fn token_stream_helper(text: &str) -> Vec<Token> {
+        let a = TextAnalyzer::from(SimpleTokenizer);
+        let mut token_stream = a.token_stream(text);
+        let mut tokens: Vec<Token> = vec![];
+        let mut add_token = |token: &Token| {
+            tokens.push(token.clone());
+        };
+        token_stream.process(&mut add_token);
+        tokens
+    }
+}

--- a/src/tokenizer/stop_word_filter.rs
+++ b/src/tokenizer/stop_word_filter.rs
@@ -93,3 +93,37 @@ impl Default for StopWordFilter {
         StopWordFilter::english()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tokenizer::tests::assert_token;
+    use crate::tokenizer::{SimpleTokenizer, StopWordFilter, TextAnalyzer, Token};
+
+    #[test]
+    fn test_stop_word() {
+        let tokens = token_stream_helper("i am a cat. as yet i have no name.");
+        assert_eq!(tokens.len(), 5);
+        assert_token(&tokens[0], 3, "cat", 7, 10);
+        assert_token(&tokens[1], 5, "yet", 15, 18);
+        assert_token(&tokens[2], 7, "have", 21, 25);
+        assert_token(&tokens[3], 8, "no", 26, 28);
+        assert_token(&tokens[4], 9, "name", 29, 33);
+    }
+
+    fn token_stream_helper(text: &str) -> Vec<Token> {
+        let stops = vec![
+            "a".to_string(),
+            "as".to_string(),
+            "am".to_string(),
+            "i".to_string(),
+        ];
+        let a = TextAnalyzer::from(SimpleTokenizer).filter(StopWordFilter::remove(stops));
+        let mut token_stream = a.token_stream(text);
+        let mut tokens: Vec<Token> = vec![];
+        let mut add_token = |token: &Token| {
+            tokens.push(token.clone());
+        };
+        token_stream.process(&mut add_token);
+        tokens
+    }
+}

--- a/src/tokenizer/whitespace_tokenizer.rs
+++ b/src/tokenizer/whitespace_tokenizer.rs
@@ -57,3 +57,30 @@ impl<'a> TokenStream for WhitespaceTokenStream<'a> {
         &mut self.token
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tokenizer::tests::assert_token;
+    use crate::tokenizer::{TextAnalyzer, Token, WhitespaceTokenizer};
+
+    #[test]
+    fn test_whitespace_tokenizer() {
+        let tokens = token_stream_helper("Hello, happy tax payer!");
+        assert_eq!(tokens.len(), 4);
+        assert_token(&tokens[0], 0, "Hello,", 0, 6);
+        assert_token(&tokens[1], 1, "happy", 7, 12);
+        assert_token(&tokens[2], 2, "tax", 13, 16);
+        assert_token(&tokens[3], 3, "payer!", 17, 23);
+    }
+
+    fn token_stream_helper(text: &str) -> Vec<Token> {
+        let a = TextAnalyzer::from(WhitespaceTokenizer);
+        let mut token_stream = a.token_stream(text);
+        let mut tokens: Vec<Token> = vec![];
+        let mut add_token = |token: &Token| {
+            tokens.push(token.clone());
+        };
+        token_stream.process(&mut add_token);
+        tokens
+    }
+}


### PR DESCRIPTION
Some tokenizers/filters seem to have no unit test (e.g. SimpleTokenizer and StopWordFilter).
I think it would be nice to add basic tests for them for future development. To start with, I added a test module for SimpleTokenizer; does it make sense?