### PR TITLE
canonicalize path when opening `MmapDirectory`

### DIFF
--- a/src/directory/error.rs
+++ b/src/directory/error.rs
@@ -42,7 +42,10 @@ pub enum OpenDirectoryError {
 impl OpenDirectoryError {
     /// Wraps an io error.
     pub fn wrap_io_error(io_error: io::Error, directory_path: PathBuf) -> Self {
-        Self::IoError { io_error, directory_path }
+        Self::IoError {
+            io_error,
+            directory_path,
+        }
     }
 }
 

--- a/src/directory/error.rs
+++ b/src/directory/error.rs
@@ -39,6 +39,13 @@ pub enum OpenDirectoryError {
     },
 }
 
+impl OpenDirectoryError {
+    /// Wraps an io error.
+    pub fn wrap_io_error(io_error: io::Error, directory_path: PathBuf) -> Self {
+        Self::IoError { io_error, directory_path }
+    }
+}
+
 /// Error that may occur when starting to write in a file
 #[derive(Debug, Error)]
 pub enum OpenWriteError {

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -196,7 +196,7 @@ impl MmapDirectory {
             |io_err| OpenDirectoryError::wrap_io_error(io_err, PathBuf::from(directory_path))
         )?;
         if !canonical_path.exists() {
-            Err(OpenDirectoryError::DoesNotExist(PathBuf::from(
+            return Err(OpenDirectoryError::DoesNotExist(PathBuf::from(
                 directory_path,
             )))
         } else if !canonical_path.is_dir() {

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -192,17 +192,19 @@ impl MmapDirectory {
     /// exist or if it is not a directory.
     pub fn open<P: AsRef<Path>>(directory_path: P) -> Result<MmapDirectory, OpenDirectoryError> {
         let directory_path: &Path = directory_path.as_ref();
-        if !directory_path.exists() {
+        let canonical_path: PathBuf = directory_path.canonicalize().map_err(
+            |io_err| OpenDirectoryError::wrap_io_error(io_err, PathBuf::from(directory_path))
+        )?;
+        if !canonical_path.exists() {
             Err(OpenDirectoryError::DoesNotExist(PathBuf::from(
                 directory_path,
             )))
-        } else if !directory_path.is_dir() {
+        } else if !canonical_path.is_dir() {
             Err(OpenDirectoryError::NotADirectory(PathBuf::from(
                 directory_path,
             )))
-        } else {
-            Ok(MmapDirectory::new(PathBuf::from(directory_path), None))
         }
+        Ok(MmapDirectory::new(canonical_path, None))
     }
 
     /// Joins a relative_path to the directory `root_path`

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -199,10 +199,11 @@ impl MmapDirectory {
             return Err(OpenDirectoryError::DoesNotExist(PathBuf::from(
                 directory_path,
             )))
-        } else if !canonical_path.is_dir() {
-            Err(OpenDirectoryError::NotADirectory(PathBuf::from(
+        }
+        if !canonical_path.is_dir() {
+            return Err(OpenDirectoryError::NotADirectory(PathBuf::from(
                 directory_path,
-            )))
+            )));
         }
         Ok(MmapDirectory::new(canonical_path, None))
     }

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -192,14 +192,14 @@ impl MmapDirectory {
     /// exist or if it is not a directory.
     pub fn open<P: AsRef<Path>>(directory_path: P) -> Result<MmapDirectory, OpenDirectoryError> {
         let directory_path: &Path = directory_path.as_ref();
-        let canonical_path: PathBuf = directory_path.canonicalize().map_err(|io_err| {
-            OpenDirectoryError::wrap_io_error(io_err, PathBuf::from(directory_path))
-        })?;
-        if !canonical_path.exists() {
+        if !directory_path.exists() {
             return Err(OpenDirectoryError::DoesNotExist(PathBuf::from(
                 directory_path,
             )));
         }
+        let canonical_path: PathBuf = directory_path.canonicalize().map_err(|io_err| {
+            OpenDirectoryError::wrap_io_error(io_err, PathBuf::from(directory_path))
+        })?;
         if !canonical_path.is_dir() {
             return Err(OpenDirectoryError::NotADirectory(PathBuf::from(
                 directory_path,

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -192,13 +192,13 @@ impl MmapDirectory {
     /// exist or if it is not a directory.
     pub fn open<P: AsRef<Path>>(directory_path: P) -> Result<MmapDirectory, OpenDirectoryError> {
         let directory_path: &Path = directory_path.as_ref();
-        let canonical_path: PathBuf = directory_path.canonicalize().map_err(
-            |io_err| OpenDirectoryError::wrap_io_error(io_err, PathBuf::from(directory_path))
-        )?;
+        let canonical_path: PathBuf = directory_path.canonicalize().map_err(|io_err| {
+            OpenDirectoryError::wrap_io_error(io_err, PathBuf::from(directory_path))
+        })?;
         if !canonical_path.exists() {
             return Err(OpenDirectoryError::DoesNotExist(PathBuf::from(
                 directory_path,
-            )))
+            )));
         }
         if !canonical_path.is_dir() {
             return Err(OpenDirectoryError::NotADirectory(PathBuf::from(


### PR DESCRIPTION
fixes #1229



- [x] test on linux box
- [ ] factorise `wrap_io_error`s in a trait ?