### PR TITLE
Warming pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 Tantivy 0.17
 ================================
+- LogMergePolicy now triggers merges if the ratio of deleted documents reaches a threshold (@shikhar) [#115](https://github.com/quickwit-inc/tantivy/issues/115)
+- Adds a searcher Warmer API (@shikhar)
 - Change to non-strict schema. Ignore fields in data which are not defined in schema. Previously this returned an error. #1211
 - Facets are necessarily indexed. Existing index with indexed facets should work out of the box. Index without facets that are marked with index: false should be broken (but they were already broken in a sense). (@fulmicoton) #1195 .
 - Bugfix that could in theory impact durability in theory on some filesystems [#1224](https://github.com/quickwit-inc/tantivy/issues/1224)
-- Reduce the number of fsync calls [#1225](https://github.com/quickwit-inc/tantivy/issues/1225)
 - Schema now offers not indexing fieldnorms (@lpouget) [#922](https://github.com/quickwit-inc/tantivy/issues/922)
-- LogMergePolicy now triggers merges if the ratio of deleted documents reaches a threshold (@shikhar) [#115](https://github.com/quickwit-inc/tantivy/issues/115)
+- Reduce the number of fsync calls [#1225](https://github.com/quickwit-inc/tantivy/issues/1225)
 
 Tantivy 0.16.2
 ================================

--- a/examples/warmer.rs
+++ b/examples/warmer.rs
@@ -1,0 +1,224 @@
+use std::cmp::Reverse;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock, Weak};
+
+use tantivy::collector::TopDocs;
+use tantivy::fastfield::FastFieldReader;
+use tantivy::query::QueryParser;
+use tantivy::schema::{Field, Schema, FAST, TEXT};
+use tantivy::{doc, DocAddress, DocId, Index, IndexReader, SegmentReader, TrackedObject};
+use tantivy::{Opstamp, Searcher, SearcherIndexGeneration, SegmentId, Warmer};
+
+// This example shows how warmers can be used to
+// load a values from an external sources using the Warmer API.
+//
+// In this example, we assume an e-commerce search engine.
+
+type ProductId = u64;
+
+/// Price
+type Price = u32;
+
+pub trait PriceFetcher: Send + Sync + 'static {
+    fn fetch_prices(&self, product_ids: &[ProductId]) -> Vec<Price>;
+}
+
+struct DynamicPriceColumn {
+    field: Field,
+    price_cache: RwLock<HashMap<(SegmentId, Option<Opstamp>), Arc<Vec<Price>>>>,
+    price_fetcher: Box<dyn PriceFetcher>,
+}
+
+impl DynamicPriceColumn {
+    pub fn with_product_id_field<T: PriceFetcher>(field: Field, price_fetcher: T) -> Self {
+        DynamicPriceColumn {
+            field,
+            price_cache: Default::default(),
+            price_fetcher: Box::new(price_fetcher),
+        }
+    }
+
+    pub fn price_for_segment(&self, segment_reader: &SegmentReader) -> Option<Arc<Vec<Price>>> {
+        let segment_key = (segment_reader.segment_id(), segment_reader.delete_opstamp());
+        self.price_cache.read().unwrap().get(&segment_key).cloned()
+    }
+}
+impl Warmer for DynamicPriceColumn {
+    fn warm(&self, searcher: &Searcher) -> tantivy::Result<()> {
+        for segment in searcher.segment_readers() {
+            let key = (segment.segment_id(), segment.delete_opstamp());
+            let product_id_reader = segment.fast_fields().u64(self.field)?;
+            let product_ids: Vec<ProductId> = segment
+                .doc_ids_alive()
+                .map(|doc| product_id_reader.get(doc))
+                .collect();
+            let mut prices_it = self.price_fetcher.fetch_prices(&product_ids).into_iter();
+            let mut price_vals: Vec<Price> = Vec::new();
+            for doc in 0..segment.max_doc() {
+                if segment.is_deleted(doc) {
+                    price_vals.push(0);
+                } else {
+                    price_vals.push(prices_it.next().unwrap())
+                }
+            }
+            self.price_cache
+                .write()
+                .unwrap()
+                .insert(key, Arc::new(price_vals));
+        }
+        Ok(())
+    }
+
+    fn garbage_collect(&self, live_generations: &[TrackedObject<SearcherIndexGeneration>]) {
+        let live_segment_id_and_delete_ops: HashSet<(SegmentId, Option<Opstamp>)> =
+            live_generations
+                .iter()
+                .flat_map(|gen| gen.segments())
+                .map(|(&segment_id, &opstamp)| (segment_id, opstamp))
+                .collect();
+        let mut price_cache_wrt = self.price_cache.write().unwrap();
+        // let price_cache = std::mem::take(&mut *price_cache_wrt);
+        // Drain would be nicer here.
+        *price_cache_wrt = std::mem::take(&mut *price_cache_wrt)
+            .into_iter()
+            .filter(|(seg_id_and_op, _)| !live_segment_id_and_delete_ops.contains(seg_id_and_op))
+            .collect();
+    }
+}
+
+/// For the sake of this example, the table is just an editable HashMap behind a RwLock.
+/// This map represents a map (ProductId -> Price)
+///
+/// In practise, it could be fetching things from an external service, like a SQL table.
+///
+#[derive(Default, Clone)]
+pub struct ExternalPriceTable {
+    prices: Arc<RwLock<HashMap<ProductId, Price>>>,
+}
+
+impl ExternalPriceTable {
+    pub fn update_price(&self, product_id: ProductId, price: Price) {
+        let mut prices_wrt = self.prices.write().unwrap();
+        prices_wrt.insert(product_id, price);
+    }
+}
+
+impl PriceFetcher for ExternalPriceTable {
+    fn fetch_prices(&self, product_ids: &[ProductId]) -> Vec<Price> {
+        let prices_read = self.prices.read().unwrap();
+        product_ids
+            .iter()
+            .map(|product_id| prices_read.get(product_id).cloned().unwrap_or(0))
+            .collect()
+    }
+}
+
+fn main() -> tantivy::Result<()> {
+    // Declaring our schema.
+    let mut schema_builder = Schema::builder();
+    // The product id is assumed to be a primary id for our external price source.
+    let product_id = schema_builder.add_u64_field("product_id", FAST);
+    let text = schema_builder.add_text_field("text", TEXT);
+    let schema: Schema = schema_builder.build();
+
+    let price_table = ExternalPriceTable::default();
+    let price_dynamic_column = Arc::new(DynamicPriceColumn::with_product_id_field(
+        product_id,
+        price_table.clone(),
+    ));
+    price_table.update_price(OLIVE_OIL, 12);
+    price_table.update_price(GLOVES, 13);
+    price_table.update_price(SNEAKERS, 80);
+
+    const OLIVE_OIL: ProductId = 323423;
+    const GLOVES: ProductId = 3966623;
+    const SNEAKERS: ProductId = 23222;
+
+    let index = Index::create_in_ram(schema);
+    let mut writer = index.writer_with_num_threads(1, 10_000_000)?;
+    writer.add_document(doc!(product_id=>OLIVE_OIL, text=>"cooking olive oil from greece"))?;
+    writer.add_document(doc!(product_id=>GLOVES, text=>"kitchen gloves, perfect for cooking"))?;
+    writer.add_document(doc!(product_id=>SNEAKERS, text=>"uber sweet sneakers"))?;
+    writer.commit()?;
+
+    let warmers: Vec<Weak<dyn Warmer>> = vec![Arc::downgrade(
+        &(price_dynamic_column.clone() as Arc<dyn Warmer>),
+    )];
+    let reader: IndexReader = index
+        .reader_builder()
+        .warmers(warmers)
+        .num_searchers(1)
+        .try_into()?;
+    reader.reload()?;
+
+    let query_parser = QueryParser::for_index(&index, vec![text]);
+    let query = query_parser.parse_query("cooking")?;
+
+    let searcher = reader.searcher();
+    let score_by_price = move |segment_reader: &SegmentReader| {
+        let price = price_dynamic_column
+            .price_for_segment(segment_reader)
+            .unwrap();
+        move |doc_id: DocId| Reverse(price[doc_id as usize])
+    };
+
+    let most_expensive_first = TopDocs::with_limit(10).custom_score(score_by_price);
+
+    let hits = searcher.search(&query, &most_expensive_first)?;
+    assert_eq!(
+        &hits,
+        &[
+            (
+                Reverse(12u32),
+                DocAddress {
+                    segment_ord: 0,
+                    doc_id: 0u32
+                }
+            ),
+            (
+                Reverse(13u32),
+                DocAddress {
+                    segment_ord: 0,
+                    doc_id: 1u32
+                }
+            ),
+        ]
+    );
+
+    // Olive oil just got more expensive!
+    price_table.update_price(OLIVE_OIL, 15);
+
+    // The price update are directly reflected on `reload`.
+    //
+    // Be careful here though!...
+    // You may have spotted that we are still using the same `Searcher`.
+    //
+    // It is up to the `Warmer` implementer to decide how
+    // to control this behavior.
+
+    reader.reload()?;
+
+    let searcher = reader.searcher();
+    let hits_with_new_prices = searcher.search(&query, &most_expensive_first)?;
+    assert_eq!(
+        &hits_with_new_prices,
+        &[
+            (
+                Reverse(13u32),
+                DocAddress {
+                    segment_ord: 0,
+                    doc_id: 1u32
+                }
+            ),
+            (
+                Reverse(15u32),
+                DocAddress {
+                    segment_ord: 0,
+                    doc_id: 0u32
+                }
+            ),
+        ]
+    );
+
+    Ok(())
+}

--- a/examples/warmer.rs
+++ b/examples/warmer.rs
@@ -198,7 +198,6 @@ fn main() -> tantivy::Result<()> {
 
     reader.reload()?;
 
-    let searcher = reader.searcher();
     let hits_with_new_prices = searcher.search(&query, &most_expensive_first)?;
     assert_eq!(
         &hits_with_new_prices,

--- a/examples/warmer.rs
+++ b/examples/warmer.rs
@@ -7,7 +7,7 @@ use tantivy::fastfield::FastFieldReader;
 use tantivy::query::QueryParser;
 use tantivy::schema::{Field, Schema, FAST, TEXT};
 use tantivy::{doc, DocAddress, DocId, Index, IndexReader, SegmentReader, TrackedObject};
-use tantivy::{Opstamp, Searcher, SearcherIndexGeneration, SegmentId, Warmer};
+use tantivy::{Opstamp, Searcher, SearcherGeneration, SegmentId, Warmer};
 
 // This example shows how warmers can be used to
 // load a values from an external sources using the Warmer API.
@@ -69,7 +69,7 @@ impl Warmer for DynamicPriceColumn {
         Ok(())
     }
 
-    fn garbage_collect(&self, live_generations: &[TrackedObject<SearcherIndexGeneration>]) {
+    fn garbage_collect(&self, live_generations: &[TrackedObject<SearcherGeneration>]) {
         let live_segment_id_and_delete_ops: HashSet<(SegmentId, Option<Opstamp>)> =
             live_generations
                 .iter()

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -217,7 +217,7 @@ impl Index {
     /// Replace the default single thread search executor pool
     /// by a thread pool with a given number of threads.
     pub fn set_multithread_executor(&mut self, num_threads: usize) -> crate::Result<()> {
-        self.executor = Arc::new(Executor::multi_thread(num_threads, "thrd-tantivy-search-")?);
+        self.executor = Arc::new(Executor::multi_thread(num_threads, "tantivy-search-")?);
         Ok(())
     }
 

--- a/src/core/index_meta.rs
+++ b/src/core/index_meta.rs
@@ -2,7 +2,7 @@ use super::SegmentComponent;
 use crate::schema::Schema;
 use crate::Opstamp;
 use crate::{core::SegmentId, store::Compressor};
-use census::{Inventory, TrackedObject};
+use crate::{Inventory, TrackedObject};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{collections::HashSet, sync::atomic::AtomicBool};

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,7 +14,7 @@ pub use self::index_meta::{
     IndexMeta, IndexSettings, IndexSortByField, Order, SegmentMeta, SegmentMetaInventory,
 };
 pub use self::inverted_index_reader::InvertedIndexReader;
-pub use self::searcher::{Searcher, SearcherIndexGeneration};
+pub use self::searcher::{Searcher, SearcherGeneration};
 pub use self::segment::Segment;
 pub use self::segment_component::SegmentComponent;
 pub use self::segment_id::SegmentId;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,7 +14,7 @@ pub use self::index_meta::{
     IndexMeta, IndexSettings, IndexSortByField, Order, SegmentMeta, SegmentMetaInventory,
 };
 pub use self::inverted_index_reader::InvertedIndexReader;
-pub use self::searcher::Searcher;
+pub use self::searcher::{Searcher, SearcherGeneration, SearcherGenerationToken};
 pub use self::segment::Segment;
 pub use self::segment_component::SegmentComponent;
 pub use self::segment_id::SegmentId;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,7 +14,7 @@ pub use self::index_meta::{
     IndexMeta, IndexSettings, IndexSortByField, Order, SegmentMeta, SegmentMetaInventory,
 };
 pub use self::inverted_index_reader::InvertedIndexReader;
-pub use self::searcher::{Searcher, SearcherGeneration, SearcherGenerationToken};
+pub use self::searcher::{Searcher, SearcherGenerationToken, SearcherIndexGeneration};
 pub use self::segment::Segment;
 pub use self::segment_component::SegmentComponent;
 pub use self::segment_id::SegmentId;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,7 +14,7 @@ pub use self::index_meta::{
     IndexMeta, IndexSettings, IndexSortByField, Order, SegmentMeta, SegmentMetaInventory,
 };
 pub use self::inverted_index_reader::InvertedIndexReader;
-pub use self::searcher::{Searcher, SearcherGenerationToken, SearcherIndexGeneration};
+pub use self::searcher::{Searcher, SearcherIndexGeneration};
 pub use self::segment::Segment;
 pub use self::segment_component::SegmentComponent;
 pub use self::segment_id::SegmentId;

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -11,7 +11,6 @@ use crate::DocAddress;
 use crate::Index;
 use crate::Opstamp;
 use crate::SegmentId;
-use crate::SegmentMeta;
 use crate::TrackedObject;
 
 use std::collections::BTreeMap;
@@ -25,13 +24,13 @@ pub struct SearcherIndexGeneration {
 }
 
 impl SearcherIndexGeneration {
-    pub(crate) fn from_segment_metas<'a>(
-        segment_metas: impl Iterator<Item = &'a SegmentMeta>,
+    pub(crate) fn from_segment_readers(
+        segment_readers: &[SegmentReader],
         generation_id: u64,
     ) -> Self {
         let mut segment_id_to_del_opstamp = BTreeMap::new();
-        for meta in segment_metas {
-            segment_id_to_del_opstamp.insert(meta.id(), meta.delete_opstamp());
+        for segment_reader in segment_readers {
+            segment_id_to_del_opstamp.insert(segment_reader.segment_id(), segment_reader.delete_opstamp());
         }
         Self {
             segments: segment_id_to_del_opstamp,

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -44,7 +44,8 @@ impl SearcherGeneration {
     ) -> Self {
         let mut segment_id_to_del_opstamp = BTreeMap::new();
         for segment_reader in segment_readers {
-            segment_id_to_del_opstamp.insert(segment_reader.segment_id(), segment_reader.delete_opstamp());
+            segment_id_to_del_opstamp
+                .insert(segment_reader.segment_id(), segment_reader.delete_opstamp());
         }
         Self {
             segments: segment_id_to_del_opstamp,
@@ -57,7 +58,7 @@ impl SearcherGeneration {
         self.generation_id
     }
 
-    /// Return an iterator over the `(SegmentId, Option<Opstamp>)`.
+    /// Return a `(SegmentId -> DeleteOpstamp)` mapping.
     pub fn segments(&self) -> &BTreeMap<SegmentId, Option<Opstamp>> {
         &self.segments
     }

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -74,7 +74,7 @@ pub struct Searcher {
     index: Index,
     segment_readers: Vec<SegmentReader>,
     store_readers: Vec<StoreReader>,
-    index_generation: TrackedObject<SearcherGeneration>,
+    generation: TrackedObject<SearcherGeneration>,
 }
 
 impl Searcher {
@@ -83,7 +83,7 @@ impl Searcher {
         schema: Schema,
         index: Index,
         segment_readers: Vec<SegmentReader>,
-        index_generation: TrackedObject<SearcherGeneration>,
+        generation: TrackedObject<SearcherGeneration>,
     ) -> io::Result<Searcher> {
         let store_readers: Vec<StoreReader> = segment_readers
             .iter()
@@ -94,7 +94,7 @@ impl Searcher {
             index,
             segment_readers,
             store_readers,
-            index_generation,
+            generation,
         })
     }
 
@@ -103,9 +103,9 @@ impl Searcher {
         &self.index
     }
 
-    /// [SearcherIndexGeneration] which identifies the index data accessed by this generation of `Searcher`.
-    pub fn index_generation(&self) -> &SearcherGeneration {
-        self.index_generation.as_ref()
+    /// [SearcherGeneration] which identifies the version of the snapshot held by this `Searcher`.
+    pub fn generation(&self) -> &SearcherGeneration {
+        self.generation.as_ref()
     }
 
     /// Fetches a document from tantivy's store given a `DocAddress`.

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -52,29 +52,14 @@ impl SearcherGeneration {
         }
     }
 
-    /// Segment IDs represented in this generation.
-    pub fn segment_ids(&self) -> impl Iterator<Item = SegmentId> + '_ {
-        self.segments.keys().copied()
-    }
-
     /// Returns the searcher generation id.
     pub fn generation_id(&self) -> u64 {
         self.generation_id
     }
 
-    /// `Opstamp` of the last delete operation accounted for in the specified segment, if present.
-    pub fn delete_opstamp(&self, segment_id: &SegmentId) -> Option<Opstamp> {
-        self.segments.get(segment_id).copied().flatten()
-    }
-
     /// Return an iterator over the `(SegmentId, Option<Opstamp>)`.
     pub fn segments(&self) -> &BTreeMap<SegmentId, Option<Opstamp>> {
         &self.segments
-    }
-
-    /// Returns an ID identifying a searcher generation uniquely.
-    pub fn searcher_gen(&self) -> u64 {
-        self.generation_id
     }
 }
 

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -26,7 +26,7 @@ use std::{fmt, io};
 /// artifact should be refreshed or garbage collected.
 ///
 /// Depending on the use case, `Warmer`'s implementers can decide to
-/// product artifacts per:
+/// produce artifacts per:
 /// - `generation_id` (e.g. some searcher level aggregates)
 /// - `(segment_id, delete_opstamp)` (e.g. segment level aggregates)
 /// - `segment_id` (e.g. for immutable document level information)

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -18,18 +18,19 @@ use std::{fmt, io};
 
 /// Identifies the searcher generation accessed by a [Searcher].
 ///
-/// While this may seem, it contains both a `generation_id` AND a list of
-/// `(SegmentId, DeleteOpstamp)`.
+/// While this might seem redundant, a [SearcherGeneration] contains
+/// both a `generation_id` AND a list of `(SegmentId, DeleteOpstamp)`.
 ///
-/// The reason for this, is that this object is used by the `Warmer` API.
-/// It makes it possible to identify which artifact should be refreshed
-/// or garbage collected.
+/// This is on purpose. This object is used by the `Warmer` API.
+/// Having both information makes it possible to identify which
+/// artifact should be refreshed or garbage collected.
 ///
-/// Some `Warmer` might product artifact keyed by:
+/// Depending on the use case, `Warmer`'s implementers can decide to
+/// product artifacts per:
 /// - `generation_id` (e.g. some searcher level aggregates)
-/// - `(segment_id, delete_opstamp)`: segment level aggregates
-/// - `segment_id`: immutable document level information
-/// - `(generation_id, segment_id)`: consistent dynamic column.
+/// - `(segment_id, delete_opstamp)` (e.g. segment level aggregates)
+/// - `segment_id` (e.g. for immutable document level information)
+/// - `(generation_id, segment_id)` (e.g. for consistent dynamic column)
 /// - ...
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SearcherGeneration {

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -11,6 +11,7 @@ use crate::store::StoreReader;
 use crate::DocAddress;
 use crate::Index;
 
+use std::sync::Arc;
 use std::{fmt, io};
 
 /// Holds a list of `SegmentReader`s ready for search.
@@ -23,6 +24,7 @@ pub struct Searcher {
     index: Index,
     segment_readers: Vec<SegmentReader>,
     store_readers: Vec<StoreReader>,
+    _liveness_token: Arc<()>,
 }
 
 impl Searcher {
@@ -31,6 +33,7 @@ impl Searcher {
         schema: Schema,
         index: Index,
         segment_readers: Vec<SegmentReader>,
+        liveness_token: Arc<()>,
     ) -> io::Result<Searcher> {
         let store_readers: Vec<StoreReader> = segment_readers
             .iter()
@@ -41,6 +44,7 @@ impl Searcher {
             index,
             segment_readers,
             store_readers,
+            _liveness_token: liveness_token,
         })
     }
 

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -18,11 +18,11 @@ use std::sync::Arc;
 use std::sync::Weak;
 use std::{fmt, io};
 
-/// Identifies the data accessed by a generation of [Searcher].
+/// Identifies the index generation accessed by a [Searcher].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SearcherGeneration(BTreeMap<SegmentId, u32>);
+pub struct SearcherIndexGeneration(BTreeMap<SegmentId, u32>);
 
-impl SearcherGeneration {
+impl SearcherIndexGeneration {
     pub(crate) fn from_segment_readers(readers: &[SegmentReader]) -> Self {
         let mut segment_id_to_del_docs = BTreeMap::new();
         for reader in readers {
@@ -42,18 +42,18 @@ impl SearcherGeneration {
     }
 }
 
-/// A token that is coupled with the lifetime of a [SearcherGeneration].
+/// A token that is coupled with the lifetime of a generation of [Searcher].
 #[derive(Debug, Clone)]
-pub struct SearcherGenerationToken(Weak<SearcherGeneration>);
+pub struct SearcherGenerationToken(Weak<SearcherIndexGeneration>);
 
 impl SearcherGenerationToken {
-    /// Whether the [SearcherGeneration] is still alive.
+    /// Whether this generation of [Searcher] is still alive.
     pub fn is_live(&self) -> bool {
         self.0.strong_count() > 0
     }
 
-    /// Access the [SearcherGeneration] if it is still alive.
-    pub fn access(&self) -> Option<SearcherGeneration> {
+    /// Access the [SearcherIndexGeneration] if this generation of [Searcher] is still alive.
+    pub fn index_generation(&self) -> Option<SearcherIndexGeneration> {
         Weak::upgrade(&self.0).map(|gen| gen.deref().clone())
     }
 }
@@ -68,7 +68,7 @@ pub struct Searcher {
     index: Index,
     segment_readers: Vec<SegmentReader>,
     store_readers: Vec<StoreReader>,
-    generation: Arc<SearcherGeneration>,
+    index_generation: Arc<SearcherIndexGeneration>,
 }
 
 impl Searcher {
@@ -77,7 +77,7 @@ impl Searcher {
         schema: Schema,
         index: Index,
         segment_readers: Vec<SegmentReader>,
-        generation: Arc<SearcherGeneration>,
+        index_generation: Arc<SearcherIndexGeneration>,
     ) -> io::Result<Searcher> {
         let store_readers: Vec<StoreReader> = segment_readers
             .iter()
@@ -88,7 +88,7 @@ impl Searcher {
             index,
             segment_readers,
             store_readers,
-            generation,
+            index_generation,
         })
     }
 
@@ -97,14 +97,14 @@ impl Searcher {
         &self.index
     }
 
-    /// [SearcherGeneration] which uniquely identifies that data accessed by this generation of `Searcher`.
-    pub fn generation(&self) -> &SearcherGeneration {
-        &self.generation
+    /// [SearcherIndexGeneration] which identifies the index data accessed by this generation of `Searcher`.
+    pub fn index_generation(&self) -> &SearcherIndexGeneration {
+        &self.index_generation
     }
 
     /// [SearcherGenerationToken] which is coupled with the lifetime of this generation of `Searcher`.
     pub fn generation_token(&self) -> SearcherGenerationToken {
-        SearcherGenerationToken(Arc::downgrade(&self.generation))
+        SearcherGenerationToken(Arc::downgrade(&self.index_generation))
     }
 
     /// Fetches a document from tantivy's store given a `DocAddress`.

--- a/src/core/segment_reader.rs
+++ b/src/core/segment_reader.rs
@@ -17,6 +17,7 @@ use crate::space_usage::SegmentSpaceUsage;
 use crate::store::StoreReader;
 use crate::termdict::TermDictionary;
 use crate::DocId;
+use crate::Opstamp;
 use fail::fail_point;
 use std::fmt;
 use std::sync::Arc;
@@ -38,6 +39,8 @@ pub struct SegmentReader {
     inv_idx_reader_cache: Arc<RwLock<HashMap<Field, Arc<InvertedIndexReader>>>>,
 
     segment_id: SegmentId,
+    delete_opstamp: Option<Opstamp>,
+
     max_doc: DocId,
     num_docs: DocId,
 
@@ -205,6 +208,7 @@ impl SegmentReader {
             fast_fields_readers: fast_field_readers,
             fieldnorm_readers,
             segment_id: segment.id(),
+            delete_opstamp: segment.meta().delete_opstamp(),
             store_file,
             alive_bitset_opt,
             positions_composite,
@@ -288,6 +292,11 @@ impl SegmentReader {
     /// Returns the segment id
     pub fn segment_id(&self) -> SegmentId {
         self.segment_id
+    }
+
+    /// Returns the delete opstamp
+    pub fn delete_opstamp(&self) -> Option<Opstamp> {
+        self.delete_opstamp
     }
 
     /// Returns the bitset representing

--- a/src/indexer/merge_operation.rs
+++ b/src/indexer/merge_operation.rs
@@ -1,6 +1,6 @@
 use crate::Opstamp;
 use crate::SegmentId;
-use census::{Inventory, TrackedObject};
+use crate::{Inventory, TrackedObject};
 use std::collections::HashSet;
 use std::ops::Deref;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,8 +166,8 @@ mod docset;
 pub use self::docset::{DocSet, TERMINATED};
 pub use crate::core::{Executor, SegmentComponent};
 pub use crate::core::{
-    Index, IndexBuilder, IndexMeta, IndexSettings, IndexSortByField, Order, Searcher, Segment,
-    SegmentId, SegmentMeta,
+    Index, IndexBuilder, IndexMeta, IndexSettings, IndexSortByField, Order, Searcher,
+    SearcherGeneration, SearcherGenerationToken, Segment, SegmentId, SegmentMeta,
 };
 pub use crate::core::{InvertedIndexReader, SegmentReader};
 pub use crate::directory::Directory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub use self::docset::{DocSet, TERMINATED};
 pub use crate::core::{Executor, SegmentComponent};
 pub use crate::core::{
     Index, IndexBuilder, IndexMeta, IndexSettings, IndexSortByField, Order, Searcher,
-    SearcherGenerationToken, SearcherIndexGeneration, Segment, SegmentId, SegmentMeta,
+    SearcherIndexGeneration, Segment, SegmentId, SegmentMeta,
 };
 pub use crate::core::{InvertedIndexReader, SegmentReader};
 pub use crate::directory::Directory;
@@ -179,6 +179,7 @@ pub use crate::indexer::{IndexWriter, PreparedCommit};
 pub use crate::postings::Postings;
 pub use crate::reader::LeasedItem;
 pub use crate::schema::{Document, Term};
+pub use census::{Inventory, TrackedObject};
 pub use common::HasLen;
 pub use common::{f64_to_u64, i64_to_u64, u64_to_f64, u64_to_i64};
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub use self::docset::{DocSet, TERMINATED};
 pub use crate::core::{Executor, SegmentComponent};
 pub use crate::core::{
     Index, IndexBuilder, IndexMeta, IndexSettings, IndexSortByField, Order, Searcher,
-    SearcherIndexGeneration, Segment, SegmentId, SegmentMeta,
+    SearcherGeneration, Segment, SegmentId, SegmentMeta,
 };
 pub use crate::core::{InvertedIndexReader, SegmentReader};
 pub use crate::directory::Directory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub use self::docset::{DocSet, TERMINATED};
 pub use crate::core::{Executor, SegmentComponent};
 pub use crate::core::{
     Index, IndexBuilder, IndexMeta, IndexSettings, IndexSortByField, Order, Searcher,
-    SearcherGeneration, SearcherGenerationToken, Segment, SegmentId, SegmentMeta,
+    SearcherGenerationToken, SearcherIndexGeneration, Segment, SegmentId, SegmentMeta,
 };
 pub use crate::core::{InvertedIndexReader, SegmentReader};
 pub use crate::directory::Directory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub mod termdict;
 
 mod reader;
 
-pub use self::reader::{IndexReader, IndexReaderBuilder, ReloadPolicy};
+pub use self::reader::{IndexReader, IndexReaderBuilder, ReloadPolicy, Warmer};
 mod snippet;
 pub use self::snippet::{Snippet, SnippetGenerator};
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -179,7 +179,7 @@ impl InnerIndexReader {
         Ok(segment_readers)
     }
 
-    fn create_new_index_generation(
+    fn create_new_searcher_generation(
         &self,
         segment_readers: &[SegmentReader],
     ) -> TrackedObject<SearcherGeneration> {
@@ -194,14 +194,14 @@ impl InnerIndexReader {
 
     fn reload(&self) -> crate::Result<()> {
         let segment_readers = self.open_segment_readers()?;
-        let index_generation = self.create_new_index_generation(&segment_readers);
+        let searcher_generation = self.create_new_searcher_generation(&segment_readers);
         let schema = self.index.schema();
         let searchers: Vec<Searcher> = std::iter::repeat_with(|| {
             Searcher::new(
                 schema.clone(),
                 self.index.clone(),
                 segment_readers.clone(),
-                index_generation.clone(),
+                searcher_generation.clone(),
             )
         })
         .take(self.num_searchers)

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -4,7 +4,7 @@ mod warming;
 pub use self::pool::LeasedItem;
 use self::pool::Pool;
 use self::warming::WarmingState;
-use crate::core::searcher::SearcherIndexGeneration;
+use crate::core::searcher::SearcherGeneration;
 use crate::directory::WatchHandle;
 use crate::directory::META_LOCK;
 use crate::directory::{Directory, WatchCallback};
@@ -160,7 +160,7 @@ struct InnerIndexReader {
     warming_state: WarmingState,
     searcher_pool: Pool<Searcher>,
     searcher_generation_counter: Arc<AtomicU64>,
-    searcher_generation_inventory: Inventory<SearcherIndexGeneration>,
+    searcher_generation_inventory: Inventory<SearcherGeneration>,
 }
 
 impl InnerIndexReader {
@@ -180,11 +180,11 @@ impl InnerIndexReader {
         Ok(segment_readers)
     }
 
-    fn create_new_index_generation(&self, segment_readers: &[SegmentReader]) -> TrackedObject<SearcherIndexGeneration> {
+    fn create_new_index_generation(&self, segment_readers: &[SegmentReader]) -> TrackedObject<SearcherGeneration> {
         let generation = self
             .searcher_generation_counter
             .fetch_add(1, atomic::Ordering::Relaxed);
-        let searcher_generation = SearcherIndexGeneration::from_segment_readers(
+        let searcher_generation = SearcherGeneration::from_segment_readers(
             segment_readers,
             generation,
         );

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -181,12 +181,12 @@ impl InnerIndexReader {
     }
 
     fn create_new_index_generation(&self, segment_readers: &[SegmentReader]) -> TrackedObject<SearcherGeneration> {
-        let generation = self
+        let generation_id = self
             .searcher_generation_counter
             .fetch_add(1, atomic::Ordering::Relaxed);
         let searcher_generation = SearcherGeneration::from_segment_readers(
             segment_readers,
-            generation,
+            generation_id,
         );
         self
             .searcher_generation_inventory

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -114,7 +114,7 @@ impl IndexReaderBuilder {
 
     /// Sets the number of [Searcher] to pool.
     ///
-    /// When more than `num_searchers` are requested, the caller will block.
+    /// See [Self::searcher()].
     pub fn num_searchers(mut self, num_searchers: usize) -> IndexReaderBuilder {
         self.num_searchers = num_searchers;
         self

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -4,7 +4,7 @@ mod warming;
 pub use self::pool::LeasedItem;
 use self::pool::Pool;
 use self::warming::WarmingState;
-use crate::core::searcher::SearcherGeneration;
+use crate::core::searcher::SearcherIndexGeneration;
 use crate::core::Segment;
 use crate::directory::WatchHandle;
 use crate::directory::META_LOCK;
@@ -161,15 +161,16 @@ impl InnerIndexReader {
                 .map(SegmentReader::open)
                 .collect::<crate::Result<_>>()?
         };
-        let searcher_generation =
-            Arc::new(SearcherGeneration::from_segment_readers(&segment_readers));
+        let searcher_index_generation = Arc::new(SearcherIndexGeneration::from_segment_readers(
+            &segment_readers,
+        ));
         let schema = self.index.schema();
         let searchers: Vec<Searcher> = std::iter::repeat_with(|| {
             Searcher::new(
                 schema.clone(),
                 self.index.clone(),
                 segment_readers.clone(),
-                searcher_generation.clone(),
+                searcher_index_generation.clone(),
             )
         })
         .take(self.num_searchers)

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -164,13 +164,12 @@ struct InnerIndexReader {
 }
 
 impl InnerIndexReader {
-
     /// Opens the freshest segments `SegmentReader`.
     ///
     /// This function acquires a lot to prevent GC from removing files
     /// as we are opening our index.
     fn open_segment_readers(&self) -> crate::Result<Vec<SegmentReader>> {
-         // Prevents segment files from getting deleted while we are in the process of opening them
+        // Prevents segment files from getting deleted while we are in the process of opening them
         let _meta_lock = self.index.directory().acquire_lock(&META_LOCK)?;
         let searchable_segments = self.index.searchable_segments()?;
         let segment_readers = searchable_segments
@@ -180,16 +179,16 @@ impl InnerIndexReader {
         Ok(segment_readers)
     }
 
-    fn create_new_index_generation(&self, segment_readers: &[SegmentReader]) -> TrackedObject<SearcherGeneration> {
+    fn create_new_index_generation(
+        &self,
+        segment_readers: &[SegmentReader],
+    ) -> TrackedObject<SearcherGeneration> {
         let generation_id = self
             .searcher_generation_counter
             .fetch_add(1, atomic::Ordering::Relaxed);
-        let searcher_generation = SearcherGeneration::from_segment_readers(
-            segment_readers,
-            generation_id,
-        );
-        self
-            .searcher_generation_inventory
+        let searcher_generation =
+            SearcherGeneration::from_segment_readers(segment_readers, generation_id);
+        self.searcher_generation_inventory
             .track(searcher_generation)
     }
 

--- a/src/reader/warming.rs
+++ b/src/reader/warming.rs
@@ -155,18 +155,17 @@ impl WarmingStateInner {
     /// Start GC thread if one has not already been started.
     fn start_gc_thread_maybe(&mut self, this: &Arc<Mutex<Self>>) -> crate::Result<bool> {
         if self.gc_thread.is_some() {
-            Ok(false)
-        } else {
-            let weak_inner = Arc::downgrade(this);
-            let handle = std::thread::Builder::new()
-                .name("tantivy-warm-gc".to_owned())
-                .spawn(|| Self::gc_loop(weak_inner))
-                .map_err(|_| {
-                    TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
-                })?;
-            self.gc_thread = Some(handle);
-            Ok(true)
+            return Ok(false);
         }
+        let weak_inner = Arc::downgrade(this);
+        let handle = std::thread::Builder::new()
+            .name("tantivy-warm-gc".to_owned())
+            .spawn(|| Self::gc_loop(weak_inner))
+            .map_err(|_| {
+               TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
+             })?;
+        self.gc_thread = Some(handle);
+        Ok(true)
     }
 
     /// Every [GC_INTERVAL] attempt to GC, with panics caught and logged using [std::panic::catch_unwind].

--- a/src/reader/warming.rs
+++ b/src/reader/warming.rs
@@ -37,11 +37,11 @@ impl WarmingState {
     /// Start tracking a new generation of [Searcher], and [Warmer::warm] it if there are active warmers.
     ///
     /// A background GC thread for [Warmer::garbage_collect] calls is uniquely created if there are active warmers.
-    pub fn new_searcher_generation(&self, searcher: &Searcher) -> crate::Result<()> {
+    pub fn warm_new_searcher_generation(&self, searcher: &Searcher) -> crate::Result<()> {
         self.0
             .lock()
             .unwrap()
-            .new_searcher_generation(searcher, &self.0)
+            .warm_new_searcher_generation(searcher, &self.0)
     }
 
     #[cfg(test)]
@@ -61,7 +61,7 @@ impl WarmingStateInner {
     /// Start tracking provided searcher as an exemplar of a new generation.
     /// If there are active warmers, warm them with the provided searcher, and kick background GC thread if it has not yet been kicked.
     /// Otherwise, prune state for dropped searcher generations inline.
-    fn new_searcher_generation(
+    fn warm_new_searcher_generation(
         &mut self,
         searcher: &Searcher,
         this: &Arc<Mutex<Self>>,
@@ -109,7 +109,7 @@ impl WarmingStateInner {
             let mut i = 0;
             while i < tokens.len() {
                 if !tokens[i].is_live() {
-                    tokens.remove(i);
+                    tokens.swap_remove(i);
                 } else {
                     i += 1;
                 }

--- a/src/reader/warming.rs
+++ b/src/reader/warming.rs
@@ -17,7 +17,7 @@ pub trait Warmer: Sync + Send {
     /// Perform any warming work using the provided [Searcher].
     fn warm(&self, searcher: &Searcher) -> crate::Result<()>;
 
-    /// Discard internal state for any [SearcherIndexGeneration] not provided.
+    /// Discards internal state for any [SearcherGeneration] not provided.
     fn garbage_collect(&self, live_generations: &[TrackedObject<SearcherGeneration>]);
 }
 
@@ -83,7 +83,7 @@ impl WarmingStateInner {
         }
         self.start_gc_thread_maybe(this)?;
         self.warmed_generation_ids
-            .insert(searcher.index_generation().generation_id());
+            .insert(searcher.generation().generation_id());
         warming_executor(self.num_warming_threads.min(warmers.len()))?
             .map(|warmer| warmer.warm(searcher), warmers.into_iter())?;
         Ok(())

--- a/src/reader/warming.rs
+++ b/src/reader/warming.rs
@@ -1,0 +1,384 @@
+use std::{
+    collections::HashSet,
+    iter::FromIterator,
+    sync::{Arc, Mutex, Weak},
+    thread::JoinHandle,
+    time::Duration,
+};
+
+use crate::{Executor, Searcher, SegmentId, TantivyError};
+
+pub const GC_INTERVAL: Duration = Duration::from_secs(1);
+
+/// `Warmer` can be used to maintain segment-level state e.g. caches.
+///
+/// They must be registered with the [IndexReaderBuilder].
+pub trait Warmer: Sync + Send {
+    /// Perform any warming work using the provided [Searcher].
+    fn warm(&self, searcher: &Searcher) -> crate::Result<()>;
+
+    /// Discard internal state for any [SegmentId] not provided.
+    fn garbage_collect(&self, live_segment_ids: &HashSet<SegmentId>);
+}
+
+/// Warming-related state with interior mutability.
+#[derive(Clone)]
+pub(crate) struct WarmingState(Arc<Mutex<WarmingStateInner>>);
+
+impl WarmingState {
+    pub fn new(num_warming_threads: usize, warmers: Vec<Weak<dyn Warmer>>) -> crate::Result<Self> {
+        Ok(Self(Arc::new(Mutex::new(WarmingStateInner {
+            num_warming_threads,
+            warmers,
+            searcher_generations: Vec::new(),
+            gc_thread: None,
+        }))))
+    }
+
+    /// Start tracking a new generation of searchers, and [Warmer::warm] it if there are active warmers.
+    ///
+    /// A background GC thread for [Warmer::garbage_collect] calls is uniquely created if there are active warmers.
+    pub fn new_searcher_generation(
+        &self,
+        liveness_token: Weak<()>,
+        searcher: &Searcher,
+    ) -> crate::Result<()> {
+        self.0
+            .lock()
+            .unwrap()
+            .new_searcher_generation(liveness_token, searcher, &self.0)
+    }
+
+    #[cfg(test)]
+    fn gc_maybe(&self) -> bool {
+        self.0.lock().unwrap().gc_maybe()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SearcherGeneration {
+    liveness_token: Weak<()>,
+    segment_ids: Vec<SegmentId>,
+}
+
+impl SearcherGeneration {
+    fn is_live(&self) -> bool {
+        self.liveness_token.strong_count() > 0
+    }
+}
+
+#[derive(Default)]
+struct WarmingStateInner {
+    num_warming_threads: usize,
+    warmers: Vec<Weak<dyn Warmer>>,
+    searcher_generations: Vec<SearcherGeneration>,
+    gc_thread: Option<JoinHandle<()>>,
+}
+
+impl WarmingStateInner {
+    /// Start tracking provided searcher's segment IDs with its liveness token.
+    /// If there are active warmers, warm them with the provided searcher, and kick background GC thread if it has not yet been kicked.
+    /// Otherwise, prune state for dropped searcher generations inline.
+    fn new_searcher_generation(
+        &mut self,
+        liveness_token: Weak<()>,
+        searcher: &Searcher,
+        this: &Arc<Mutex<Self>>,
+    ) -> crate::Result<()> {
+        self.searcher_generations.push(SearcherGeneration {
+            liveness_token,
+            segment_ids: segment_ids(searcher),
+        });
+        let warmers = self.pruned_warmers();
+        // Avoid threads (warming as well as background GC) if there are no warmers
+        if warmers.is_empty() {
+            self.prune_searcher_generations();
+        } else {
+            self.start_gc_thread_maybe(this)?;
+            warming_executor(self.num_warming_threads.min(warmers.len()))?
+                .map(|warmer| warmer.warm(searcher), warmers.into_iter())?;
+        }
+        Ok(())
+    }
+
+    /// Attempt to upgrade the weak Warmer references, pruning those which cannot be upgraded.
+    /// Return the strong references.
+    fn pruned_warmers(&mut self) -> Vec<Arc<dyn Warmer>> {
+        let strong_warmers = self
+            .warmers
+            .iter()
+            .flat_map(|weak_warmer| weak_warmer.upgrade())
+            .collect::<Vec<_>>();
+        self.warmers = strong_warmers.iter().map(Arc::downgrade).collect();
+        strong_warmers
+    }
+
+    /// Prune dropped searcher generations from our state.
+    /// Return count of removed generations.
+    fn prune_searcher_generations(&mut self) -> usize {
+        // This can be implemented neatly using Vec::drain_filter() when that is stable.
+        let mut pruned = 0;
+        let mut i = 0;
+        while i < self.searcher_generations.len() {
+            if !self.searcher_generations[i].is_live() {
+                self.searcher_generations.remove(i);
+                pruned += 1;
+            } else {
+                i += 1;
+            }
+        }
+        pruned
+    }
+
+    /// Segment ID set of live searcher generations.
+    fn live_segment_ids(&self) -> HashSet<SegmentId> {
+        self.searcher_generations
+            .iter()
+            .filter(|gen| gen.is_live())
+            .flat_map(|gen| gen.segment_ids.iter().copied())
+            .collect()
+    }
+
+    /// [Warmer::garbage_collect] active warmers if some searcher generation is observed to have been dropped.
+    fn gc_maybe(&mut self) -> bool {
+        if self.prune_searcher_generations() > 0 {
+            let live_segment_ids = self.live_segment_ids();
+            for warmer in self.pruned_warmers() {
+                warmer.garbage_collect(&live_segment_ids);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Start GC thread if one has not already been started.
+    fn start_gc_thread_maybe(&mut self, this: &Arc<Mutex<Self>>) -> crate::Result<bool> {
+        if self.gc_thread.is_some() {
+            Ok(false)
+        } else {
+            let weak_inner = Arc::downgrade(this);
+            let handle = std::thread::Builder::new()
+                .name("tantivy-warm-gc".to_owned())
+                .spawn(|| Self::gc_loop(weak_inner))
+                .map_err(|_| {
+                    TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
+                })?;
+            self.gc_thread = Some(handle);
+            Ok(true)
+        }
+    }
+
+    /// Every [GC_INTERVAL] attempt to GC, with panics caught and logged using [std::panic::catch_unwind].
+    fn gc_loop(inner: Weak<Mutex<WarmingStateInner>>) {
+        for _ in crossbeam::channel::tick(GC_INTERVAL) {
+            if let Some(inner) = inner.upgrade() {
+                // rely on deterministic gc in tests
+                #[cfg(not(test))]
+                if let Err(err) = std::panic::catch_unwind(|| inner.lock().unwrap().gc_maybe()) {
+                    error!("Panic in Warmer GC {:?}", err);
+                }
+                // avoid unused var warning in tests
+                #[cfg(test)]
+                drop(inner);
+            }
+        }
+    }
+}
+
+fn warming_executor(num_threads: usize) -> crate::Result<Executor> {
+    if num_threads <= 1 {
+        Ok(Executor::single_thread())
+    } else {
+        Executor::multi_thread(num_threads, "tantivy-warm-")
+    }
+}
+
+fn segment_ids<T>(searcher: &Searcher) -> T
+where
+    T: FromIterator<SegmentId>,
+{
+    searcher
+        .segment_readers()
+        .iter()
+        .map(|reader| reader.segment_id())
+        .collect::<T>()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        sync::{
+            atomic::{self, AtomicUsize},
+            Arc, RwLock, Weak,
+        },
+    };
+
+    use crate::{
+        directory::RamDirectory,
+        reader::warming::segment_ids,
+        schema::{Schema, INDEXED},
+        Index, IndexSettings, ReloadPolicy, SegmentId,
+    };
+
+    use super::Warmer;
+
+    #[derive(Default)]
+    struct TestWarmer {
+        active_segment_ids: RwLock<HashSet<SegmentId>>,
+        warm_calls: AtomicUsize,
+        gc_calls: AtomicUsize,
+    }
+
+    impl TestWarmer {
+        fn live_segment_ids(&self) -> HashSet<SegmentId> {
+            self.active_segment_ids.read().unwrap().clone()
+        }
+
+        fn warm_calls(&self) -> usize {
+            self.warm_calls.load(atomic::Ordering::Acquire)
+        }
+
+        fn gc_calls(&self) -> usize {
+            self.gc_calls.load(atomic::Ordering::Acquire)
+        }
+
+        fn verify(
+            &self,
+            expected_warm_calls: usize,
+            expected_gc_calls: usize,
+            expected_segment_ids: HashSet<SegmentId>,
+        ) {
+            assert_eq!(self.warm_calls(), expected_warm_calls);
+            assert_eq!(self.gc_calls(), expected_gc_calls);
+            assert_eq!(self.live_segment_ids(), expected_segment_ids);
+        }
+    }
+
+    impl Warmer for TestWarmer {
+        fn warm(&self, searcher: &crate::Searcher) -> crate::Result<()> {
+            self.warm_calls.fetch_add(1, atomic::Ordering::SeqCst);
+            for reader in searcher.segment_readers() {
+                self.active_segment_ids
+                    .write()
+                    .unwrap()
+                    .insert(reader.segment_id());
+            }
+            Ok(())
+        }
+
+        fn garbage_collect(&self, segment_ids: &HashSet<SegmentId>) {
+            self.gc_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.active_segment_ids
+                .write()
+                .unwrap()
+                .retain(|id| segment_ids.contains(id));
+        }
+    }
+
+    fn test_warming(num_warming_threads: usize) -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let field = schema_builder.add_u64_field("pk", INDEXED);
+        let schema = schema_builder.build();
+
+        let directory = RamDirectory::create();
+        let index = Index::create(directory.clone(), schema, IndexSettings::default())?;
+
+        let num_writer_threads = 4;
+        let mut writer = index
+            .writer_with_num_threads(num_writer_threads, 25_000_000)
+            .unwrap();
+
+        for i in 0u64..1000u64 {
+            writer.add_document(doc!(field => i))?;
+        }
+        writer.commit()?;
+
+        let warmer1 = Arc::new(TestWarmer::default());
+        let warmer2 = Arc::new(TestWarmer::default());
+        warmer1.verify(0, 0, HashSet::new());
+        warmer2.verify(0, 0, HashSet::new());
+
+        let num_searchers = 4;
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .num_warming_threads(num_warming_threads)
+            .num_searchers(num_searchers)
+            .warmers(vec![
+                Arc::downgrade(&warmer1) as Weak<dyn Warmer>,
+                Arc::downgrade(&warmer2) as Weak<dyn Warmer>,
+            ])
+            .try_into()?;
+
+        let warming_state = &reader.inner.warming_state;
+
+        {
+            let searcher = reader.searcher();
+            assert_eq!(searcher.segment_readers().len(), num_writer_threads);
+            assert!(
+                !warming_state.gc_maybe(),
+                "no GC after first searcher generation"
+            );
+            warmer1.verify(1, 0, segment_ids(&searcher));
+            warmer2.verify(1, 0, segment_ids(&searcher));
+            assert_eq!(searcher.num_docs(), 1000);
+        }
+
+        reader.reload()?;
+        warming_state.gc_maybe();
+
+        let searcher = reader.searcher();
+        assert_eq!(searcher.num_docs(), 1000);
+        warmer1.verify(2, 1, segment_ids(&searcher));
+        warmer2.verify(2, 1, segment_ids(&searcher));
+
+        for i in 1000u64..2000u64 {
+            writer.add_document(doc!(field => i))?;
+        }
+        writer.commit()?;
+        writer.wait_merging_threads()?;
+
+        drop(warmer1);
+
+        let old_searcher = searcher;
+
+        reader.reload()?;
+        assert!(!warming_state.gc_maybe(), "old searcher still around");
+
+        let searcher = reader.searcher();
+        assert_eq!(searcher.num_docs(), 2000);
+
+        warmer2.verify(
+            3,
+            1,
+            segment_ids::<HashSet<_>>(&old_searcher)
+                .union(&segment_ids(&searcher))
+                .copied()
+                .collect(),
+        );
+
+        drop(old_searcher);
+        for _ in 0..num_searchers {
+            // make sure the old searcher is dropped by the pool too
+            let _ = reader.searcher();
+        }
+        assert!(warming_state.gc_maybe(), "old searcher dropped");
+
+        warmer2.verify(3, 2, segment_ids(&searcher));
+
+        Ok(())
+    }
+
+    #[test]
+    fn warming_single_thread() -> crate::Result<()> {
+        test_warming(1)
+    }
+
+    #[test]
+    fn warming_four_threads() -> crate::Result<()> {
+        test_warming(4)
+    }
+}

--- a/src/reader/warming.rs
+++ b/src/reader/warming.rs
@@ -162,8 +162,8 @@ impl WarmingStateInner {
             .name("tantivy-warm-gc".to_owned())
             .spawn(|| Self::gc_loop(weak_inner))
             .map_err(|_| {
-               TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
-             })?;
+                TantivyError::SystemError("Failed to spawn warmer GC thread".to_owned())
+            })?;
         self.gc_thread = Some(handle);
         Ok(true)
     }


### PR DESCRIPTION
Warmer implementations can be registered with the IndexReaderBuilder and used to maintain any segment-level caches effectively.

By integrating Warmer::warm() with the reload mechanism, we can ensure that any new segments are warmed before they can be exercised via a new generation of Searchers.

Warmer::garbage_collect() is called when some searcher generation has been fully dropped, with the set of segment IDs that are still active. This allows implementations to prune redundant state.