### PR TITLE
Levenshtein distance score with custom score function (POC for #998)

### DIFF
--- a/src/query/automaton_weight.rs
+++ b/src/query/automaton_weight.rs
@@ -1,5 +1,5 @@
 use crate::core::SegmentReader;
-use crate::query::fuzzy_query::DFAWrapper;
+use crate::query::fuzzy_query::DfaWrapper;
 use crate::query::score_combiner::SumCombiner;
 use crate::query::Explanation;
 use crate::query::{ConstScorer, Union};
@@ -8,7 +8,6 @@ use crate::schema::{Field, IndexRecordOption};
 use crate::termdict::{TermDictionary, TermWithStateStreamer};
 use crate::TantivyError;
 use crate::{DocId, Score};
-use common::BitSet;
 use std::any::{Any, TypeId};
 use std::io;
 use std::sync::Arc;
@@ -88,8 +87,8 @@ where
     A::State: Clone,
     F: Fn(u8) -> f32,
 {
-    if TypeId::of::<DFAWrapper>() == automaton.type_id() && TypeId::of::<u32>() == state.type_id() {
-        let dfa = automaton as *const A as *const DFAWrapper;
+    if TypeId::of::<DfaWrapper>() == automaton.type_id() && TypeId::of::<u32>() == state.type_id() {
+        let dfa = automaton as *const A as *const DfaWrapper;
         let dfa = unsafe { &*dfa };
 
         let id = &state as *const A::State as *const u32;
@@ -162,7 +161,7 @@ mod tests {
     fn test_automaton_weight() -> crate::Result<()> {
         let index = create_index()?;
         let field = index.schema().get_field("title").unwrap();
-        let automaton_weight = AutomatonWeight::new(field, PrefixedByA);
+        let automaton_weight = AutomatonWeight::new(field, PrefixedByA, |_| 1.0);
         let reader = index.reader()?;
         let searcher = reader.searcher();
         let mut scorer = automaton_weight.scorer(searcher.segment_reader(0u32), 1.0)?;
@@ -179,7 +178,7 @@ mod tests {
     fn test_automaton_weight_boost() -> crate::Result<()> {
         let index = create_index()?;
         let field = index.schema().get_field("title").unwrap();
-        let automaton_weight = AutomatonWeight::new(field, PrefixedByA);
+        let automaton_weight = AutomatonWeight::new(field, PrefixedByA, |_| 1.0);
         let reader = index.reader()?;
         let searcher = reader.searcher();
         let mut scorer = automaton_weight.scorer(searcher.segment_reader(0u32), 1.32)?;

--- a/src/query/automaton_weight.rs
+++ b/src/query/automaton_weight.rs
@@ -3,7 +3,7 @@ use crate::query::ConstScorer;
 use crate::query::{BitSetDocSet, Explanation};
 use crate::query::{Scorer, Weight};
 use crate::schema::{Field, IndexRecordOption};
-use crate::termdict::{TermDictionary, TermStreamer};
+use crate::termdict::{TermDictionary, TermWithStateStreamer};
 use crate::TantivyError;
 use crate::{DocId, Score};
 use common::BitSet;
@@ -33,9 +33,9 @@ where
     fn automaton_stream<'a>(
         &'a self,
         term_dict: &'a TermDictionary,
-    ) -> io::Result<TermStreamer<'a, &'a A>> {
+    ) -> io::Result<TermWithStateStreamer<'a, &'a A>> {
         let automaton: &A = &*self.automaton;
-        let term_stream_builder = term_dict.search(automaton);
+        let term_stream_builder = term_dict.search_with_state(automaton);
         term_stream_builder.into_stream()
     }
 }
@@ -51,8 +51,7 @@ where
         let inverted_index = reader.inverted_index(self.field)?;
         let term_dict = inverted_index.terms();
         let mut term_stream = self.automaton_stream(term_dict)?;
-        while term_stream.advance() {
-            let term_info = term_stream.value();
+        while let Some((_term, term_info, _state)) = term_stream.next() {
             let mut block_segment_postings = inverted_index
                 .read_block_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
             loop {

--- a/src/query/automaton_weight.rs
+++ b/src/query/automaton_weight.rs
@@ -4,7 +4,7 @@ use crate::query::ConstScorer;
 use crate::query::{BitSetDocSet, Explanation};
 use crate::query::{Scorer, Weight};
 use crate::schema::{Field, IndexRecordOption};
-use crate::termdict::{TermDictionary, TermStreamer};
+use crate::termdict::{TermDictionary, TermWithStateStreamer};
 use crate::TantivyError;
 use crate::{DocId, Score};
 use std::io;
@@ -33,9 +33,9 @@ where
     fn automaton_stream<'a>(
         &'a self,
         term_dict: &'a TermDictionary,
-    ) -> io::Result<TermStreamer<'a, &'a A>> {
+    ) -> io::Result<TermWithStateStreamer<'a, &'a A>> {
         let automaton: &A = &*self.automaton;
-        let term_stream_builder = term_dict.search(automaton);
+        let term_stream_builder = term_dict.search_with_state(automaton);
         term_stream_builder.into_stream()
     }
 }
@@ -51,8 +51,7 @@ where
         let inverted_index = reader.inverted_index(self.field)?;
         let term_dict = inverted_index.terms();
         let mut term_stream = self.automaton_stream(term_dict)?;
-        while term_stream.advance() {
-            let term_info = term_stream.value();
+        while let Some((_term, term_info, _state)) = term_stream.next() {
             let mut block_segment_postings = inverted_index
                 .read_block_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
             loop {

--- a/src/query/automaton_weight.rs
+++ b/src/query/automaton_weight.rs
@@ -15,21 +15,24 @@ use std::sync::Arc;
 use tantivy_fst::Automaton;
 
 /// A weight struct for Fuzzy Term and Regex Queries
-pub struct AutomatonWeight<A> {
+pub struct AutomatonWeight<A, F> {
     field: Field,
     automaton: Arc<A>,
+    score_fn: F,
 }
 
-impl<A> AutomatonWeight<A>
+impl<A, F> AutomatonWeight<A, F>
 where
     A: Automaton + Send + Sync + 'static,
     A::State: Clone,
+    F: Fn(u8) -> f32,
 {
     /// Create a new AutomationWeight
-    pub fn new<IntoArcA: Into<Arc<A>>>(field: Field, automaton: IntoArcA) -> AutomatonWeight<A> {
+    pub fn new<IntoArcA: Into<Arc<A>>>(field: Field, automaton: IntoArcA, score_fn: F) -> AutomatonWeight<A, F> {
         AutomatonWeight {
             field,
             automaton: automaton.into(),
+            score_fn,
         }
     }
 
@@ -43,10 +46,11 @@ where
     }
 }
 
-impl<A> Weight for AutomatonWeight<A>
+impl<A, F> Weight for AutomatonWeight<A, F>
 where
     A: Automaton + Send + Sync + 'static,
     A::State: Clone,
+    F: Fn(u8) -> f32 + Send + Sync + 'static,
 {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
         let inverted_index = reader.inverted_index(self.field)?;
@@ -55,7 +59,7 @@ where
 
         let mut scorers = vec![];
         while let Some((_term, term_info, state)) = term_stream.next() {
-            let score = automaton_score(self.automaton.as_ref(), state);
+            let score = automaton_score(self.automaton.as_ref(), state, &self.score_fn);
             let segment_postings =
                 inverted_index.read_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
             let scorer = ConstScorer::new(segment_postings, boost * score);
@@ -78,10 +82,11 @@ where
     }
 }
 
-fn automaton_score<A>(automaton: &A, state: A::State) -> f32
+fn automaton_score<A, F>(automaton: &A, state: A::State, score_fn: F) -> f32
 where
     A: Automaton + Send + Sync + 'static,
     A::State: Clone,
+    F: Fn(u8) -> f32,
 {
     if TypeId::of::<DFAWrapper>() == automaton.type_id() && TypeId::of::<u32>() == state.type_id() {
         let dfa = automaton as *const A as *const DFAWrapper;
@@ -90,8 +95,8 @@ where
         let id = &state as *const A::State as *const u32;
         let id = unsafe { *id };
 
-        let dist = dfa.0.distance(id).to_u8() as f32;
-        1.0 / (1.0 + dist)
+        let dist = dfa.0.distance(id).to_u8();
+        score_fn(dist)
     } else {
         1.0
     }

--- a/src/query/automaton_weight.rs
+++ b/src/query/automaton_weight.rs
@@ -1,12 +1,15 @@
 use crate::core::SegmentReader;
-use crate::query::ConstScorer;
-use crate::query::{BitSetDocSet, Explanation};
+use crate::query::fuzzy_query::DFAWrapper;
+use crate::query::score_combiner::SumCombiner;
+use crate::query::Explanation;
+use crate::query::{ConstScorer, Union};
 use crate::query::{Scorer, Weight};
 use crate::schema::{Field, IndexRecordOption};
 use crate::termdict::{TermDictionary, TermWithStateStreamer};
 use crate::TantivyError;
 use crate::{DocId, Score};
 use common::BitSet;
+use std::any::{Any, TypeId};
 use std::io;
 use std::sync::Arc;
 use tantivy_fst::Automaton;
@@ -46,39 +49,51 @@ where
     A::State: Clone,
 {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
-        let max_doc = reader.max_doc();
-        let mut doc_bitset = BitSet::with_max_value(max_doc);
         let inverted_index = reader.inverted_index(self.field)?;
         let term_dict = inverted_index.terms();
         let mut term_stream = self.automaton_stream(term_dict)?;
-        while let Some((_term, term_info, _state)) = term_stream.next() {
-            let mut block_segment_postings = inverted_index
-                .read_block_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
-            loop {
-                let docs = block_segment_postings.docs();
-                if docs.is_empty() {
-                    break;
-                }
-                for &doc in docs {
-                    doc_bitset.insert(doc);
-                }
-                block_segment_postings.advance();
-            }
+
+        let mut scorers = vec![];
+        while let Some((_term, term_info, state)) = term_stream.next() {
+            let score = automaton_score(self.automaton.as_ref(), state);
+            let segment_postings =
+                inverted_index.read_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
+            let scorer = ConstScorer::new(segment_postings, boost * score);
+            scorers.push(scorer);
         }
-        let doc_bitset = BitSetDocSet::from(doc_bitset);
-        let const_scorer = ConstScorer::new(doc_bitset, boost);
-        Ok(Box::new(const_scorer))
+
+        let scorer = Union::<_, SumCombiner>::from(scorers);
+        Ok(Box::new(scorer))
     }
 
     fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation> {
         let mut scorer = self.scorer(reader, 1.0)?;
         if scorer.seek(doc) == doc {
-            Ok(Explanation::new("AutomatonScorer", 1.0))
+            Ok(Explanation::new("AutomatonScorer", scorer.score()))
         } else {
             Err(TantivyError::InvalidArgument(
                 "Document does not exist".to_string(),
             ))
         }
+    }
+}
+
+fn automaton_score<A>(automaton: &A, state: A::State) -> f32
+where
+    A: Automaton + Send + Sync + 'static,
+    A::State: Clone,
+{
+    if TypeId::of::<DFAWrapper>() == automaton.type_id() && TypeId::of::<u32>() == state.type_id() {
+        let dfa = automaton as *const A as *const DFAWrapper;
+        let dfa = unsafe { &*dfa };
+
+        let id = &state as *const A::State as *const u32;
+        let id = unsafe { *id };
+
+        let dist = dfa.0.distance(id).to_u8() as f32;
+        1.0 / (1.0 + dist)
+    } else {
+        1.0
     }
 }
 

--- a/src/query/automaton_weight.rs
+++ b/src/query/automaton_weight.rs
@@ -1,12 +1,14 @@
-use crate::common::BitSet;
 use crate::core::SegmentReader;
-use crate::query::ConstScorer;
-use crate::query::{BitSetDocSet, Explanation};
+use crate::query::fuzzy_query::DFAWrapper;
+use crate::query::score_combiner::SumCombiner;
+use crate::query::Explanation;
+use crate::query::{ConstScorer, Union};
 use crate::query::{Scorer, Weight};
 use crate::schema::{Field, IndexRecordOption};
 use crate::termdict::{TermDictionary, TermWithStateStreamer};
 use crate::TantivyError;
 use crate::{DocId, Score};
+use std::any::{Any, TypeId};
 use std::io;
 use std::sync::Arc;
 use tantivy_fst::Automaton;
@@ -46,39 +48,51 @@ where
     A::State: Clone,
 {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
-        let max_doc = reader.max_doc();
-        let mut doc_bitset = BitSet::with_max_value(max_doc);
         let inverted_index = reader.inverted_index(self.field)?;
         let term_dict = inverted_index.terms();
         let mut term_stream = self.automaton_stream(term_dict)?;
-        while let Some((_term, term_info, _state)) = term_stream.next() {
-            let mut block_segment_postings = inverted_index
-                .read_block_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
-            loop {
-                let docs = block_segment_postings.docs();
-                if docs.is_empty() {
-                    break;
-                }
-                for &doc in docs {
-                    doc_bitset.insert(doc);
-                }
-                block_segment_postings.advance();
-            }
+
+        let mut scorers = vec![];
+        while let Some((_term, term_info, state)) = term_stream.next() {
+            let score = automaton_score(self.automaton.as_ref(), state);
+            let segment_postings =
+                inverted_index.read_postings_from_terminfo(term_info, IndexRecordOption::Basic)?;
+            let scorer = ConstScorer::new(segment_postings, boost * score);
+            scorers.push(scorer);
         }
-        let doc_bitset = BitSetDocSet::from(doc_bitset);
-        let const_scorer = ConstScorer::new(doc_bitset, boost);
-        Ok(Box::new(const_scorer))
+
+        let scorer = Union::<_, SumCombiner>::from(scorers);
+        Ok(Box::new(scorer))
     }
 
     fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation> {
         let mut scorer = self.scorer(reader, 1.0)?;
         if scorer.seek(doc) == doc {
-            Ok(Explanation::new("AutomatonScorer", 1.0))
+            Ok(Explanation::new("AutomatonScorer", scorer.score()))
         } else {
             Err(TantivyError::InvalidArgument(
                 "Document does not exist".to_string(),
             ))
         }
+    }
+}
+
+fn automaton_score<A>(automaton: &A, state: A::State) -> f32
+where
+    A: Automaton + Send + Sync + 'static,
+    A::State: Clone,
+{
+    if TypeId::of::<DFAWrapper>() == automaton.type_id() && TypeId::of::<u32>() == state.type_id() {
+        let dfa = automaton as *const A as *const DFAWrapper;
+        let dfa = unsafe { &*dfa };
+
+        let id = &state as *const A::State as *const u32;
+        let id = unsafe { *id };
+
+        let dist = dfa.0.distance(id).to_u8() as f32;
+        1.0 / (1.0 + dist)
+    } else {
+        1.0
     }
 }
 

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -199,7 +199,7 @@ mod test {
                 .unwrap();
             assert_eq!(top_docs.len(), 1, "Expected only 1 document");
             let (score, _) = top_docs[0];
-            assert_nearly_equals!(1.0, score);
+            assert_nearly_equals!(0.5, score);
         }
 
         // fails because non-prefix Levenshtein distance is more than 1 (add 'a' and 'n')

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -5,6 +5,7 @@ use crate::TantivyError::InvalidArgument;
 use levenshtein_automata::{Distance, LevenshteinAutomatonBuilder, DFA};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
 use std::ops::Range;
 use tantivy_fst::Automaton;
 
@@ -94,8 +95,8 @@ static LEV_BUILDER: Lazy<HashMap<(u8, bool), LevenshteinAutomatonBuilder>> = Laz
 /// }
 /// # assert!(example().is_ok());
 /// ```
-#[derive(Debug, Clone)]
-pub struct FuzzyTermQuery {
+#[derive(Clone)]
+pub struct FuzzyTermQuery<F> {
     /// What term are we searching
     term: Term,
     /// How many changes are we going to allow
@@ -104,30 +105,70 @@ pub struct FuzzyTermQuery {
     transposition_cost_one: bool,
     ///
     prefix: bool,
+    /// The function to score the term by (taking the distance and returning the score).
+    score_fn: F,
 }
 
-impl FuzzyTermQuery {
+impl<F> Debug for FuzzyTermQuery<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FuzzyTermQuery")
+            .field("term", &self.term)
+            .field("distance", &self.distance)
+            .field("transposition_cost_one", &self.transposition_cost_one)
+            .field("prefix", &self.prefix)
+            .finish()
+    }
+}
+
+pub(crate) fn default_score(distance: u8) -> f32 {
+    // This uses the constant's end to ensure that this code will be updated if the range is too
+    const WEIGHTS: [f32; VALID_LEVENSHTEIN_DISTANCE_RANGE.end as usize] = [1.0, 0.5, 1.0 / 3.0];
+    WEIGHTS[distance as usize]
+}
+
+impl FuzzyTermQuery<fn(u8) -> f32> {
     /// Creates a new Fuzzy Query
-    pub fn new(term: Term, distance: u8, transposition_cost_one: bool) -> FuzzyTermQuery {
+    pub fn new(term: Term, distance: u8, transposition_cost_one: bool) -> Self<> {
         FuzzyTermQuery {
             term,
             distance,
             transposition_cost_one,
             prefix: false,
+            score_fn: default_score,
         }
     }
 
     /// Creates a new Fuzzy Query of the Term prefix
-    pub fn new_prefix(term: Term, distance: u8, transposition_cost_one: bool) -> FuzzyTermQuery {
+    pub fn new_prefix(term: Term, distance: u8, transposition_cost_one: bool) -> Self<> {
         FuzzyTermQuery {
             term,
             distance,
             transposition_cost_one,
             prefix: true,
+            score_fn: default_score,
+        }
+    }
+}
+
+impl<F: Fn(u8) -> f32 + Clone> FuzzyTermQuery<F> {
+    /// Creates a new Fuzzy Query with a custom score function
+    pub fn new_score_fn(
+        term: Term,
+        distance: u8,
+        transposition_cost_one: bool,
+        prefix: bool,
+        score_fn: F
+    ) -> Self {
+        FuzzyTermQuery {
+            term,
+            distance,
+            transposition_cost_one,
+            prefix,
+            score_fn,
         }
     }
 
-    fn specialized_weight(&self) -> crate::Result<AutomatonWeight<DFAWrapper>> {
+    fn specialized_weight(&self) -> crate::Result<AutomatonWeight<DFAWrapper, F>> {
         // LEV_BUILDER is a HashMap, whose `get` method returns an Option
         match LEV_BUILDER.get(&(self.distance, false)) {
             // Unwrap the option and build the Ok(AutomatonWeight)
@@ -140,6 +181,7 @@ impl FuzzyTermQuery {
                 Ok(AutomatonWeight::new(
                     self.term.field(),
                     DFAWrapper(automaton),
+                    self.score_fn.clone(),
                 ))
             }
             None => Err(InvalidArgument(format!(
@@ -150,7 +192,9 @@ impl FuzzyTermQuery {
     }
 }
 
-impl Query for FuzzyTermQuery {
+impl<F> Query for FuzzyTermQuery<F>
+    where F: Fn(u8) -> f32 + Send + Sync + 'static + Clone,
+{
     fn weight(
         &self,
         _searcher: &Searcher,

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -5,6 +5,7 @@ use crate::TantivyError::InvalidArgument;
 use levenshtein_automata::{Distance, LevenshteinAutomatonBuilder, DFA};
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
 use std::ops::Range;
 use tantivy_fst::Automaton;
 
@@ -94,8 +95,8 @@ static LEV_BUILDER: Lazy<HashMap<(u8, bool), LevenshteinAutomatonBuilder>> = Laz
 /// }
 /// # assert!(example().is_ok());
 /// ```
-#[derive(Debug, Clone)]
-pub struct FuzzyTermQuery {
+#[derive(Clone)]
+pub struct FuzzyTermQuery<F> {
     /// What term are we searching
     term: Term,
     /// How many changes are we going to allow
@@ -104,30 +105,70 @@ pub struct FuzzyTermQuery {
     transposition_cost_one: bool,
     ///
     prefix: bool,
+    /// The function to score the term by (taking the distance and returning the score).
+    score_fn: F,
 }
 
-impl FuzzyTermQuery {
+impl<F> Debug for FuzzyTermQuery<F> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FuzzyTermQuery")
+            .field("term", &self.term)
+            .field("distance", &self.distance)
+            .field("transposition_cost_one", &self.transposition_cost_one)
+            .field("prefix", &self.prefix)
+            .finish()
+    }
+}
+
+pub(crate) fn default_score(distance: u8) -> f32 {
+    // This uses the constant's end to ensure that this code will be updated if the range is too
+    const WEIGHTS: [f32; VALID_LEVENSHTEIN_DISTANCE_RANGE.end as usize] = [1.0, 0.5, 1.0 / 3.0];
+    WEIGHTS[distance as usize]
+}
+
+impl FuzzyTermQuery<fn(u8) -> f32> {
     /// Creates a new Fuzzy Query
-    pub fn new(term: Term, distance: u8, transposition_cost_one: bool) -> FuzzyTermQuery {
+    pub fn new(term: Term, distance: u8, transposition_cost_one: bool) -> Self<> {
         FuzzyTermQuery {
             term,
             distance,
             transposition_cost_one,
             prefix: false,
+            score_fn: default_score,
         }
     }
 
     /// Creates a new Fuzzy Query of the Term prefix
-    pub fn new_prefix(term: Term, distance: u8, transposition_cost_one: bool) -> FuzzyTermQuery {
+    pub fn new_prefix(term: Term, distance: u8, transposition_cost_one: bool) -> Self<> {
         FuzzyTermQuery {
             term,
             distance,
             transposition_cost_one,
             prefix: true,
+            score_fn: default_score,
+        }
+    }
+}
+
+impl<F: Fn(u8) -> f32 + Clone> FuzzyTermQuery<F> {
+    /// Creates a new Fuzzy Query with a custom score function
+    pub fn new_score_fn(
+        term: Term,
+        distance: u8,
+        transposition_cost_one: bool,
+        prefix: bool,
+        score_fn: F
+    ) -> Self {
+        FuzzyTermQuery {
+            term,
+            distance,
+            transposition_cost_one,
+            prefix,
+            score_fn,
         }
     }
 
-    fn specialized_weight(&self) -> crate::Result<AutomatonWeight<DfaWrapper>> {
+    fn specialized_weight(&self) -> crate::Result<AutomatonWeight<DfaWrapper, F>> {
         // LEV_BUILDER is a HashMap, whose `get` method returns an Option
         match LEV_BUILDER.get(&(self.distance, self.transposition_cost_one)) {
             // Unwrap the option and build the Ok(AutomatonWeight)
@@ -140,6 +181,7 @@ impl FuzzyTermQuery {
                 Ok(AutomatonWeight::new(
                     self.term.field(),
                     DfaWrapper(automaton),
+                    self.score_fn.clone(),
                 ))
             }
             None => Err(InvalidArgument(format!(
@@ -150,7 +192,9 @@ impl FuzzyTermQuery {
     }
 }
 
-impl Query for FuzzyTermQuery {
+impl<F> Query for FuzzyTermQuery<F>
+    where F: Fn(u8) -> f32 + Send + Sync + 'static + Clone,
+{
     fn weight(
         &self,
         _searcher: &Searcher,

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -197,7 +197,7 @@ mod test {
             let top_docs = searcher.search(&fuzzy_query, &TopDocs::with_limit(2))?;
             assert_eq!(top_docs.len(), 1, "Expected only 1 document");
             let (score, _) = top_docs[0];
-            assert_nearly_equals!(1.0, score);
+            assert_nearly_equals!(0.5, score);
         }
 
         // fails because non-prefix Levenshtein distance is more than 1 (add 'a' and 'n')

--- a/src/query/regex_query.rs
+++ b/src/query/regex_query.rs
@@ -1,5 +1,5 @@
 use crate::error::TantivyError;
-use crate::query::{AutomatonWeight, Query, Weight};
+use crate::query::{AutomatonWeight, fuzzy_query, Query, Weight};
 use crate::schema::Field;
 use crate::Searcher;
 use std::clone::Clone;
@@ -74,8 +74,9 @@ impl RegexQuery {
         }
     }
 
-    fn specialized_weight(&self) -> AutomatonWeight<Regex> {
-        AutomatonWeight::new(self.field, self.regex.clone())
+    fn specialized_weight(&self) -> AutomatonWeight<Regex, impl Fn(u8) -> f32> {
+        // TODO(lev weight): should this use the old behaviour of |_| 1.0 or should it use new?
+        AutomatonWeight::new(self.field, self.regex.clone(), fuzzy_query::default_score)
     }
 }
 

--- a/src/query/regex_query.rs
+++ b/src/query/regex_query.rs
@@ -1,5 +1,5 @@
 use crate::error::TantivyError;
-use crate::query::{AutomatonWeight, Query, Weight};
+use crate::query::{AutomatonWeight, fuzzy_query, Query, Weight};
 use crate::schema::Field;
 use crate::Searcher;
 use std::clone::Clone;
@@ -71,8 +71,9 @@ impl RegexQuery {
         }
     }
 
-    fn specialized_weight(&self) -> AutomatonWeight<Regex> {
-        AutomatonWeight::new(self.field, self.regex.clone())
+    fn specialized_weight(&self) -> AutomatonWeight<Regex, impl Fn(u8) -> f32> {
+        // TODO(lev weight): should this use the old behaviour of |_| 1.0 or should it use new?
+        AutomatonWeight::new(self.field, self.regex.clone(), fuzzy_query::default_score)
     }
 }
 

--- a/src/termdict/fst_termdict/mod.rs
+++ b/src/termdict/fst_termdict/mod.rs
@@ -23,5 +23,7 @@ mod streamer;
 mod term_info_store;
 mod termdict;
 
-pub use self::streamer::{TermStreamer, TermStreamerBuilder};
+pub use self::streamer::{
+    TermStreamer, TermStreamerBuilder, TermWithStateStreamer, TermWithStateStreamerBuilder,
+};
 pub use self::termdict::{TermDictionary, TermDictionaryBuilder};

--- a/src/termdict/fst_termdict/streamer.rs
+++ b/src/termdict/fst_termdict/streamer.rs
@@ -4,7 +4,7 @@ use super::TermDictionary;
 use crate::postings::TermInfo;
 use crate::termdict::TermOrdinal;
 use tantivy_fst::automaton::AlwaysMatch;
-use tantivy_fst::map::{Stream, StreamBuilder};
+use tantivy_fst::map::{Stream, StreamBuilder, StreamWithState};
 use tantivy_fst::Automaton;
 use tantivy_fst::{IntoStreamer, Streamer};
 
@@ -144,6 +144,156 @@ where
     pub fn next(&mut self) -> Option<(&[u8], &TermInfo)> {
         if self.advance() {
             Some((self.key(), self.value()))
+        } else {
+            None
+        }
+    }
+}
+
+/// `TermWithStateStreamerBuilder` is a helper object used to define
+/// a range of terms that should be streamed.
+pub struct TermWithStateStreamerBuilder<'a, A = AlwaysMatch>
+where
+    A: Automaton,
+    A::State: Clone,
+{
+    fst_map: &'a TermDictionary,
+    stream_builder: StreamBuilder<'a, A>,
+}
+
+impl<'a, A> TermWithStateStreamerBuilder<'a, A>
+where
+    A: Automaton,
+    A::State: Clone,
+{
+    pub(crate) fn new(fst_map: &'a TermDictionary, stream_builder: StreamBuilder<'a, A>) -> Self {
+        TermWithStateStreamerBuilder {
+            fst_map,
+            stream_builder,
+        }
+    }
+
+    /// Limit the range to terms greater or equal to the bound
+    pub fn ge<T: AsRef<[u8]>>(mut self, bound: T) -> Self {
+        self.stream_builder = self.stream_builder.ge(bound);
+        self
+    }
+
+    /// Limit the range to terms strictly greater than the bound
+    pub fn gt<T: AsRef<[u8]>>(mut self, bound: T) -> Self {
+        self.stream_builder = self.stream_builder.gt(bound);
+        self
+    }
+
+    /// Limit the range to terms lesser or equal to the bound
+    pub fn le<T: AsRef<[u8]>>(mut self, bound: T) -> Self {
+        self.stream_builder = self.stream_builder.le(bound);
+        self
+    }
+
+    /// Limit the range to terms lesser or equal to the bound
+    pub fn lt<T: AsRef<[u8]>>(mut self, bound: T) -> Self {
+        self.stream_builder = self.stream_builder.lt(bound);
+        self
+    }
+
+    /// Iterate over the range backwards.
+    pub fn backward(mut self) -> Self {
+        self.stream_builder = self.stream_builder.backward();
+        self
+    }
+
+    /// Creates the stream corresponding to the range
+    /// of terms defined using the `TermWithStateStreamerBuilder`.
+    pub fn into_stream(self) -> io::Result<TermWithStateStreamer<'a, A>> {
+        Ok(TermWithStateStreamer {
+            fst_map: self.fst_map,
+            stream: self.stream_builder.with_state().into_stream(),
+            term_ord: 0u64,
+            current_key: Vec::with_capacity(100),
+            current_value: TermInfo::default(),
+            current_state: None,
+        })
+    }
+}
+
+/// `TermWithStateStreamer` acts as a cursor over a range of terms of a segment.
+/// Terms are guaranteed to be sorted.
+pub struct TermWithStateStreamer<'a, A = AlwaysMatch>
+where
+    A: Automaton,
+    A::State: Clone,
+{
+    fst_map: &'a TermDictionary,
+    stream: StreamWithState<'a, A>,
+    term_ord: TermOrdinal,
+    current_key: Vec<u8>,
+    current_value: TermInfo,
+    current_state: Option<A::State>,
+}
+
+impl<'a, A> TermWithStateStreamer<'a, A>
+where
+    A: Automaton,
+    A::State: Clone,
+{
+    /// Advance position the stream on the next item.
+    /// Before the first call to `.advance()`, the stream
+    /// is an unitialized state.
+    pub fn advance(&mut self) -> bool {
+        if let Some((term, term_ord, state)) = self.stream.next() {
+            self.current_key.clear();
+            self.current_key.extend_from_slice(term);
+            self.term_ord = term_ord;
+            self.current_value = self.fst_map.term_info_from_ord(term_ord);
+            self.current_state = Some(state);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns the `TermOrdinal` of the given term.
+    ///
+    /// May panic if the called as `.advance()` as never
+    /// been called before.
+    pub fn term_ord(&self) -> TermOrdinal {
+        self.term_ord
+    }
+
+    /// Accesses the current key.
+    ///
+    /// `.key()` should return the key that was returned
+    /// by the `.next()` method.
+    ///
+    /// If the end of the stream as been reached, and `.next()`
+    /// has been called and returned `None`, `.key()` remains
+    /// the value of the last key encountered.
+    ///
+    /// Before any call to `.next()`, `.key()` returns an empty array.
+    pub fn key(&self) -> &[u8] {
+        &self.current_key
+    }
+
+    /// Accesses the current value.
+    ///
+    /// Calling `.value()` after the end of the stream will return the
+    /// last `.value()` encountered.
+    ///
+    /// # Panics
+    ///
+    /// Calling `.value()` before the first call to `.advance()` returns
+    /// `V::default()`.
+    pub fn value(&self) -> &TermInfo {
+        &self.current_value
+    }
+
+    /// Return the next `(key, value, state)` triplet.
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::should_implement_trait))]
+    pub fn next(&mut self) -> Option<(&[u8], &TermInfo, A::State)> {
+        if self.advance() {
+            let state = self.current_state.take().unwrap(); // always Some(_) after advance
+            Some((self.key(), self.value(), state))
         } else {
             None
         }

--- a/src/termdict/fst_termdict/termdict.rs
+++ b/src/termdict/fst_termdict/termdict.rs
@@ -1,5 +1,5 @@
 use super::term_info_store::{TermInfoStore, TermInfoStoreWriter};
-use super::{TermStreamer, TermStreamerBuilder};
+use super::{TermStreamer, TermStreamerBuilder, TermWithStateStreamerBuilder};
 use crate::common::{BinarySerializable, CountingWriter};
 use crate::directory::{FileSlice, OwnedBytes};
 use crate::error::DataCorruption;
@@ -200,5 +200,16 @@ impl TermDictionary {
     pub fn search<'a, A: Automaton + 'a>(&'a self, automaton: A) -> TermStreamerBuilder<'a, A> {
         let stream_builder = self.fst_index.search(automaton);
         TermStreamerBuilder::<A>::new(self, stream_builder)
+    }
+
+    /// Returns a search builder, to stream all of the terms
+    /// within the Automaton
+    pub fn search_with_state<'a, A>(&'a self, automaton: A) -> TermWithStateStreamerBuilder<'a, A>
+    where
+        A: Automaton + 'a,
+        A::State: Clone,
+    {
+        let stream_builder = self.fst_index.search(automaton);
+        TermWithStateStreamerBuilder::<A>::new(self, stream_builder)
     }
 }

--- a/src/termdict/fst_termdict/termdict.rs
+++ b/src/termdict/fst_termdict/termdict.rs
@@ -1,5 +1,6 @@
 use super::term_info_store::{TermInfoStore, TermInfoStoreWriter};
-use super::{TermStreamer, TermStreamerBuilder};
+use super::{TermStreamer, TermStreamerBuilder, TermWithStateStreamerBuilder};
+use crate::common::{BinarySerializable, CountingWriter};
 use crate::directory::{FileSlice, OwnedBytes};
 use crate::error::DataCorruption;
 use crate::postings::TermInfo;
@@ -200,5 +201,16 @@ impl TermDictionary {
     pub fn search<'a, A: Automaton + 'a>(&'a self, automaton: A) -> TermStreamerBuilder<'a, A> {
         let stream_builder = self.fst_index.search(automaton);
         TermStreamerBuilder::<A>::new(self, stream_builder)
+    }
+
+    /// Returns a search builder, to stream all of the terms
+    /// within the Automaton
+    pub fn search_with_state<'a, A>(&'a self, automaton: A) -> TermWithStateStreamerBuilder<'a, A>
+    where
+        A: Automaton + 'a,
+        A::State: Clone,
+    {
+        let stream_builder = self.fst_index.search(automaton);
+        TermWithStateStreamerBuilder::<A>::new(self, stream_builder)
     }
 }

--- a/src/termdict/fst_termdict/termdict.rs
+++ b/src/termdict/fst_termdict/termdict.rs
@@ -1,6 +1,5 @@
 use super::term_info_store::{TermInfoStore, TermInfoStoreWriter};
 use super::{TermStreamer, TermStreamerBuilder, TermWithStateStreamerBuilder};
-use crate::common::{BinarySerializable, CountingWriter};
 use crate::directory::{FileSlice, OwnedBytes};
 use crate::error::DataCorruption;
 use crate::postings::TermInfo;

--- a/src/termdict/mod.rs
+++ b/src/termdict/mod.rs
@@ -54,3 +54,7 @@ pub type TermMerger<'a> = self::merger::TermMerger<'a>;
 /// `TermStreamer` acts as a cursor over a range of terms of a segment.
 /// Terms are guaranteed to be sorted.
 pub type TermStreamer<'a, A = AlwaysMatch> = self::termdict::TermStreamer<'a, A>;
+
+/// `TermWithStateStreamer` acts as a cursor over a range of terms of a segment.
+/// Terms are guaranteed to be sorted.
+pub type TermWithStateStreamer<'a, A = AlwaysMatch> = self::termdict::TermWithStateStreamer<'a, A>;


### PR DESCRIPTION
Hi, I've tried to implement the ability to use a custom score function (`Fn(u8) -> f32`) for fuzzy queries, which take the DFA distance as the input and return the score for the term. This is a **proof of concept** for #998, and I am opening this as a draft so that people can more easily see the diff and comment on it. If the solution is good, it could perhaps be merged into @lerouxrgd's branch first, and then #998 could be merged, or whatever people see fit.