### PR TITLE
Fix the deserialization error of FieldEntry when the 'options' field …

### DIFF
--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -7,6 +7,7 @@ use crate::schema::Value;
 use crate::schema::{IntOptions, TextOptions};
 use crate::tokenizer::PreTokenizedString;
 use chrono::{FixedOffset, Utc};
+use serde::{Serialize, Deserialize};
 use serde_json::Value as JsonValue;
 
 /// Possible error that may occur while parsing a field value
@@ -48,9 +49,12 @@ pub enum Type {
 
 /// A `FieldType` describes the type (text, u64) of a field as well as
 /// how it should be handled by tantivy.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "options")]
+#[serde(rename_all = "snake_case")]
 pub enum FieldType {
     /// String field type configuration
+    #[serde(rename = "text")]
     Str(TextOptions),
     /// Unsigned 64-bits integers field type configuration
     U64(IntOptions),


### PR DESCRIPTION
Currently, FieldEntry deserialization is done manually by using a custom deserializer. During the parsing process, if  the "options" field appears before the "type" field, an error will occur.
Example of json on which the error occurs:
```
{
  "name": "title",
  "options": {
    "indexing": {
      "record": "position",
      "tokenizer": "default"
    },
    "stored": false
  },
  "type": "text"
}
```
This pull request changes the custom serializer to serde_derive macro, which fixes the described error.

