### PR TITLE
rename IntOptions to NumericOptions

### DIFF
--- a/examples/aggregation.rs
+++ b/examples/aggregation.rs
@@ -26,7 +26,8 @@ fn main() -> tantivy::Result<()> {
         )
         .set_stored();
     let text_field = schema_builder.add_text_field("text", text_fieldtype);
-    let score_fieldtype = crate::schema::IntOptions::default().set_fast(Cardinality::SingleValue);
+    let score_fieldtype =
+        crate::schema::NumericOptions::default().set_fast(Cardinality::SingleValue);
     let highscore_field = schema_builder.add_f64_field("highscore", score_fieldtype.clone());
     let price_field = schema_builder.add_f64_field("price", score_fieldtype.clone());
 

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -304,13 +304,13 @@ mod tests {
             .set_stored();
         let text_field = schema_builder.add_text_field("text", text_fieldtype);
         let score_fieldtype =
-            crate::schema::IntOptions::default().set_fast(Cardinality::SingleValue);
+            crate::schema::NumericOptions::default().set_fast(Cardinality::SingleValue);
         let score_field = schema_builder.add_u64_field("score", score_fieldtype.clone());
         let score_field_f64 = schema_builder.add_f64_field("score_f64", score_fieldtype.clone());
         let score_field_i64 = schema_builder.add_i64_field("score_i64", score_fieldtype);
         let fraction_field = schema_builder.add_f64_field(
             "fraction_f64",
-            crate::schema::IntOptions::default().set_fast(Cardinality::SingleValue),
+            crate::schema::NumericOptions::default().set_fast(Cardinality::SingleValue),
         );
         let index = Index::create_in_ram(schema_builder.build());
         {
@@ -451,7 +451,7 @@ mod tests {
             .set_stored();
         let text_field = schema_builder.add_text_field("text", text_fieldtype);
         let score_fieldtype =
-            crate::schema::IntOptions::default().set_fast(Cardinality::SingleValue);
+            crate::schema::NumericOptions::default().set_fast(Cardinality::SingleValue);
         let score_field = schema_builder.add_u64_field("score", score_fieldtype.clone());
         let score_field_f64 = schema_builder.add_f64_field("score_f64", score_fieldtype.clone());
         let score_field_i64 = schema_builder.add_i64_field("score_i64", score_fieldtype);
@@ -888,7 +888,7 @@ mod tests {
                 .set_stored();
             let text_field = schema_builder.add_text_field("text", text_fieldtype);
             let score_fieldtype =
-                crate::schema::IntOptions::default().set_fast(Cardinality::SingleValue);
+                crate::schema::NumericOptions::default().set_fast(Cardinality::SingleValue);
             let score_field = schema_builder.add_u64_field("score", score_fieldtype.clone());
             let score_field_f64 =
                 schema_builder.add_f64_field("score_f64", score_fieldtype.clone());

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -64,7 +64,7 @@ fn load_metas(
 /// let body_field = schema_builder.add_text_field("body", TEXT);
 /// let number_field = schema_builder.add_u64_field(
 ///     "number",
-///     IntOptions::default().set_fast(Cardinality::SingleValue),
+///     NumericOptions::default().set_fast(Cardinality::SingleValue),
 /// );
 ///
 /// let schema = schema_builder.build();

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -212,7 +212,7 @@ mod tests {
     use super::*;
     use crate::directory::{CompositeFile, Directory, RamDirectory, WritePtr};
     use crate::merge_policy::NoMergePolicy;
-    use crate::schema::{Document, Field, IntOptions, Schema, FAST};
+    use crate::schema::{Document, Field, NumericOptions, Schema, FAST};
     use crate::{Index, SegmentId, SegmentReader};
 
     pub static SCHEMA: Lazy<Schema> = Lazy::new(|| {
@@ -520,7 +520,7 @@ mod tests {
         let date_field = schema_builder.add_date_field("date", FAST);
         let multi_date_field = schema_builder.add_date_field(
             "multi_date",
-            IntOptions::default().set_fast(Cardinality::MultiValues),
+            NumericOptions::default().set_fast(Cardinality::MultiValues),
         );
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -16,7 +16,7 @@ mod tests {
     use crate::collector::TopDocs;
     use crate::indexer::NoMergePolicy;
     use crate::query::QueryParser;
-    use crate::schema::{Cardinality, Facet, FacetOptions, IntOptions, Schema};
+    use crate::schema::{Cardinality, Facet, FacetOptions, NumericOptions, Schema};
     use crate::{Document, Index, Term};
 
     #[test]
@@ -24,7 +24,7 @@ mod tests {
         let mut schema_builder = Schema::builder();
         let field = schema_builder.add_u64_field(
             "multifield",
-            IntOptions::default().set_fast(Cardinality::MultiValues),
+            NumericOptions::default().set_fast(Cardinality::MultiValues),
         );
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
@@ -59,14 +59,14 @@ mod tests {
         let mut schema_builder = Schema::builder();
         let date_field = schema_builder.add_date_field(
             "multi_date_field",
-            IntOptions::default()
+            NumericOptions::default()
                 .set_fast(Cardinality::MultiValues)
                 .set_indexed()
                 .set_fieldnorm()
                 .set_stored(),
         );
         let time_i =
-            schema_builder.add_i64_field("time_stamp_i", IntOptions::default().set_stored());
+            schema_builder.add_i64_field("time_stamp_i", NumericOptions::default().set_stored());
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests()?;
@@ -196,7 +196,7 @@ mod tests {
         let mut schema_builder = Schema::builder();
         let field = schema_builder.add_i64_field(
             "multifield",
-            IntOptions::default().set_fast(Cardinality::MultiValues),
+            NumericOptions::default().set_fast(Cardinality::MultiValues),
         );
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
@@ -226,7 +226,7 @@ mod tests {
         let mut schema_builder = Schema::builder();
         let field = schema_builder.add_u64_field(
             "multifield",
-            IntOptions::default()
+            NumericOptions::default()
                 .set_fast(Cardinality::MultiValues)
                 .set_indexed(),
         );

--- a/src/fastfield/multivalued/reader.rs
+++ b/src/fastfield/multivalued/reader.rs
@@ -90,7 +90,7 @@ impl<Item: FastValue> MultiValueLength for MultiValuedFastFieldReader<Item> {
 mod tests {
 
     use crate::core::Index;
-    use crate::schema::{Cardinality, Facet, FacetOptions, IntOptions, Schema};
+    use crate::schema::{Cardinality, Facet, FacetOptions, NumericOptions, Schema};
 
     #[test]
     fn test_multifastfield_reader() -> crate::Result<()> {
@@ -148,7 +148,7 @@ mod tests {
     #[test]
     fn test_multifastfield_reader_min_max() -> crate::Result<()> {
         let mut schema_builder = Schema::builder();
-        let field_options = IntOptions::default()
+        let field_options = NumericOptions::default()
             .set_indexed()
             .set_fast(Cardinality::MultiValues);
         let item_field = schema_builder.add_i64_field("items", field_options);

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -168,12 +168,12 @@ mod tests_indexsorting {
         let my_string_field = schema_builder.add_text_field("string_field", STRING | STORED);
         let my_number = schema_builder.add_u64_field(
             "my_number",
-            IntOptions::default().set_fast(Cardinality::SingleValue),
+            NumericOptions::default().set_fast(Cardinality::SingleValue),
         );
 
         let multi_numbers = schema_builder.add_u64_field(
             "multi_numbers",
-            IntOptions::default().set_fast(Cardinality::MultiValues),
+            NumericOptions::default().set_fast(Cardinality::MultiValues),
         );
 
         let schema = schema_builder.build();

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -794,8 +794,8 @@ mod tests {
     use crate::indexer::NoMergePolicy;
     use crate::query::{QueryParser, TermQuery};
     use crate::schema::{
-        self, Cardinality, Facet, FacetOptions, IndexRecordOption, IntOptions, TextFieldIndexing,
-        TextOptions, FAST, INDEXED, STORED, STRING, TEXT,
+        self, Cardinality, Facet, FacetOptions, IndexRecordOption, NumericOptions,
+        TextFieldIndexing, TextOptions, FAST, INDEXED, STORED, STRING, TEXT,
     };
     use crate::{DocAddress, Index, IndexSettings, IndexSortByField, Order, ReloadPolicy, Term};
 
@@ -1404,7 +1404,7 @@ mod tests {
 
         let multi_numbers = schema_builder.add_u64_field(
             "multi_numbers",
-            IntOptions::default()
+            NumericOptions::default()
                 .set_fast(Cardinality::MultiValues)
                 .set_stored(),
         );

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1137,7 +1137,7 @@ mod tests {
     use crate::fastfield::FastFieldReader;
     use crate::query::{AllQuery, BooleanQuery, Scorer, TermQuery};
     use crate::schema::{
-        Cardinality, Document, Facet, FacetOptions, IndexRecordOption, IntOptions, Term,
+        Cardinality, Document, Facet, FacetOptions, IndexRecordOption, NumericOptions, Term,
         TextFieldIndexing, INDEXED, TEXT,
     };
     use crate::{
@@ -1157,7 +1157,7 @@ mod tests {
             .set_stored();
         let text_field = schema_builder.add_text_field("text", text_fieldtype);
         let date_field = schema_builder.add_date_field("date", INDEXED);
-        let score_fieldtype = schema::IntOptions::default().set_fast(Cardinality::SingleValue);
+        let score_fieldtype = schema::NumericOptions::default().set_fast(Cardinality::SingleValue);
         let score_field = schema_builder.add_u64_field("score", score_fieldtype);
         let bytes_score_field = schema_builder.add_bytes_field("score_bytes", FAST);
         let index = Index::create_in_ram(schema_builder.build());
@@ -1306,7 +1306,7 @@ mod tests {
             )
             .set_stored();
         let text_field = schema_builder.add_text_field("text", text_fieldtype);
-        let score_fieldtype = schema::IntOptions::default().set_fast(Cardinality::SingleValue);
+        let score_fieldtype = schema::NumericOptions::default().set_fast(Cardinality::SingleValue);
         let score_field = schema_builder.add_u64_field("score", score_fieldtype);
         let bytes_score_field = schema_builder.add_bytes_field("score_bytes", FAST);
         let index = Index::create_in_ram(schema_builder.build());
@@ -1666,7 +1666,7 @@ mod tests {
     fn test_merge_facets(index_settings: Option<IndexSettings>, force_segment_value_overlap: bool) {
         let mut schema_builder = schema::Schema::builder();
         let facet_field = schema_builder.add_facet_field("facet", FacetOptions::default());
-        let int_options = IntOptions::default()
+        let int_options = NumericOptions::default()
             .set_fast(Cardinality::SingleValue)
             .set_indexed();
         let int_field = schema_builder.add_u64_field("intval", int_options);
@@ -1830,7 +1830,7 @@ mod tests {
     #[test]
     fn test_merge_multivalued_int_fields_all_deleted() -> crate::Result<()> {
         let mut schema_builder = schema::Schema::builder();
-        let int_options = IntOptions::default()
+        let int_options = NumericOptions::default()
             .set_fast(Cardinality::MultiValues)
             .set_indexed();
         let int_field = schema_builder.add_u64_field("intvals", int_options);
@@ -1867,7 +1867,7 @@ mod tests {
     #[test]
     fn test_merge_multivalued_int_fields_simple() -> crate::Result<()> {
         let mut schema_builder = schema::Schema::builder();
-        let int_options = IntOptions::default()
+        let int_options = NumericOptions::default()
             .set_fast(Cardinality::MultiValues)
             .set_indexed();
         let int_field = schema_builder.add_u64_field("intvals", int_options);
@@ -1994,7 +1994,7 @@ mod tests {
     fn merges_f64_fast_fields_correctly() -> crate::Result<()> {
         let mut builder = schema::SchemaBuilder::new();
 
-        let fast_multi = IntOptions::default().set_fast(Cardinality::MultiValues);
+        let fast_multi = NumericOptions::default().set_fast(Cardinality::MultiValues);
 
         let field = builder.add_f64_field("f64", schema::FAST);
         let multi_field = builder.add_f64_field("f64s", fast_multi);

--- a/src/indexer/merger_sorted_index_test.rs
+++ b/src/indexer/merger_sorted_index_test.rs
@@ -7,14 +7,14 @@ mod tests {
     use crate::fastfield::{AliveBitSet, FastFieldReader, MultiValuedFastFieldReader};
     use crate::query::QueryParser;
     use crate::schema::{
-        self, BytesOptions, Cardinality, Facet, FacetOptions, IndexRecordOption, IntOptions,
+        self, BytesOptions, Cardinality, Facet, FacetOptions, IndexRecordOption, NumericOptions,
         TextFieldIndexing, TextOptions,
     };
     use crate::{DocAddress, DocSet, IndexSettings, IndexSortByField, Order, Postings, Term};
 
     fn create_test_index_posting_list_issue(index_settings: Option<IndexSettings>) -> Index {
         let mut schema_builder = schema::Schema::builder();
-        let int_options = IntOptions::default()
+        let int_options = NumericOptions::default()
             .set_fast(Cardinality::SingleValue)
             .set_indexed();
         let int_field = schema_builder.add_u64_field("intval", int_options);
@@ -63,7 +63,7 @@ mod tests {
         force_disjunct_segment_sort_values: bool,
     ) -> crate::Result<Index> {
         let mut schema_builder = schema::Schema::builder();
-        let int_options = IntOptions::default()
+        let int_options = NumericOptions::default()
             .set_fast(Cardinality::SingleValue)
             .set_stored()
             .set_indexed();
@@ -75,7 +75,7 @@ mod tests {
 
         let multi_numbers = schema_builder.add_u64_field(
             "multi_numbers",
-            IntOptions::default().set_fast(Cardinality::MultiValues),
+            NumericOptions::default().set_fast(Cardinality::MultiValues),
         );
         let text_field_options = TextOptions::default()
             .set_indexing_options(
@@ -486,11 +486,11 @@ mod bench_sorted_index_merge {
     // use cratedoc_id, readerdoc_id_mappinglet vals = reader.fate::schema;
     use crate::fastfield::{DynamicFastFieldReader, FastFieldReader};
     use crate::indexer::merger::IndexMerger;
-    use crate::schema::{Cardinality, Document, IntOptions, Schema};
+    use crate::schema::{Cardinality, Document, NumericOptions, Schema};
     use crate::{IndexSettings, IndexSortByField, IndexWriter, Order};
     fn create_index(sort_by_field: Option<IndexSortByField>) -> Index {
         let mut schema_builder = Schema::builder();
-        let int_options = IntOptions::default()
+        let int_options = NumericOptions::default()
             .set_fast(Cardinality::SingleValue)
             .set_indexed();
         let int_field = schema_builder.add_u64_field("intval", int_options);

--- a/src/schema/bytes_options.rs
+++ b/src/schema/bytes_options.rs
@@ -17,7 +17,7 @@ pub struct BytesOptions {
 /// lack of fieldnorms attribute as "true" iff indexed.
 ///
 /// (Downstream, for the moment, this attribute is not used anyway if not indexed...)
-/// Note that: newly serialized IntOptions will include the new attribute.
+/// Note that: newly serialized NumericOptions will include the new attribute.
 #[derive(Deserialize)]
 struct BytesOptionsDeser {
     indexed: bool,

--- a/src/schema/field_entry.rs
+++ b/src/schema/field_entry.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::schema::bytes_options::BytesOptions;
-use crate::schema::{is_valid_field_name, FacetOptions, FieldType, IntOptions, TextOptions};
+use crate::schema::{is_valid_field_name, FacetOptions, FieldType, NumericOptions, TextOptions};
 
 /// A `FieldEntry` represents a field and its configuration.
 /// `Schema` are a collection of `FieldEntry`
@@ -39,7 +39,7 @@ impl FieldEntry {
 
     /// Creates a new u64 field entry in the schema, given
     /// a name, and some options.
-    pub fn new_u64(field_name: String, field_type: IntOptions) -> FieldEntry {
+    pub fn new_u64(field_name: String, field_type: NumericOptions) -> FieldEntry {
         assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,
@@ -49,7 +49,7 @@ impl FieldEntry {
 
     /// Creates a new i64 field entry in the schema, given
     /// a name, and some options.
-    pub fn new_i64(field_name: String, field_type: IntOptions) -> FieldEntry {
+    pub fn new_i64(field_name: String, field_type: NumericOptions) -> FieldEntry {
         assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,
@@ -59,7 +59,7 @@ impl FieldEntry {
 
     /// Creates a new f64 field entry in the schema, given
     /// a name, and some options.
-    pub fn new_f64(field_name: String, field_type: IntOptions) -> FieldEntry {
+    pub fn new_f64(field_name: String, field_type: NumericOptions) -> FieldEntry {
         assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,
@@ -69,7 +69,7 @@ impl FieldEntry {
 
     /// Creates a new date field entry in the schema, given
     /// a name, and some options.
-    pub fn new_date(field_name: String, field_type: IntOptions) -> FieldEntry {
+    pub fn new_date(field_name: String, field_type: NumericOptions) -> FieldEntry {
         assert!(is_valid_field_name(&field_name));
         FieldEntry {
             name: field_name,

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -5,7 +5,9 @@ use thiserror::Error;
 
 use crate::schema::bytes_options::BytesOptions;
 use crate::schema::facet_options::FacetOptions;
-use crate::schema::{Facet, IndexRecordOption, IntOptions, TextFieldIndexing, TextOptions, Value};
+use crate::schema::{
+    Facet, IndexRecordOption, NumericOptions, TextFieldIndexing, TextOptions, Value,
+};
 use crate::tokenizer::PreTokenizedString;
 
 /// Possible error that may occur while parsing a field value
@@ -110,13 +112,13 @@ pub enum FieldType {
     #[serde(rename = "text")]
     Str(TextOptions),
     /// Unsigned 64-bits integers field type configuration
-    U64(IntOptions),
+    U64(NumericOptions),
     /// Signed 64-bits integers 64 field type configuration
-    I64(IntOptions),
+    I64(NumericOptions),
     /// 64-bits float 64 field type configuration
-    F64(IntOptions),
+    F64(NumericOptions),
     /// Signed 64-bits Date 64 field type configuration,
-    Date(IntOptions),
+    Date(NumericOptions),
     /// Hierachical Facet
     Facet(FacetOptions),
     /// Bytes (one per document)

--- a/src/schema/flags.rs
+++ b/src/schema/flags.rs
@@ -1,6 +1,6 @@
 use std::ops::BitOr;
 
-use crate::schema::{IntOptions, TextOptions};
+use crate::schema::{NumericOptions, TextOptions};
 
 #[derive(Clone)]
 pub struct StoredFlag;
@@ -22,8 +22,8 @@ pub const STORED: SchemaFlagList<StoredFlag, ()> = SchemaFlagList {
 pub struct IndexedFlag;
 /// Flag to mark the field as indexed. An indexed field is searchable and has a fieldnorm.
 ///
-/// The `INDEXED` flag can only be used when building `IntOptions` (`u64`, `i64` and `f64` fields)
-/// Of course, text fields can also be indexed... But this is expressed by using either the
+/// The `INDEXED` flag can only be used when building `NumericOptions` (`u64`, `i64` and `f64`
+/// fields) Of course, text fields can also be indexed... But this is expressed by using either the
 /// `STRING` (untokenized) or `TEXT` (tokenized with the english tokenizer) flags.
 pub const INDEXED: SchemaFlagList<IndexedFlag, ()> = SchemaFlagList {
     head: IndexedFlag,
@@ -36,7 +36,7 @@ pub struct FastFlag;
 ///
 /// Fast fields can be random-accessed rapidly. Fields useful for scoring, filtering
 /// or collection should be mark as fast fields.
-/// The `FAST` flag can only be used when building `IntOptions` (`u64`, `i64` and `f64` fields)
+/// The `FAST` flag can only be used when building `NumericOptions` (`u64`, `i64` and `f64` fields)
 pub const FAST: SchemaFlagList<FastFlag, ()> = SchemaFlagList {
     head: FastFlag,
     tail: (),
@@ -58,10 +58,10 @@ where
     }
 }
 
-impl<T: Clone + Into<IntOptions>> BitOr<IntOptions> for SchemaFlagList<T, ()> {
-    type Output = IntOptions;
+impl<T: Clone + Into<NumericOptions>> BitOr<NumericOptions> for SchemaFlagList<T, ()> {
+    type Output = NumericOptions;
 
-    fn bitor(self, rhs: IntOptions) -> Self::Output {
+    fn bitor(self, rhs: NumericOptions) -> Self::Output {
         self.head.into() | rhs
     }
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -60,7 +60,7 @@
 //! ```
 //! use tantivy::schema::*;
 //! let mut schema_builder = Schema::builder();
-//! let num_stars_options = IntOptions::default()
+//! let num_stars_options = NumericOptions::default()
 //! .set_stored()
 //! .set_indexed();
 //! schema_builder.add_u64_field("num_stars", num_stars_options);
@@ -113,8 +113,8 @@ mod field_value;
 mod bytes_options;
 mod field;
 mod index_record_option;
-mod int_options;
 mod named_field_document;
+mod numeric_options;
 mod text_options;
 mod value;
 
@@ -131,8 +131,9 @@ pub use self::field_type::{FieldType, Type};
 pub use self::field_value::FieldValue;
 pub use self::flags::{FAST, INDEXED, STORED};
 pub use self::index_record_option::IndexRecordOption;
-pub use self::int_options::{Cardinality, IntOptions};
 pub use self::named_field_document::NamedFieldDocument;
+#[allow(deprecated)]
+pub use self::numeric_options::{Cardinality, IntOptions, NumericOptions};
 pub use self::schema::{DocParsingError, Schema, SchemaBuilder};
 pub use self::term::Term;
 pub use self::text_options::{TextFieldIndexing, TextOptions, STRING, TEXT};

--- a/src/schema/numeric_options.rs
+++ b/src/schema/numeric_options.rs
@@ -16,10 +16,14 @@ pub enum Cardinality {
     MultiValues,
 }
 
+#[deprecated(since = "0.17.0", note = "Use NumericOptions instead.")]
+/// Deprecated use [NumericOptions] instead.
+pub type IntOptions = NumericOptions;
+
 /// Define how an u64, i64, of f64 field should be handled by tantivy.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(from = "IntOptionsDeser")]
-pub struct IntOptions {
+#[serde(from = "NumericOptionsDeser")]
+pub struct NumericOptions {
     indexed: bool,
     // This boolean has no effect if the field is not marked as indexed too.
     fieldnorms: bool, // This attribute only has an effect if indexed is true.
@@ -32,9 +36,9 @@ pub struct IntOptions {
 /// lack of fieldnorms attribute as "true" iff indexed.
 ///
 /// (Downstream, for the moment, this attribute is not used anyway if not indexed...)
-/// Note that: newly serialized IntOptions will include the new attribute.
+/// Note that: newly serialized NumericOptions will include the new attribute.
 #[derive(Deserialize)]
-struct IntOptionsDeser {
+struct NumericOptionsDeser {
     indexed: bool,
     #[serde(default)]
     fieldnorms: Option<bool>, // This attribute only has an effect if indexed is true.
@@ -43,9 +47,9 @@ struct IntOptionsDeser {
     stored: bool,
 }
 
-impl From<IntOptionsDeser> for IntOptions {
-    fn from(deser: IntOptionsDeser) -> Self {
-        IntOptions {
+impl From<NumericOptionsDeser> for NumericOptions {
+    fn from(deser: NumericOptionsDeser) -> Self {
+        NumericOptions {
             indexed: deser.indexed,
             fieldnorms: deser.fieldnorms.unwrap_or(deser.indexed),
             fast: deser.fast,
@@ -54,7 +58,7 @@ impl From<IntOptionsDeser> for IntOptions {
     }
 }
 
-impl IntOptions {
+impl NumericOptions {
     /// Returns true iff the value is stored.
     pub fn is_stored(&self) -> bool {
         self.stored
@@ -80,7 +84,7 @@ impl IntOptions {
     /// Only the fields that are set as *stored* are
     /// persisted into the Tantivy's store.
     #[must_use]
-    pub fn set_stored(mut self) -> IntOptions {
+    pub fn set_stored(mut self) -> NumericOptions {
         self.stored = true;
         self
     }
@@ -92,7 +96,7 @@ impl IntOptions {
     ///
     /// This is required for the field to be searchable.
     #[must_use]
-    pub fn set_indexed(mut self) -> IntOptions {
+    pub fn set_indexed(mut self) -> NumericOptions {
         self.indexed = true;
         self
     }
@@ -102,7 +106,7 @@ impl IntOptions {
     /// Setting an integer as fieldnorm will generate
     /// the fieldnorm data for it.
     #[must_use]
-    pub fn set_fieldnorm(mut self) -> IntOptions {
+    pub fn set_fieldnorm(mut self) -> NumericOptions {
         self.fieldnorms = true;
         self
     }
@@ -114,7 +118,7 @@ impl IntOptions {
     /// If more than one value is associated to a fast field, only the last one is
     /// kept.
     #[must_use]
-    pub fn set_fast(mut self, cardinality: Cardinality) -> IntOptions {
+    pub fn set_fast(mut self, cardinality: Cardinality) -> NumericOptions {
         self.fast = Some(cardinality);
         self
     }
@@ -128,15 +132,15 @@ impl IntOptions {
     }
 }
 
-impl From<()> for IntOptions {
-    fn from(_: ()) -> IntOptions {
-        IntOptions::default()
+impl From<()> for NumericOptions {
+    fn from(_: ()) -> NumericOptions {
+        NumericOptions::default()
     }
 }
 
-impl From<FastFlag> for IntOptions {
+impl From<FastFlag> for NumericOptions {
     fn from(_: FastFlag) -> Self {
-        IntOptions {
+        NumericOptions {
             indexed: false,
             fieldnorms: false,
             stored: false,
@@ -145,9 +149,9 @@ impl From<FastFlag> for IntOptions {
     }
 }
 
-impl From<StoredFlag> for IntOptions {
+impl From<StoredFlag> for NumericOptions {
     fn from(_: StoredFlag) -> Self {
-        IntOptions {
+        NumericOptions {
             indexed: false,
             fieldnorms: false,
             stored: true,
@@ -156,9 +160,9 @@ impl From<StoredFlag> for IntOptions {
     }
 }
 
-impl From<IndexedFlag> for IntOptions {
+impl From<IndexedFlag> for NumericOptions {
     fn from(_: IndexedFlag) -> Self {
-        IntOptions {
+        NumericOptions {
             indexed: true,
             fieldnorms: true,
             stored: false,
@@ -167,12 +171,12 @@ impl From<IndexedFlag> for IntOptions {
     }
 }
 
-impl<T: Into<IntOptions>> BitOr<T> for IntOptions {
-    type Output = IntOptions;
+impl<T: Into<NumericOptions>> BitOr<T> for NumericOptions {
+    type Output = NumericOptions;
 
-    fn bitor(self, other: T) -> IntOptions {
+    fn bitor(self, other: T) -> NumericOptions {
         let other = other.into();
-        IntOptions {
+        NumericOptions {
             indexed: self.indexed | other.indexed,
             fieldnorms: self.fieldnorms | other.fieldnorms,
             stored: self.stored | other.stored,
@@ -181,7 +185,7 @@ impl<T: Into<IntOptions>> BitOr<T> for IntOptions {
     }
 }
 
-impl<Head, Tail> From<SchemaFlagList<Head, Tail>> for IntOptions
+impl<Head, Tail> From<SchemaFlagList<Head, Tail>> for NumericOptions
 where
     Head: Clone,
     Tail: Clone,
@@ -202,10 +206,10 @@ mod tests {
             "indexed": true,
             "stored": false
         }"#;
-        let int_options: IntOptions = serde_json::from_str(json).unwrap();
+        let int_options: NumericOptions = serde_json::from_str(json).unwrap();
         assert_eq!(
             &int_options,
-            &IntOptions {
+            &NumericOptions {
                 indexed: true,
                 fieldnorms: true,
                 fast: None,
@@ -220,10 +224,10 @@ mod tests {
             "indexed": false,
             "stored": false
         }"#;
-        let int_options: IntOptions = serde_json::from_str(json).unwrap();
+        let int_options: NumericOptions = serde_json::from_str(json).unwrap();
         assert_eq!(
             &int_options,
-            &IntOptions {
+            &NumericOptions {
                 indexed: false,
                 fieldnorms: false,
                 fast: None,
@@ -239,10 +243,10 @@ mod tests {
             "fieldnorms": false,
             "stored": false
         }"#;
-        let int_options: IntOptions = serde_json::from_str(json).unwrap();
+        let int_options: NumericOptions = serde_json::from_str(json).unwrap();
         assert_eq!(
             &int_options,
-            &IntOptions {
+            &NumericOptions {
                 indexed: true,
                 fieldnorms: false,
                 fast: None,
@@ -259,10 +263,10 @@ mod tests {
             "fieldnorms": true,
             "stored": false
         }"#;
-        let int_options: IntOptions = serde_json::from_str(json).unwrap();
+        let int_options: NumericOptions = serde_json::from_str(json).unwrap();
         assert_eq!(
             &int_options,
-            &IntOptions {
+            &NumericOptions {
                 indexed: false,
                 fieldnorms: true,
                 fast: None,

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -52,7 +52,7 @@ impl SchemaBuilder {
     /// by the second one.
     /// The first field will get a field id
     /// but only the second one will be indexed
-    pub fn add_u64_field<T: Into<IntOptions>>(
+    pub fn add_u64_field<T: Into<NumericOptions>>(
         &mut self,
         field_name_str: &str,
         field_options: T,
@@ -72,7 +72,7 @@ impl SchemaBuilder {
     /// by the second one.
     /// The first field will get a field id
     /// but only the second one will be indexed
-    pub fn add_i64_field<T: Into<IntOptions>>(
+    pub fn add_i64_field<T: Into<NumericOptions>>(
         &mut self,
         field_name_str: &str,
         field_options: T,
@@ -92,7 +92,7 @@ impl SchemaBuilder {
     /// by the second one.
     /// The first field will get a field id
     /// but only the second one will be indexed
-    pub fn add_f64_field<T: Into<IntOptions>>(
+    pub fn add_f64_field<T: Into<NumericOptions>>(
         &mut self,
         field_name_str: &str,
         field_options: T,
@@ -114,7 +114,7 @@ impl SchemaBuilder {
     /// by the second one.
     /// The first field will get a field id
     /// but only the second one will be indexed
-    pub fn add_date_field<T: Into<IntOptions>>(
+    pub fn add_date_field<T: Into<NumericOptions>>(
         &mut self,
         field_name_str: &str,
         field_options: T,
@@ -398,7 +398,7 @@ mod tests {
     use serde_json;
 
     use crate::schema::field_type::ValueParsingError;
-    use crate::schema::int_options::Cardinality::SingleValue;
+    use crate::schema::numeric_options::Cardinality::SingleValue;
     use crate::schema::schema::DocParsingError::NotJson;
     use crate::schema::*;
 
@@ -413,13 +413,13 @@ mod tests {
     #[test]
     pub fn test_schema_serialization() {
         let mut schema_builder = Schema::builder();
-        let count_options = IntOptions::default()
+        let count_options = NumericOptions::default()
             .set_stored()
             .set_fast(Cardinality::SingleValue);
-        let popularity_options = IntOptions::default()
+        let popularity_options = NumericOptions::default()
             .set_stored()
             .set_fast(Cardinality::SingleValue);
-        let score_options = IntOptions::default()
+        let score_options = NumericOptions::default()
             .set_indexed()
             .set_fieldnorm()
             .set_fast(Cardinality::SingleValue);
@@ -529,7 +529,7 @@ mod tests {
     #[test]
     pub fn test_document_to_json() {
         let mut schema_builder = Schema::builder();
-        let count_options = IntOptions::default()
+        let count_options = NumericOptions::default()
             .set_stored()
             .set_fast(Cardinality::SingleValue);
         schema_builder.add_text_field("title", TEXT);
@@ -594,13 +594,13 @@ mod tests {
     #[test]
     pub fn test_parse_document() {
         let mut schema_builder = Schema::builder();
-        let count_options = IntOptions::default()
+        let count_options = NumericOptions::default()
             .set_stored()
             .set_fast(Cardinality::SingleValue);
-        let popularity_options = IntOptions::default()
+        let popularity_options = NumericOptions::default()
             .set_stored()
             .set_fast(Cardinality::SingleValue);
-        let score_options = IntOptions::default()
+        let score_options = NumericOptions::default()
             .set_indexed()
             .set_fast(Cardinality::SingleValue);
         let title_field = schema_builder.add_text_field("title", TEXT);
@@ -744,7 +744,7 @@ mod tests {
                 .set_tokenizer("raw")
                 .set_index_option(IndexRecordOption::Basic),
         );
-        let timestamp_options = IntOptions::default()
+        let timestamp_options = NumericOptions::default()
             .set_stored()
             .set_indexed()
             .set_fieldnorm()


### PR DESCRIPTION
keep IntOptions with deprecation warning
Fixes #1286