### PR TITLE
Use test-log instead of test-env-log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ maplit = "1.0.2"
 matches = "0.1.8"
 proptest = "1.0"
 criterion = "0.3.5"
-test-env-log = "0.2.7"
+test-log = "0.2.8"
 env_logger = "0.9.0"
 
 [dev-dependencies.fail]

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -23,7 +23,7 @@ mod tests {
     use proptest::prop_oneof;
     use proptest::proptest;
     use proptest::strategy::Strategy;
-    use test_env_log::test;
+    use test_log::test;
 
     #[test]
     fn test_multivalued_u64() -> crate::Result<()> {


### PR DESCRIPTION
The test-env-log crate has been renamed to test-log to better reflect
its intent of not only catering to env_logger specific initialization
but also tracing (and potentially others in the future).
This change updates the crate to use test-log instead of the now
deprecated test-env-log.