### PR TITLE
Optimize block wand for one and several TermScorer.

### DIFF
--- a/src/query/boolean_query/block_wand.rs
+++ b/src/query/boolean_query/block_wand.rs
@@ -231,7 +231,7 @@ pub fn block_wand_single_scorer(
         // the threshold.
         while scorer.block_max_score() < threshold {
             let last_doc_in_block = scorer.last_doc_in_block();
-            if doc == TERMINATED {
+            if last_doc_in_block == TERMINATED {
                 return;
             }
             doc = last_doc_in_block + 1;
@@ -247,7 +247,8 @@ pub fn block_wand_single_scorer(
             if score > threshold {
                 threshold = callback(doc, score);
             }
-            if doc >= scorer.last_doc_in_block() {
+            debug_assert!(doc <= scorer.last_doc_in_block());
+            if doc == scorer.last_doc_in_block() {
                 break;
             }
             doc = scorer.advance();

--- a/src/query/boolean_query/mod.rs
+++ b/src/query/boolean_query/mod.rs
@@ -3,6 +3,7 @@ mod boolean_query;
 mod boolean_weight;
 
 pub(crate) use self::block_wand::block_wand;
+pub(crate) use self::block_wand::block_wand_single_scorer;
 pub use self::boolean_query::BooleanQuery;
 
 #[cfg(test)]

--- a/src/query/term_query/term_weight.rs
+++ b/src/query/term_query/term_weight.rs
@@ -79,7 +79,7 @@ impl Weight for TermWeight {
         callback: &mut dyn FnMut(DocId, Score) -> Score,
     ) -> crate::Result<()> {
         let scorer = self.specialized_scorer(reader, 1.0)?;
-        crate::query::boolean_query::block_wand(vec![scorer], threshold, callback);
+        crate::query::boolean_query::block_wand_single_scorer(scorer, threshold, callback);
         Ok(())
     }
 }


### PR DESCRIPTION
I made some changes to your initial commit @fulmicoton 

- first, based on the [paper](http://engineering.nyu.edu/~suel/papers/bmw.pdf) of Ding and Suel I made a small change on the block wand algorithm. The function `block_max_was_too_low_advance_one_scorer` now takes the min of all last doc id scorers until the pivot scorer. Before, we were taking the `doc()` of the pivot scorer.
- secondly, I think there was a tiny bug in `block_max_was_too_low_advance_one_scorer`: we were doing `doc_to_seek_after + 1` even on scorer after the pivot. There is a very small probability to miss a document here, I think we should not add +1 in this case.
- thirdly, I updated the way the scorer to advance is chosen. Now we take the scorer which has the best score among scorers[..pivot_len].
- at last, I added the implementation for the case where we have one `TermScorer` because the code is simple and readable and the performance is far better (around x3 faster). With that, we are on par with Lucene.

I also created a branch with the benchmark results here: https://github.com/quickwit-inc/search-benchmark-game/tree/blockwand-for-termquery

I noticed that the performance is better on average and for union we have:
- Top 10 - UNION: 1,081 μs | 1,419 μs



