### PR TITLE
Add `none` compression

### DIFF
--- a/src/store/compressors.rs
+++ b/src/store/compressors.rs
@@ -53,7 +53,7 @@ impl Compressor {
     }
     pub(crate) fn get_id(&self) -> u8 {
         match self {
-            Compressor::NoOp => 0,
+            Self::NoOp => 0,
             Self::Lz4 => 1,
             Self::Brotli => 2,
             Self::Snappy => 3,

--- a/src/store/compressors.rs
+++ b/src/store/compressors.rs
@@ -63,7 +63,7 @@ impl Compressor {
     pub(crate) fn compress(&self, uncompressed: &[u8], compressed: &mut Vec<u8>) -> io::Result<()> {
         match self {
             Self::None => {
-                debug_assert!(compressed.is_empty());
+                compressed.clear();
                 compressed.extend_from_slice(uncompressed);
                 Ok(())
             }
@@ -108,7 +108,7 @@ impl Compressor {
     ) -> io::Result<()> {
         match self {
             Self::None => {
-                debug_assert!(decompressed.is_empty());
+                decompressed.clear();
                 decompressed.extend_from_slice(compressed);
                 Ok(())
             }

--- a/src/store/compressors.rs
+++ b/src/store/compressors.rs
@@ -13,6 +13,9 @@ pub trait StoreCompressor {
 /// The default is Lz4Block, but also depends on the enabled feature flags.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Compressor {
+    #[serde(rename = "noop")]
+    /// No-op compressor
+    NoOp,
     #[serde(rename = "lz4")]
     /// Use the lz4 compressor (block format)
     Lz4,
@@ -33,9 +36,7 @@ impl Default for Compressor {
         } else if cfg!(feature = "snappy-compression") {
             Compressor::Snappy
         } else {
-            panic!(
-                "all compressor feature flags like are disabled (e.g. lz4-compression), can't choose default compressor"
-            );
+            Compressor::NoOp
         }
     }
 }
@@ -43,6 +44,7 @@ impl Default for Compressor {
 impl Compressor {
     pub(crate) fn from_id(id: u8) -> Compressor {
         match id {
+            0 => Compressor::NoOp,
             1 => Compressor::Lz4,
             2 => Compressor::Brotli,
             3 => Compressor::Snappy,
@@ -51,6 +53,7 @@ impl Compressor {
     }
     pub(crate) fn get_id(&self) -> u8 {
         match self {
+            Compressor::NoOp => 0,
             Self::Lz4 => 1,
             Self::Brotli => 2,
             Self::Snappy => 3,
@@ -59,6 +62,11 @@ impl Compressor {
     #[inline]
     pub(crate) fn compress(&self, uncompressed: &[u8], compressed: &mut Vec<u8>) -> io::Result<()> {
         match self {
+            Self::NoOp => {
+                debug_assert!(compressed.is_empty());
+                compressed.extend_from_slice(uncompressed);
+                Ok(())
+            }
             Self::Lz4 => {
                 #[cfg(feature = "lz4-compression")]
                 {
@@ -99,6 +107,11 @@ impl Compressor {
         decompressed: &mut Vec<u8>,
     ) -> io::Result<()> {
         match self {
+            Self::NoOp => {
+                debug_assert!(decompressed.is_empty());
+                decompressed.extend_from_slice(compressed);
+                Ok(())
+            }
             Self::Lz4 => {
                 #[cfg(feature = "lz4-compression")]
                 {

--- a/src/store/compressors.rs
+++ b/src/store/compressors.rs
@@ -13,9 +13,9 @@ pub trait StoreCompressor {
 /// The default is Lz4Block, but also depends on the enabled feature flags.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Compressor {
-    #[serde(rename = "noop")]
-    /// No-op compressor
-    NoOp,
+    #[serde(rename = "none")]
+    /// No compression
+    None,
     #[serde(rename = "lz4")]
     /// Use the lz4 compressor (block format)
     Lz4,
@@ -36,7 +36,7 @@ impl Default for Compressor {
         } else if cfg!(feature = "snappy-compression") {
             Compressor::Snappy
         } else {
-            Compressor::NoOp
+            Compressor::None
         }
     }
 }
@@ -44,7 +44,7 @@ impl Default for Compressor {
 impl Compressor {
     pub(crate) fn from_id(id: u8) -> Compressor {
         match id {
-            0 => Compressor::NoOp,
+            0 => Compressor::None,
             1 => Compressor::Lz4,
             2 => Compressor::Brotli,
             3 => Compressor::Snappy,
@@ -53,7 +53,7 @@ impl Compressor {
     }
     pub(crate) fn get_id(&self) -> u8 {
         match self {
-            Self::NoOp => 0,
+            Self::None => 0,
             Self::Lz4 => 1,
             Self::Brotli => 2,
             Self::Snappy => 3,
@@ -62,7 +62,7 @@ impl Compressor {
     #[inline]
     pub(crate) fn compress(&self, uncompressed: &[u8], compressed: &mut Vec<u8>) -> io::Result<()> {
         match self {
-            Self::NoOp => {
+            Self::None => {
                 debug_assert!(compressed.is_empty());
                 compressed.extend_from_slice(uncompressed);
                 Ok(())
@@ -107,7 +107,7 @@ impl Compressor {
         decompressed: &mut Vec<u8>,
     ) -> io::Result<()> {
         match self {
-            Self::NoOp => {
+            Self::None => {
                 debug_assert!(decompressed.is_empty());
                 decompressed.extend_from_slice(compressed);
                 Ok(())

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -183,6 +183,10 @@ pub mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_store_noop() -> crate::Result<()> {
+        test_store(Compressor::NoOp)
+    }
     #[cfg(feature = "lz4-compression")]
     #[test]
     fn test_store_lz4_block() -> crate::Result<()> {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -185,7 +185,7 @@ pub mod tests {
 
     #[test]
     fn test_store_noop() -> crate::Result<()> {
-        test_store(Compressor::NoOp)
+        test_store(Compressor::None)
     }
     #[cfg(feature = "lz4-compression")]
     #[test]


### PR DESCRIPTION
If none of the `{lz4,brotli,snappy}-compression` feature flags are present, `Compressor::None` is used.

It just copies the input slice to destination vector. The copy may be avoidable with some `Compressor` API changes, but left to a future optimization if it's even worthwhile - someone exercising the docstore will probably enable compression.