### PR TITLE
Searcher warming API, take 2

### DIFF
--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -217,7 +217,7 @@ impl Index {
     /// Replace the default single thread search executor pool
     /// by a thread pool with a given number of threads.
     pub fn set_multithread_executor(&mut self, num_threads: usize) -> crate::Result<()> {
-        self.executor = Arc::new(Executor::multi_thread(num_threads, "thrd-tantivy-search-")?);
+        self.executor = Arc::new(Executor::multi_thread(num_threads, "tantivy-search-")?);
         Ok(())
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,7 +14,7 @@ pub use self::index_meta::{
     IndexMeta, IndexSettings, IndexSortByField, Order, SegmentMeta, SegmentMetaInventory,
 };
 pub use self::inverted_index_reader::InvertedIndexReader;
-pub use self::searcher::Searcher;
+pub use self::searcher::{Searcher, SearcherGeneration, SearcherGenerationToken};
 pub use self::segment::Segment;
 pub use self::segment_component::SegmentComponent;
 pub use self::segment_id::SegmentId;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,7 +14,7 @@ pub use self::index_meta::{
     IndexMeta, IndexSettings, IndexSortByField, Order, SegmentMeta, SegmentMetaInventory,
 };
 pub use self::inverted_index_reader::InvertedIndexReader;
-pub use self::searcher::{Searcher, SearcherGeneration, SearcherGenerationToken};
+pub use self::searcher::{Searcher, SearcherGenerationToken, SearcherIndexGeneration};
 pub use self::segment::Segment;
 pub use self::segment_component::SegmentComponent;
 pub use self::segment_id::SegmentId;

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -11,6 +11,7 @@ use crate::store::StoreReader;
 use crate::DocAddress;
 use crate::Index;
 
+use std::sync::Arc;
 use std::{fmt, io};
 
 /// Holds a list of `SegmentReader`s ready for search.
@@ -23,6 +24,7 @@ pub struct Searcher {
     index: Index,
     segment_readers: Vec<SegmentReader>,
     store_readers: Vec<StoreReader>,
+    _liveness_token: Arc<()>,
 }
 
 impl Searcher {
@@ -31,6 +33,7 @@ impl Searcher {
         schema: Schema,
         index: Index,
         segment_readers: Vec<SegmentReader>,
+        liveness_token: Arc<()>,
     ) -> io::Result<Searcher> {
         let store_readers: Vec<StoreReader> = segment_readers
             .iter()
@@ -41,6 +44,7 @@ impl Searcher {
             index,
             segment_readers,
             store_readers,
+            _liveness_token: liveness_token,
         })
     }
 

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -18,11 +18,11 @@ use std::sync::Arc;
 use std::sync::Weak;
 use std::{fmt, io};
 
-/// Identifies the data accessed by a generation of [Searcher].
+/// Identifies the index generation accessed by a [Searcher].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SearcherGeneration(BTreeMap<SegmentId, u32>);
+pub struct SearcherIndexGeneration(BTreeMap<SegmentId, u32>);
 
-impl SearcherGeneration {
+impl SearcherIndexGeneration {
     pub(crate) fn from_segment_readers(readers: &[SegmentReader]) -> Self {
         let mut segment_id_to_del_docs = BTreeMap::new();
         for reader in readers {
@@ -42,18 +42,18 @@ impl SearcherGeneration {
     }
 }
 
-/// A token that is coupled with the lifetime of a [SearcherGeneration].
+/// A token that is coupled with the lifetime of a generation of [Searcher].
 #[derive(Debug, Clone)]
-pub struct SearcherGenerationToken(Weak<SearcherGeneration>);
+pub struct SearcherGenerationToken(Weak<SearcherIndexGeneration>);
 
 impl SearcherGenerationToken {
-    /// Whether the [SearcherGeneration] is still alive.
+    /// Whether this generation of [Searcher] is still alive.
     pub fn is_live(&self) -> bool {
         self.0.strong_count() > 0
     }
 
-    /// Access the [SearcherGeneration] if it is still alive.
-    pub fn access(&self) -> Option<SearcherGeneration> {
+    /// Access the [SearcherIndexGeneration] if this generation of [Searcher] is still alive.
+    pub fn index_generation(&self) -> Option<SearcherIndexGeneration> {
         Weak::upgrade(&self.0).map(|gen| gen.deref().clone())
     }
 }
@@ -68,7 +68,7 @@ pub struct Searcher {
     index: Index,
     segment_readers: Vec<SegmentReader>,
     store_readers: Vec<StoreReader>,
-    generation: Arc<SearcherGeneration>,
+    index_generation: Arc<SearcherIndexGeneration>,
 }
 
 impl Searcher {
@@ -77,7 +77,7 @@ impl Searcher {
         schema: Schema,
         index: Index,
         segment_readers: Vec<SegmentReader>,
-        generation: Arc<SearcherGeneration>,
+        index_generation: Arc<SearcherIndexGeneration>,
     ) -> io::Result<Searcher> {
         let store_readers: Vec<StoreReader> = segment_readers
             .iter()
@@ -88,7 +88,7 @@ impl Searcher {
             index,
             segment_readers,
             store_readers,
-            generation,
+            index_generation,
         })
     }
 
@@ -97,14 +97,14 @@ impl Searcher {
         &self.index
     }
 
-    /// [SearcherGeneration] which uniquely identifies that data accessed by this generation of `Searcher`.
-    pub fn generation(&self) -> &SearcherGeneration {
-        &self.generation
+    /// [SearcherIndexGeneration] which identifies the index data accessed by this generation of `Searcher`.
+    pub fn index_generation(&self) -> &SearcherIndexGeneration {
+        &self.index_generation
     }
 
     /// [SearcherGenerationToken] which is coupled with the lifetime of this generation of `Searcher`.
     pub fn generation_token(&self) -> SearcherGenerationToken {
-        SearcherGenerationToken(Arc::downgrade(&self.generation))
+        SearcherGenerationToken(Arc::downgrade(&self.index_generation))
     }
 
     /// Fetches a document from tantivy's store given a `DocAddress`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,8 +166,8 @@ mod docset;
 pub use self::docset::{DocSet, TERMINATED};
 pub use crate::core::{Executor, SegmentComponent};
 pub use crate::core::{
-    Index, IndexBuilder, IndexMeta, IndexSettings, IndexSortByField, Order, Searcher, Segment,
-    SegmentId, SegmentMeta,
+    Index, IndexBuilder, IndexMeta, IndexSettings, IndexSortByField, Order, Searcher,
+    SearcherGeneration, SearcherGenerationToken, Segment, SegmentId, SegmentMeta,
 };
 pub use crate::core::{InvertedIndexReader, SegmentReader};
 pub use crate::directory::Directory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub use self::docset::{DocSet, TERMINATED};
 pub use crate::core::{Executor, SegmentComponent};
 pub use crate::core::{
     Index, IndexBuilder, IndexMeta, IndexSettings, IndexSortByField, Order, Searcher,
-    SearcherGeneration, SearcherGenerationToken, Segment, SegmentId, SegmentMeta,
+    SearcherGenerationToken, SearcherIndexGeneration, Segment, SegmentId, SegmentMeta,
 };
 pub use crate::core::{InvertedIndexReader, SegmentReader};
 pub use crate::directory::Directory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub mod termdict;
 
 mod reader;
 
-pub use self::reader::{IndexReader, IndexReaderBuilder, ReloadPolicy};
+pub use self::reader::{IndexReader, IndexReaderBuilder, ReloadPolicy, Warmer};
 mod snippet;
 pub use self::snippet::{Snippet, SnippetGenerator};
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -114,7 +114,7 @@ impl IndexReaderBuilder {
 
     /// Sets the number of [Searcher] to pool.
     ///
-    /// When more than `num_searchers` are requested, the caller will block.
+    /// See [Self::searcher()].
     pub fn num_searchers(mut self, num_searchers: usize) -> IndexReaderBuilder {
         self.num_searchers = num_searchers;
         self

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -4,7 +4,7 @@ mod warming;
 pub use self::pool::LeasedItem;
 use self::pool::Pool;
 use self::warming::WarmingState;
-use crate::core::searcher::SearcherGeneration;
+use crate::core::searcher::SearcherIndexGeneration;
 use crate::core::Segment;
 use crate::directory::WatchHandle;
 use crate::directory::META_LOCK;
@@ -161,15 +161,16 @@ impl InnerIndexReader {
                 .map(SegmentReader::open)
                 .collect::<crate::Result<_>>()?
         };
-        let searcher_generation =
-            Arc::new(SearcherGeneration::from_segment_readers(&segment_readers));
+        let searcher_index_generation = Arc::new(SearcherIndexGeneration::from_segment_readers(
+            &segment_readers,
+        ));
         let schema = self.index.schema();
         let searchers: Vec<Searcher> = std::iter::repeat_with(|| {
             Searcher::new(
                 schema.clone(),
                 self.index.clone(),
                 segment_readers.clone(),
-                searcher_generation.clone(),
+                searcher_index_generation.clone(),
             )
         })
         .take(self.num_searchers)

--- a/src/reader/warming.rs
+++ b/src/reader/warming.rs
@@ -155,18 +155,17 @@ impl WarmingStateInner {
     /// Start GC thread if one has not already been started.
     fn start_gc_thread_maybe(&mut self, this: &Arc<Mutex<Self>>) -> crate::Result<bool> {
         if self.gc_thread.is_some() {
-            Ok(false)
-        } else {
-            let weak_inner = Arc::downgrade(this);
-            let handle = std::thread::Builder::new()
-                .name("tantivy-warm-gc".to_owned())
-                .spawn(|| Self::gc_loop(weak_inner))
-                .map_err(|_| {
-                    TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
-                })?;
-            self.gc_thread = Some(handle);
-            Ok(true)
+            return Ok(false);
         }
+        let weak_inner = Arc::downgrade(this);
+        let handle = std::thread::Builder::new()
+            .name("tantivy-warm-gc".to_owned())
+            .spawn(|| Self::gc_loop(weak_inner))
+            .map_err(|_| {
+               TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
+             })?;
+        self.gc_thread = Some(handle);
+        Ok(true)
     }
 
     /// Every [GC_INTERVAL] attempt to GC, with panics caught and logged using [std::panic::catch_unwind].

--- a/src/reader/warming.rs
+++ b/src/reader/warming.rs
@@ -37,11 +37,11 @@ impl WarmingState {
     /// Start tracking a new generation of [Searcher], and [Warmer::warm] it if there are active warmers.
     ///
     /// A background GC thread for [Warmer::garbage_collect] calls is uniquely created if there are active warmers.
-    pub fn new_searcher_generation(&self, searcher: &Searcher) -> crate::Result<()> {
+    pub fn warm_new_searcher_generation(&self, searcher: &Searcher) -> crate::Result<()> {
         self.0
             .lock()
             .unwrap()
-            .new_searcher_generation(searcher, &self.0)
+            .warm_new_searcher_generation(searcher, &self.0)
     }
 
     #[cfg(test)]
@@ -61,7 +61,7 @@ impl WarmingStateInner {
     /// Start tracking provided searcher as an exemplar of a new generation.
     /// If there are active warmers, warm them with the provided searcher, and kick background GC thread if it has not yet been kicked.
     /// Otherwise, prune state for dropped searcher generations inline.
-    fn new_searcher_generation(
+    fn warm_new_searcher_generation(
         &mut self,
         searcher: &Searcher,
         this: &Arc<Mutex<Self>>,
@@ -109,7 +109,7 @@ impl WarmingStateInner {
             let mut i = 0;
             while i < tokens.len() {
                 if !tokens[i].is_live() {
-                    tokens.remove(i);
+                    tokens.swap_remove(i);
                 } else {
                     i += 1;
                 }

--- a/src/reader/warming.rs
+++ b/src/reader/warming.rs
@@ -1,0 +1,384 @@
+use std::{
+    collections::HashSet,
+    iter::FromIterator,
+    sync::{Arc, Mutex, Weak},
+    thread::JoinHandle,
+    time::Duration,
+};
+
+use crate::{Executor, Searcher, SegmentId, TantivyError};
+
+pub const GC_INTERVAL: Duration = Duration::from_secs(1);
+
+/// `Warmer` can be used to maintain segment-level state e.g. caches.
+///
+/// They must be registered with the [IndexReaderBuilder].
+pub trait Warmer: Sync + Send {
+    /// Perform any warming work using the provided [Searcher].
+    fn warm(&self, searcher: &Searcher) -> crate::Result<()>;
+
+    /// Discard internal state for any [SegmentId] not provided.
+    fn garbage_collect(&self, live_segment_ids: &HashSet<SegmentId>);
+}
+
+/// Warming-related state with interior mutability.
+#[derive(Clone)]
+pub(crate) struct WarmingState(Arc<Mutex<WarmingStateInner>>);
+
+impl WarmingState {
+    pub fn new(num_warming_threads: usize, warmers: Vec<Weak<dyn Warmer>>) -> crate::Result<Self> {
+        Ok(Self(Arc::new(Mutex::new(WarmingStateInner {
+            num_warming_threads,
+            warmers,
+            searcher_generations: Vec::new(),
+            gc_thread: None,
+        }))))
+    }
+
+    /// Start tracking a new generation of searchers, and [Warmer::warm] it if there are active warmers.
+    ///
+    /// A background GC thread for [Warmer::garbage_collect] calls is uniquely created if there are active warmers.
+    pub fn new_searcher_generation(
+        &self,
+        liveness_token: Weak<()>,
+        searcher: &Searcher,
+    ) -> crate::Result<()> {
+        self.0
+            .lock()
+            .unwrap()
+            .new_searcher_generation(liveness_token, searcher, &self.0)
+    }
+
+    #[cfg(test)]
+    fn gc_maybe(&self) -> bool {
+        self.0.lock().unwrap().gc_maybe()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SearcherGeneration {
+    liveness_token: Weak<()>,
+    segment_ids: Vec<SegmentId>,
+}
+
+impl SearcherGeneration {
+    fn is_live(&self) -> bool {
+        self.liveness_token.strong_count() > 0
+    }
+}
+
+#[derive(Default)]
+struct WarmingStateInner {
+    num_warming_threads: usize,
+    warmers: Vec<Weak<dyn Warmer>>,
+    searcher_generations: Vec<SearcherGeneration>,
+    gc_thread: Option<JoinHandle<()>>,
+}
+
+impl WarmingStateInner {
+    /// Start tracking provided searcher's segment IDs with its liveness token.
+    /// If there are active warmers, warm them with the provided searcher, and kick background GC thread if it has not yet been kicked.
+    /// Otherwise, prune state for dropped searcher generations inline.
+    fn new_searcher_generation(
+        &mut self,
+        liveness_token: Weak<()>,
+        searcher: &Searcher,
+        this: &Arc<Mutex<Self>>,
+    ) -> crate::Result<()> {
+        self.searcher_generations.push(SearcherGeneration {
+            liveness_token,
+            segment_ids: segment_ids(searcher),
+        });
+        let warmers = self.pruned_warmers();
+        // Avoid threads (warming as well as background GC) if there are no warmers
+        if warmers.is_empty() {
+            self.prune_searcher_generations();
+        } else {
+            self.start_gc_thread_maybe(this)?;
+            warming_executor(self.num_warming_threads.min(warmers.len()))?
+                .map(|warmer| warmer.warm(searcher), warmers.into_iter())?;
+        }
+        Ok(())
+    }
+
+    /// Attempt to upgrade the weak Warmer references, pruning those which cannot be upgraded.
+    /// Return the strong references.
+    fn pruned_warmers(&mut self) -> Vec<Arc<dyn Warmer>> {
+        let strong_warmers = self
+            .warmers
+            .iter()
+            .flat_map(|weak_warmer| weak_warmer.upgrade())
+            .collect::<Vec<_>>();
+        self.warmers = strong_warmers.iter().map(Arc::downgrade).collect();
+        strong_warmers
+    }
+
+    /// Prune dropped searcher generations from our state.
+    /// Return count of removed generations.
+    fn prune_searcher_generations(&mut self) -> usize {
+        // This can be implemented neatly using Vec::drain_filter() when that is stable.
+        let mut pruned = 0;
+        let mut i = 0;
+        while i < self.searcher_generations.len() {
+            if !self.searcher_generations[i].is_live() {
+                self.searcher_generations.remove(i);
+                pruned += 1;
+            } else {
+                i += 1;
+            }
+        }
+        pruned
+    }
+
+    /// Segment ID set of live searcher generations.
+    fn live_segment_ids(&self) -> HashSet<SegmentId> {
+        self.searcher_generations
+            .iter()
+            .filter(|gen| gen.is_live())
+            .flat_map(|gen| gen.segment_ids.iter().copied())
+            .collect()
+    }
+
+    /// [Warmer::garbage_collect] active warmers if some searcher generation is observed to have been dropped.
+    fn gc_maybe(&mut self) -> bool {
+        if self.prune_searcher_generations() > 0 {
+            let live_segment_ids = self.live_segment_ids();
+            for warmer in self.pruned_warmers() {
+                warmer.garbage_collect(&live_segment_ids);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Start GC thread if one has not already been started.
+    fn start_gc_thread_maybe(&mut self, this: &Arc<Mutex<Self>>) -> crate::Result<bool> {
+        if self.gc_thread.is_some() {
+            Ok(false)
+        } else {
+            let weak_inner = Arc::downgrade(this);
+            let handle = std::thread::Builder::new()
+                .name("tantivy-warm-gc".to_owned())
+                .spawn(|| Self::gc_loop(weak_inner))
+                .map_err(|_| {
+                    TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
+                })?;
+            self.gc_thread = Some(handle);
+            Ok(true)
+        }
+    }
+
+    /// Every [GC_INTERVAL] attempt to GC, with panics caught and logged using [std::panic::catch_unwind].
+    fn gc_loop(inner: Weak<Mutex<WarmingStateInner>>) {
+        for _ in crossbeam::channel::tick(GC_INTERVAL) {
+            if let Some(inner) = inner.upgrade() {
+                // rely on deterministic gc in tests
+                #[cfg(not(test))]
+                if let Err(err) = std::panic::catch_unwind(|| inner.lock().unwrap().gc_maybe()) {
+                    error!("Panic in Warmer GC {:?}", err);
+                }
+                // avoid unused var warning in tests
+                #[cfg(test)]
+                drop(inner);
+            }
+        }
+    }
+}
+
+fn warming_executor(num_threads: usize) -> crate::Result<Executor> {
+    if num_threads <= 1 {
+        Ok(Executor::single_thread())
+    } else {
+        Executor::multi_thread(num_threads, "tantivy-warm-")
+    }
+}
+
+fn segment_ids<T>(searcher: &Searcher) -> T
+where
+    T: FromIterator<SegmentId>,
+{
+    searcher
+        .segment_readers()
+        .iter()
+        .map(|reader| reader.segment_id())
+        .collect::<T>()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        sync::{
+            atomic::{self, AtomicUsize},
+            Arc, RwLock, Weak,
+        },
+    };
+
+    use crate::{
+        directory::RamDirectory,
+        reader::warming::segment_ids,
+        schema::{Schema, INDEXED},
+        Index, IndexSettings, ReloadPolicy, SegmentId,
+    };
+
+    use super::Warmer;
+
+    #[derive(Default)]
+    struct TestWarmer {
+        active_segment_ids: RwLock<HashSet<SegmentId>>,
+        warm_calls: AtomicUsize,
+        gc_calls: AtomicUsize,
+    }
+
+    impl TestWarmer {
+        fn live_segment_ids(&self) -> HashSet<SegmentId> {
+            self.active_segment_ids.read().unwrap().clone()
+        }
+
+        fn warm_calls(&self) -> usize {
+            self.warm_calls.load(atomic::Ordering::Acquire)
+        }
+
+        fn gc_calls(&self) -> usize {
+            self.gc_calls.load(atomic::Ordering::Acquire)
+        }
+
+        fn verify(
+            &self,
+            expected_warm_calls: usize,
+            expected_gc_calls: usize,
+            expected_segment_ids: HashSet<SegmentId>,
+        ) {
+            assert_eq!(self.warm_calls(), expected_warm_calls);
+            assert_eq!(self.gc_calls(), expected_gc_calls);
+            assert_eq!(self.live_segment_ids(), expected_segment_ids);
+        }
+    }
+
+    impl Warmer for TestWarmer {
+        fn warm(&self, searcher: &crate::Searcher) -> crate::Result<()> {
+            self.warm_calls.fetch_add(1, atomic::Ordering::SeqCst);
+            for reader in searcher.segment_readers() {
+                self.active_segment_ids
+                    .write()
+                    .unwrap()
+                    .insert(reader.segment_id());
+            }
+            Ok(())
+        }
+
+        fn garbage_collect(&self, segment_ids: &HashSet<SegmentId>) {
+            self.gc_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.active_segment_ids
+                .write()
+                .unwrap()
+                .retain(|id| segment_ids.contains(id));
+        }
+    }
+
+    fn test_warming(num_warming_threads: usize) -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let field = schema_builder.add_u64_field("pk", INDEXED);
+        let schema = schema_builder.build();
+
+        let directory = RamDirectory::create();
+        let index = Index::create(directory.clone(), schema, IndexSettings::default())?;
+
+        let num_writer_threads = 4;
+        let mut writer = index
+            .writer_with_num_threads(num_writer_threads, 25_000_000)
+            .unwrap();
+
+        for i in 0u64..1000u64 {
+            writer.add_document(doc!(field => i))?;
+        }
+        writer.commit()?;
+
+        let warmer1 = Arc::new(TestWarmer::default());
+        let warmer2 = Arc::new(TestWarmer::default());
+        warmer1.verify(0, 0, HashSet::new());
+        warmer2.verify(0, 0, HashSet::new());
+
+        let num_searchers = 4;
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .num_warming_threads(num_warming_threads)
+            .num_searchers(num_searchers)
+            .warmers(vec![
+                Arc::downgrade(&warmer1) as Weak<dyn Warmer>,
+                Arc::downgrade(&warmer2) as Weak<dyn Warmer>,
+            ])
+            .try_into()?;
+
+        let warming_state = &reader.inner.warming_state;
+
+        {
+            let searcher = reader.searcher();
+            assert_eq!(searcher.segment_readers().len(), num_writer_threads);
+            assert!(
+                !warming_state.gc_maybe(),
+                "no GC after first searcher generation"
+            );
+            warmer1.verify(1, 0, segment_ids(&searcher));
+            warmer2.verify(1, 0, segment_ids(&searcher));
+            assert_eq!(searcher.num_docs(), 1000);
+        }
+
+        reader.reload()?;
+        warming_state.gc_maybe();
+
+        let searcher = reader.searcher();
+        assert_eq!(searcher.num_docs(), 1000);
+        warmer1.verify(2, 1, segment_ids(&searcher));
+        warmer2.verify(2, 1, segment_ids(&searcher));
+
+        for i in 1000u64..2000u64 {
+            writer.add_document(doc!(field => i))?;
+        }
+        writer.commit()?;
+        writer.wait_merging_threads()?;
+
+        drop(warmer1);
+
+        let old_searcher = searcher;
+
+        reader.reload()?;
+        assert!(!warming_state.gc_maybe(), "old searcher still around");
+
+        let searcher = reader.searcher();
+        assert_eq!(searcher.num_docs(), 2000);
+
+        warmer2.verify(
+            3,
+            1,
+            segment_ids::<HashSet<_>>(&old_searcher)
+                .union(&segment_ids(&searcher))
+                .copied()
+                .collect(),
+        );
+
+        drop(old_searcher);
+        for _ in 0..num_searchers {
+            // make sure the old searcher is dropped by the pool too
+            let _ = reader.searcher();
+        }
+        assert!(warming_state.gc_maybe(), "old searcher dropped");
+
+        warmer2.verify(3, 2, segment_ids(&searcher));
+
+        Ok(())
+    }
+
+    #[test]
+    fn warming_single_thread() -> crate::Result<()> {
+        test_warming(1)
+    }
+
+    #[test]
+    fn warming_four_threads() -> crate::Result<()> {
+        test_warming(4)
+    }
+}

--- a/src/reader/warming.rs
+++ b/src/reader/warming.rs
@@ -162,8 +162,8 @@ impl WarmingStateInner {
             .name("tantivy-warm-gc".to_owned())
             .spawn(|| Self::gc_loop(weak_inner))
             .map_err(|_| {
-               TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
-             })?;
+                TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
+            })?;
         self.gc_thread = Some(handle);
         Ok(true)
     }


### PR DESCRIPTION
`Warmer` implementations can be registered with the `IndexReaderBuilder` and used to maintain any segment-level caches effectively.

By integrating `Warmer::warm()` with the reload mechanism, we can ensure that any new segments are warmed before they can be exercised via a new generation of `Searcher`s.

`Warmer::garbage_collect()` is called when some searcher generation has been fully dropped, with the set of segment IDs that are still active. This allows implementations to prune redundant state.