### PR TITLE
add index accessor for index writer

### DIFF
--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -348,6 +348,13 @@ impl IndexWriter {
         self.operation_sender = sender;
     }
 
+    /// Accessor to the index
+    ///
+    /// The index is actually cloned.
+    pub fn index(&self) -> Index {
+        self.index.clone()
+    }
+
     /// If there are some merging threads, blocks until they all finish their work and
     /// then drop the `IndexWriter`.
     pub fn wait_merging_threads(mut self) -> crate::Result<()> {

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -351,8 +351,8 @@ impl IndexWriter {
     /// Accessor to the index
     ///
     /// The index is actually cloned.
-    pub fn index(&self) -> Index {
-        self.index.clone()
+    pub fn index(&self) -> &Index {
+        &self.index
     }
 
     /// If there are some merging threads, blocks until they all finish their work and


### PR DESCRIPTION
I think it would be interesting to be able to access the Index from the IndexWriter. In my (specific) case, it is in particular to access the fields, from an index writer. Otherwise I don't have many ways to access it.