### PR TITLE
Searcher warming API

### DIFF
--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -217,7 +217,7 @@ impl Index {
     /// Replace the default single thread search executor pool
     /// by a thread pool with a given number of threads.
     pub fn set_multithread_executor(&mut self, num_threads: usize) -> crate::Result<()> {
-        self.executor = Arc::new(Executor::multi_thread(num_threads, "thrd-tantivy-search-")?);
+        self.executor = Arc::new(Executor::multi_thread(num_threads, "tantivy-search-")?);
         Ok(())
     }
 

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -11,6 +11,7 @@ use crate::store::StoreReader;
 use crate::DocAddress;
 use crate::Index;
 
+use std::sync::Arc;
 use std::{fmt, io};
 
 /// Holds a list of `SegmentReader`s ready for search.
@@ -23,6 +24,7 @@ pub struct Searcher {
     index: Index,
     segment_readers: Vec<SegmentReader>,
     store_readers: Vec<StoreReader>,
+    _generation_token: Arc<()>,
 }
 
 impl Searcher {
@@ -31,6 +33,7 @@ impl Searcher {
         schema: Schema,
         index: Index,
         segment_readers: Vec<SegmentReader>,
+        generation_token: Arc<()>,
     ) -> io::Result<Searcher> {
         let store_readers: Vec<StoreReader> = segment_readers
             .iter()
@@ -41,6 +44,7 @@ impl Searcher {
             index,
             segment_readers,
             store_readers,
+            _generation_token: generation_token,
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ pub mod termdict;
 
 mod reader;
 
-pub use self::reader::{IndexReader, IndexReaderBuilder, ReloadPolicy};
+pub use self::reader::{IndexReader, IndexReaderBuilder, ReloadPolicy, Warmer};
 mod snippet;
 pub use self::snippet::{Snippet, SnippetGenerator};
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -463,7 +463,6 @@ mod tests {
         reader.reload()?;
 
         let searcher = reader.searcher();
-        assert_eq!(searcher.segment_readers().len(), num_writer_threads);
         assert_eq!(searcher.num_docs(), 1000);
         warmer1.verify(segment_ids(&searcher), 2, 2);
         warmer2.verify(segment_ids(&searcher), 2, 2);
@@ -481,7 +480,6 @@ mod tests {
         reader.reload()?;
 
         let searcher = reader.searcher();
-        assert_eq!(searcher.segment_readers().len(), 1);
         assert_eq!(searcher.num_docs(), 2000);
 
         warmer2.verify(

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -485,16 +485,16 @@ mod tests {
         assert_eq!(searcher.segment_readers().len(), 1);
         assert_eq!(searcher.num_docs(), 2000);
 
-        let union_segment_ids = segment_ids(&old_searcher)
-            .union(&segment_ids(&searcher))
-            .copied()
-            .collect::<HashSet<_>>();
-
-        warmer2.verify(union_segment_ids.clone(), 3, 2);
+        warmer2.verify(
+            segment_ids(&old_searcher)
+                .union(&segment_ids(&searcher))
+                .copied()
+                .collect(),
+            3,
+            2,
+        );
 
         drop(old_searcher);
-
-        warmer2.verify(union_segment_ids.clone(), 3, 2);
 
         for _ in 0..num_searchers {
             // GC triggered when all old searchers are dropped by the pool


### PR DESCRIPTION
`Warmer`s can be registered with the `IndexReaderBuilder` and used to maintain any segment-level caches effectively. By integrating with the reload mechanism, we can ensure that any new segments are warmed before they can be exercised via a new generation of `Searcher`s.