### PR TITLE
Replace `chrono` with `time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+Unreleased
+================================
+- For date values `chrono` has been replaced with `time`:
+  - The `time` crate is re-exported as `tantivy::time` instead of `tantivy::chrono`.
+  - The type alias `tantivy::DateTime` has been removed.
+  - `Value::Date` wraps `time::PrimitiveDateTime` without time zone information.
+  - Internally date/time values are stored as seconds since UNIX epoch in UTC.
+  - Converting a `time::OffsetDateTime` to `Value::Date` implicitly converts the value into UTC.
+    If this is not desired do the time zone conversion yourself and use `time::PrimitiveDateTime`
+    directly instead.
+
 Tantivy 0.17
 ================================
 - LogMergePolicy now triggers merges if the ratio of deleted documents reaches a threshold (@shikhar @fulmicoton) [#115](https://github.com/quickwit-oss/tantivy/issues/115)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased
 ================================
-- For date values `chrono` has been replaced with `time`:
+- For date values `chrono` has been replaced with `time` (@uklotzde) #1304 :
   - The `time` crate is re-exported as `tantivy::time` instead of `tantivy::chrono`.
   - The type alias `tantivy::DateTime` has been removed.
   - `Value::Date` wraps `time::PrimitiveDateTime` without time zone information.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ thiserror = "1.0.24"
 htmlescape = "0.3.1"
 fail = "0.5"
 murmurhash32 = "0.2"
-chrono = "0.4.19"
+time = { version = "0.3.7", features = ["serde-well-known"] }
 smallvec = "1.6.1"
 rayon = "1.5"
 lru = "0.7.0"

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -67,7 +67,7 @@ fn word<'a>() -> impl Parser<&'a str, Output = String> {
 ///
 /// NOTE: also accepts 999999-99-99T99:99:99.266051969+99:99
 /// We delegate rejecting such invalid dates to the logical AST compuation code
-/// which invokes chrono::DateTime::parse_from_rfc3339 on the value to actually parse
+/// which invokes time::OffsetDateTime::parse(..., &Rfc3339) on the value to actually parse
 /// it (instead of merely extracting the datetime value as string as done here).
 fn date_time<'a>() -> impl Parser<&'a str, Output = String> {
     let two_digits = || recognize::<String, _, _>((digit(), digit()));

--- a/src/collector/histogram_collector.rs
+++ b/src/collector/histogram_collector.rs
@@ -284,9 +284,7 @@ mod tests {
         let all_query = AllQuery;
         let week_histogram_collector = HistogramCollector::new(
             date_field,
-            Date::from_calendar_date(1980, Month::January, 1)?
-                .with_hms(0, 0, 0)?
-                .assume_utc(),
+            Date::from_calendar_date(1980, Month::January, 1)?.with_hms(0, 0, 0)?,
             3600 * 24 * 365, // it is just for a unit test... sorry leap years.
             10,
         );

--- a/src/collector/histogram_collector.rs
+++ b/src/collector/histogram_collector.rs
@@ -273,11 +273,11 @@ mod tests {
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut writer = index.writer_with_num_threads(1, 4_000_000)?;
-        writer.add_document(doc!(date_field=>Date::from_calendar_date(1982, Month::September, 17)?.with_hms(0, 0, 0)?.assume_utc()))?;
+        writer.add_document(doc!(date_field=>Date::from_calendar_date(1982, Month::September, 17)?.with_hms(0, 0, 0)?))?;
         writer.add_document(
-            doc!(date_field=>Date::from_calendar_date(1986, Month::March, 9)?.with_hms(0, 0, 0)?.assume_utc()),
+            doc!(date_field=>Date::from_calendar_date(1986, Month::March, 9)?.with_hms(0, 0, 0)?),
         )?;
-        writer.add_document(doc!(date_field=>Date::from_calendar_date(1983, Month::September, 27)?.with_hms(0, 0, 0)?.assume_utc()))?;
+        writer.add_document(doc!(date_field=>Date::from_calendar_date(1983, Month::September, 27)?.with_hms(0, 0, 0)?))?;
         writer.commit()?;
         let reader = index.reader()?;
         let searcher = reader.searcher();

--- a/src/collector/histogram_collector.rs
+++ b/src/collector/histogram_collector.rs
@@ -150,10 +150,10 @@ fn add_vecs(mut vals_list: Vec<Vec<u64>>, len: usize) -> Vec<u64> {
 mod tests {
     use fastdivide::DividerU64;
     use query::AllQuery;
-    use time::{Date, Month};
 
     use super::{add_vecs, HistogramCollector, HistogramComputer};
     use crate::schema::{Schema, FAST};
+    use crate::time::{Date, Month};
     use crate::{doc, query, Index};
 
     #[test]

--- a/src/collector/histogram_collector.rs
+++ b/src/collector/histogram_collector.rs
@@ -154,7 +154,7 @@ mod tests {
     use super::{add_vecs, HistogramCollector, HistogramComputer};
     use crate::schema::{Schema, FAST};
     use crate::time::{Date, Month};
-    use crate::{doc, query, Index};
+    use crate::{doc, query, DateTime, Index};
 
     #[test]
     fn test_add_histograms_simple() {
@@ -273,18 +273,20 @@ mod tests {
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut writer = index.writer_with_num_threads(1, 4_000_000)?;
-        writer.add_document(doc!(date_field=>Date::from_calendar_date(1982, Month::September, 17)?.with_hms(0, 0, 0)?))?;
+        writer.add_document(doc!(date_field=>DateTime::new_primitive(Date::from_calendar_date(1982, Month::September, 17)?.with_hms(0, 0, 0)?)))?;
         writer.add_document(
-            doc!(date_field=>Date::from_calendar_date(1986, Month::March, 9)?.with_hms(0, 0, 0)?),
+            doc!(date_field=>DateTime::new_primitive(Date::from_calendar_date(1986, Month::March, 9)?.with_hms(0, 0, 0)?)),
         )?;
-        writer.add_document(doc!(date_field=>Date::from_calendar_date(1983, Month::September, 27)?.with_hms(0, 0, 0)?))?;
+        writer.add_document(doc!(date_field=>DateTime::new_primitive(Date::from_calendar_date(1983, Month::September, 27)?.with_hms(0, 0, 0)?)))?;
         writer.commit()?;
         let reader = index.reader()?;
         let searcher = reader.searcher();
         let all_query = AllQuery;
         let week_histogram_collector = HistogramCollector::new(
             date_field,
-            Date::from_calendar_date(1980, Month::January, 1)?.with_hms(0, 0, 0)?,
+            DateTime::new_primitive(
+                Date::from_calendar_date(1980, Month::January, 1)?.with_hms(0, 0, 0)?,
+            ),
             3600 * 24 * 365, // it is just for a unit test... sorry leap years.
             10,
         );

--- a/src/collector/histogram_collector.rs
+++ b/src/collector/histogram_collector.rs
@@ -150,9 +150,9 @@ fn add_vecs(mut vals_list: Vec<Vec<u64>>, len: usize) -> Vec<u64> {
 mod tests {
     use fastdivide::DividerU64;
     use query::AllQuery;
+    use time::{Date, Month};
 
     use super::{add_vecs, HistogramCollector, HistogramComputer};
-    use crate::chrono::{TimeZone, Utc};
     use crate::schema::{Schema, FAST};
     use crate::{doc, query, Index};
 
@@ -273,16 +273,20 @@ mod tests {
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut writer = index.writer_with_num_threads(1, 4_000_000)?;
-        writer.add_document(doc!(date_field=>Utc.ymd(1982, 9, 17).and_hms(0, 0,0)))?;
-        writer.add_document(doc!(date_field=>Utc.ymd(1986, 3, 9).and_hms(0, 0, 0)))?;
-        writer.add_document(doc!(date_field=>Utc.ymd(1983, 9, 27).and_hms(0, 0, 0)))?;
+        writer.add_document(doc!(date_field=>Date::from_calendar_date(1982, Month::September, 17)?.with_hms(0, 0, 0)?.assume_utc()))?;
+        writer.add_document(
+            doc!(date_field=>Date::from_calendar_date(1986, Month::March, 9)?.with_hms(0, 0, 0)?.assume_utc()),
+        )?;
+        writer.add_document(doc!(date_field=>Date::from_calendar_date(1983, Month::September, 27)?.with_hms(0, 0, 0)?.assume_utc()))?;
         writer.commit()?;
         let reader = index.reader()?;
         let searcher = reader.searcher();
         let all_query = AllQuery;
         let week_histogram_collector = HistogramCollector::new(
             date_field,
-            Utc.ymd(1980, 1, 1).and_hms(0, 0, 0),
+            Date::from_calendar_date(1980, Month::January, 1)?
+                .with_hms(0, 0, 0)?
+                .assume_utc(),
             3600 * 24 * 365, // it is just for a unit test... sorry leap years.
             10,
         );

--- a/src/collector/tests.rs
+++ b/src/collector/tests.rs
@@ -26,11 +26,11 @@ pub fn test_filter_collector() -> crate::Result<()> {
     let index = Index::create_in_ram(schema);
 
     let mut index_writer = index.writer_with_num_threads(1, 10_000_000)?;
-    index_writer.add_document(doc!(title => "The Name of the Wind", price => 30_200u64, date => OffsetDateTime::parse("1898-04-09T00:00:00+00:00", &Rfc3339).unwrap()))?;
-    index_writer.add_document(doc!(title => "The Diary of Muadib", price => 29_240u64, date => OffsetDateTime::parse("2020-04-09T00:00:00+00:00", &Rfc3339).unwrap()))?;
-    index_writer.add_document(doc!(title => "The Diary of Anne Frank", price => 18_240u64, date => OffsetDateTime::parse("2019-04-20T00:00:00+00:00", &Rfc3339).unwrap()))?;
-    index_writer.add_document(doc!(title => "A Dairy Cow", price => 21_240u64, date => OffsetDateTime::parse("2019-04-09T00:00:00+00:00", &Rfc3339).unwrap()))?;
-    index_writer.add_document(doc!(title => "The Diary of a Young Girl", price => 20_120u64, date => OffsetDateTime::parse("2018-04-09T00:00:00+00:00", &Rfc3339).unwrap()))?;
+    index_writer.add_document(doc!(title => "The Name of the Wind", price => 30_200u64, date => DateTime::new_utc(OffsetDateTime::parse("1898-04-09T00:00:00+00:00", &Rfc3339).unwrap())))?;
+    index_writer.add_document(doc!(title => "The Diary of Muadib", price => 29_240u64, date => DateTime::new_utc(OffsetDateTime::parse("2020-04-09T00:00:00+00:00", &Rfc3339).unwrap())))?;
+    index_writer.add_document(doc!(title => "The Diary of Anne Frank", price => 18_240u64, date => DateTime::new_utc(OffsetDateTime::parse("2019-04-20T00:00:00+00:00", &Rfc3339).unwrap())))?;
+    index_writer.add_document(doc!(title => "A Dairy Cow", price => 21_240u64, date => DateTime::new_utc(OffsetDateTime::parse("2019-04-09T00:00:00+00:00", &Rfc3339).unwrap())))?;
+    index_writer.add_document(doc!(title => "The Diary of a Young Girl", price => 20_120u64, date => DateTime::new_utc(OffsetDateTime::parse("2018-04-09T00:00:00+00:00", &Rfc3339).unwrap())))?;
     index_writer.commit()?;
 
     let reader = index.reader()?;

--- a/src/collector/tests.rs
+++ b/src/collector/tests.rs
@@ -1,12 +1,11 @@
-use time::format_description::well_known::Rfc3339;
-use time::OffsetDateTime;
-
 use super::*;
 use crate::collector::{Count, FilterCollector, TopDocs};
 use crate::core::SegmentReader;
 use crate::fastfield::{BytesFastFieldReader, DynamicFastFieldReader, FastFieldReader};
 use crate::query::{AllQuery, QueryParser};
 use crate::schema::{Field, Schema, FAST, TEXT};
+use crate::time::format_description::well_known::Rfc3339;
+use crate::time::OffsetDateTime;
 use crate::{doc, DocAddress, DocId, Document, Index, Score, Searcher, SegmentOrdinal};
 
 pub const TEST_COLLECTOR_WITH_SCORE: TestCollector = TestCollector {

--- a/src/collector/tests.rs
+++ b/src/collector/tests.rs
@@ -1,4 +1,5 @@
-use std::str::FromStr;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 use super::*;
 use crate::collector::{Count, FilterCollector, TopDocs};
@@ -6,7 +7,7 @@ use crate::core::SegmentReader;
 use crate::fastfield::{BytesFastFieldReader, DynamicFastFieldReader, FastFieldReader};
 use crate::query::{AllQuery, QueryParser};
 use crate::schema::{Field, Schema, FAST, TEXT};
-use crate::{doc, DateTime, DocAddress, DocId, Document, Index, Score, Searcher, SegmentOrdinal};
+use crate::{doc, DocAddress, DocId, Document, Index, Score, Searcher, SegmentOrdinal};
 
 pub const TEST_COLLECTOR_WITH_SCORE: TestCollector = TestCollector {
     compute_score: true,
@@ -26,11 +27,11 @@ pub fn test_filter_collector() -> crate::Result<()> {
     let index = Index::create_in_ram(schema);
 
     let mut index_writer = index.writer_with_num_threads(1, 10_000_000)?;
-    index_writer.add_document(doc!(title => "The Name of the Wind", price => 30_200u64, date => DateTime::from_str("1898-04-09T00:00:00+00:00").unwrap()))?;
-    index_writer.add_document(doc!(title => "The Diary of Muadib", price => 29_240u64, date => DateTime::from_str("2020-04-09T00:00:00+00:00").unwrap()))?;
-    index_writer.add_document(doc!(title => "The Diary of Anne Frank", price => 18_240u64, date => DateTime::from_str("2019-04-20T00:00:00+00:00").unwrap()))?;
-    index_writer.add_document(doc!(title => "A Dairy Cow", price => 21_240u64, date => DateTime::from_str("2019-04-09T00:00:00+00:00").unwrap()))?;
-    index_writer.add_document(doc!(title => "The Diary of a Young Girl", price => 20_120u64, date => DateTime::from_str("2018-04-09T00:00:00+00:00").unwrap()))?;
+    index_writer.add_document(doc!(title => "The Name of the Wind", price => 30_200u64, date => OffsetDateTime::parse("1898-04-09T00:00:00+00:00", &Rfc3339).unwrap()))?;
+    index_writer.add_document(doc!(title => "The Diary of Muadib", price => 29_240u64, date => OffsetDateTime::parse("2020-04-09T00:00:00+00:00", &Rfc3339).unwrap()))?;
+    index_writer.add_document(doc!(title => "The Diary of Anne Frank", price => 18_240u64, date => OffsetDateTime::parse("2019-04-20T00:00:00+00:00", &Rfc3339).unwrap()))?;
+    index_writer.add_document(doc!(title => "A Dairy Cow", price => 21_240u64, date => OffsetDateTime::parse("2019-04-09T00:00:00+00:00", &Rfc3339).unwrap()))?;
+    index_writer.add_document(doc!(title => "The Diary of a Young Girl", price => 20_120u64, date => OffsetDateTime::parse("2018-04-09T00:00:00+00:00", &Rfc3339).unwrap()))?;
     index_writer.commit()?;
 
     let reader = index.reader()?;
@@ -54,8 +55,10 @@ pub fn test_filter_collector() -> crate::Result<()> {
 
     assert_eq!(filtered_top_docs.len(), 0);
 
-    fn date_filter(value: DateTime) -> bool {
-        (value - DateTime::from_str("2019-04-09T00:00:00+00:00").unwrap()).num_weeks() > 0
+    fn date_filter(value: OffsetDateTime) -> bool {
+        (value - OffsetDateTime::parse("2019-04-09T00:00:00+00:00", &Rfc3339).unwrap())
+            .whole_weeks()
+            > 0
     }
 
     let filter_dates_collector = FilterCollector::new(date, &date_filter, TopDocs::with_limit(5));

--- a/src/collector/tests.rs
+++ b/src/collector/tests.rs
@@ -6,7 +6,7 @@ use crate::query::{AllQuery, QueryParser};
 use crate::schema::{Field, Schema, FAST, TEXT};
 use crate::time::format_description::well_known::Rfc3339;
 use crate::time::OffsetDateTime;
-use crate::{doc, DocAddress, DocId, Document, Index, Score, Searcher, SegmentOrdinal};
+use crate::{doc, DateTime, DocAddress, DocId, Document, Index, Score, Searcher, SegmentOrdinal};
 
 pub const TEST_COLLECTOR_WITH_SCORE: TestCollector = TestCollector {
     compute_score: true,
@@ -54,8 +54,8 @@ pub fn test_filter_collector() -> crate::Result<()> {
 
     assert_eq!(filtered_top_docs.len(), 0);
 
-    fn date_filter(value: OffsetDateTime) -> bool {
-        (value - OffsetDateTime::parse("2019-04-09T00:00:00+00:00", &Rfc3339).unwrap())
+    fn date_filter(value: DateTime) -> bool {
+        (value.to_utc() - OffsetDateTime::parse("2019-04-09T00:00:00+00:00", &Rfc3339).unwrap())
             .whole_weeks()
             > 0
     }

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -898,15 +898,21 @@ mod tests {
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests()?;
-        let pr_birthday = OffsetDateTime::parse("1898-04-09T00:00:00+00:00", &Rfc3339)?;
+        let pr_birthday = DateTime::new_utc(OffsetDateTime::parse(
+            "1898-04-09T00:00:00+00:00",
+            &Rfc3339,
+        )?);
         index_writer.add_document(doc!(
             name => "Paul Robeson",
-            birthday => pr_birthday
+            birthday => pr_birthday,
         ))?;
-        let mr_birthday = OffsetDateTime::parse("1947-11-08T00:00:00+00:00", &Rfc3339)?;
+        let mr_birthday = DateTime::new_utc(OffsetDateTime::parse(
+            "1947-11-08T00:00:00+00:00",
+            &Rfc3339,
+        )?);
         index_writer.add_document(doc!(
             name => "Minnie Riperton",
-            birthday => mr_birthday
+            birthday => mr_birthday,
         ))?;
         index_writer.commit()?;
         let searcher = index.reader()?.searcher();
@@ -915,8 +921,8 @@ mod tests {
         assert_eq!(
             &top_docs[..],
             &[
-                (DateTime::new_utc(mr_birthday), DocAddress::new(0, 1)),
-                (DateTime::new_utc(pr_birthday), DocAddress::new(0, 0)),
+                (mr_birthday, DocAddress::new(0, 1)),
+                (pr_birthday, DocAddress::new(0, 0)),
             ]
         );
         Ok(())

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -716,7 +716,7 @@ mod tests {
     use crate::schema::{Field, Schema, FAST, STORED, TEXT};
     use crate::time::format_description::well_known::Rfc3339;
     use crate::time::OffsetDateTime;
-    use crate::{DocAddress, DocId, Index, IndexWriter, Score, SegmentReader};
+    use crate::{DateTime, DocAddress, DocId, Index, IndexWriter, Score, SegmentReader};
 
     fn make_index() -> crate::Result<Index> {
         let mut schema_builder = Schema::builder();
@@ -911,13 +911,12 @@ mod tests {
         index_writer.commit()?;
         let searcher = index.reader()?.searcher();
         let top_collector = TopDocs::with_limit(3).order_by_fast_field(birthday);
-        let top_docs: Vec<(OffsetDateTime, DocAddress)> =
-            searcher.search(&AllQuery, &top_collector)?;
+        let top_docs: Vec<(DateTime, DocAddress)> = searcher.search(&AllQuery, &top_collector)?;
         assert_eq!(
             &top_docs[..],
             &[
-                (mr_birthday, DocAddress::new(0, 1)),
-                (pr_birthday, DocAddress::new(0, 0)),
+                (DateTime::new_utc(mr_birthday), DocAddress::new(0, 1)),
+                (DateTime::new_utc(pr_birthday), DocAddress::new(0, 0)),
             ]
         );
         Ok(())

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -710,13 +710,12 @@ impl SegmentCollector for TopScoreSegmentCollector {
 
 #[cfg(test)]
 mod tests {
-    use time::format_description::well_known::Rfc3339;
-    use time::OffsetDateTime;
-
     use super::TopDocs;
     use crate::collector::Collector;
     use crate::query::{AllQuery, Query, QueryParser};
     use crate::schema::{Field, Schema, FAST, STORED, TEXT};
+    use crate::time::format_description::well_known::Rfc3339;
+    use crate::time::OffsetDateTime;
     use crate::{DocAddress, DocId, Index, IndexWriter, Score, SegmentReader};
 
     fn make_index() -> crate::Result<Index> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -149,8 +149,20 @@ impl<Guard> From<PoisonError<Guard>> for TantivyError {
     }
 }
 
-impl From<chrono::ParseError> for TantivyError {
-    fn from(err: chrono::ParseError) -> TantivyError {
+impl From<time::error::Format> for TantivyError {
+    fn from(err: time::error::Format) -> TantivyError {
+        TantivyError::InvalidArgument(err.to_string())
+    }
+}
+
+impl From<time::error::Parse> for TantivyError {
+    fn from(err: time::error::Parse) -> TantivyError {
+        TantivyError::InvalidArgument(err.to_string())
+    }
+}
+
+impl From<time::error::ComponentRange> for TantivyError {
+    fn from(err: time::error::ComponentRange) -> TantivyError {
         TantivyError::InvalidArgument(err.to_string())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -151,19 +151,19 @@ impl<Guard> From<PoisonError<Guard>> for TantivyError {
 
 impl From<time::error::Format> for TantivyError {
     fn from(err: time::error::Format) -> TantivyError {
-        TantivyError::InvalidArgument(err.to_string())
+        TantivyError::InvalidArgument(format!("Date formatting error: {err}"))
     }
 }
 
 impl From<time::error::Parse> for TantivyError {
     fn from(err: time::error::Parse) -> TantivyError {
-        TantivyError::InvalidArgument(err.to_string())
+        TantivyError::InvalidArgument(format!("Date parsing error: {err}"))
     }
 }
 
 impl From<time::error::ComponentRange> for TantivyError {
     fn from(err: time::error::ComponentRange) -> TantivyError {
-        TantivyError::InvalidArgument(err.to_string())
+        TantivyError::InvalidArgument(format!("Date range error: {err}"))
     }
 }
 

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -20,8 +20,6 @@
 //!
 //! Read access performance is comparable to that of an array lookup.
 
-use time::{PrimitiveDateTime, UtcOffset};
-
 pub use self::alive_bitset::{intersect_alive_bitsets, write_alive_bitset, AliveBitSet};
 pub use self::bytes::{BytesFastFieldReader, BytesFastFieldWriter};
 pub use self::error::{FastFieldNotAvailableError, Result};
@@ -33,7 +31,7 @@ pub(crate) use self::readers::{type_and_cardinality, FastType};
 pub use self::serializer::{CompositeFastFieldSerializer, FastFieldDataAccess, FastFieldStats};
 pub use self::writer::{FastFieldsWriter, IntFastFieldWriter};
 use crate::schema::{Cardinality, FieldType, Type, Value};
-use crate::time::OffsetDateTime;
+use crate::time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
 use crate::DocId;
 
 mod alive_bitset;

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -179,7 +179,7 @@ impl FastValue for OffsetDateTime {
     }
 
     fn as_u64(&self) -> u64 {
-        self.to_u64()
+        self.unix_timestamp().as_u64()
     }
 
     fn to_type() -> Type {

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -20,8 +20,6 @@
 //!
 //! Read access performance is comparable to that of an array lookup.
 
-use time::OffsetDateTime;
-
 pub use self::alive_bitset::{intersect_alive_bitsets, write_alive_bitset, AliveBitSet};
 pub use self::bytes::{BytesFastFieldReader, BytesFastFieldWriter};
 pub use self::error::{FastFieldNotAvailableError, Result};
@@ -33,6 +31,7 @@ pub(crate) use self::readers::{type_and_cardinality, FastType};
 pub use self::serializer::{CompositeFastFieldSerializer, FastFieldDataAccess, FastFieldStats};
 pub use self::writer::{FastFieldsWriter, IntFastFieldWriter};
 use crate::schema::{Cardinality, FieldType, Type, Value};
+use crate::time::OffsetDateTime;
 use crate::DocId;
 
 mod alive_bitset;

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -192,7 +192,7 @@ fn value_to_u64(value: &Value) -> u64 {
         Value::U64(ref val) => *val,
         Value::I64(ref val) => common::i64_to_u64(*val),
         Value::F64(ref val) => common::f64_to_u64(*val),
-        Value::Date(ref datetime) => common::i64_to_u64(datetime.unix_timestamp()),
+        Value::Date(ref datetime) => common::i64_to_u64(datetime.assume_utc().unix_timestamp()),
         _ => panic!("Expected a u64/i64/f64 field, got {:?} ", value),
     }
 }

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -188,7 +188,7 @@ impl FastValue for DateTime {
 
 fn value_to_u64(value: &Value) -> u64 {
     match value {
-        Value::U64(val) => *val,
+        Value::U64(val) => val.to_u64(),
         Value::I64(val) => val.to_u64(),
         Value::F64(val) => val.to_u64(),
         Value::Date(val) => val.to_u64(),

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -489,7 +489,8 @@ mod tests {
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests().unwrap();
         index_writer.set_merge_policy(Box::new(NoMergePolicy));
-        index_writer.add_document(doc!(date_field =>OffsetDateTime::now_utc()))?;
+        index_writer
+            .add_document(doc!(date_field =>DateTime::new_utc(OffsetDateTime::now_utc())))?;
         index_writer.commit()?;
         index_writer.add_document(doc!())?;
         index_writer.commit()?;

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -11,13 +11,13 @@ mod tests {
     use proptest::strategy::Strategy;
     use proptest::{prop_oneof, proptest};
     use test_log::test;
-    use time::format_description::well_known::Rfc3339;
-    use time::{Duration, OffsetDateTime};
 
     use crate::collector::TopDocs;
     use crate::indexer::NoMergePolicy;
     use crate::query::QueryParser;
     use crate::schema::{Cardinality, Facet, FacetOptions, NumericOptions, Schema};
+    use crate::time::format_description::well_known::Rfc3339;
+    use crate::time::{Duration, OffsetDateTime};
     use crate::{Document, Index, Term};
 
     #[test]

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -18,7 +18,7 @@ mod tests {
     use crate::schema::{Cardinality, Facet, FacetOptions, NumericOptions, Schema};
     use crate::time::format_description::well_known::Rfc3339;
     use crate::time::{Duration, OffsetDateTime};
-    use crate::{Document, Index, Term};
+    use crate::{DateTime, Document, Index, Term};
 
     #[test]
     fn test_multivalued_u64() -> crate::Result<()> {
@@ -109,10 +109,8 @@ mod tests {
                         .get_first(date_field)
                         .expect("cannot find value")
                         .as_date()
-                        .unwrap()
-                        .assume_utc()
-                        .unix_timestamp(),
-                    first_time_stamp.unix_timestamp()
+                        .unwrap(),
+                    DateTime::new_utc(first_time_stamp),
                 );
                 assert_eq!(
                     retrieved_doc
@@ -138,10 +136,8 @@ mod tests {
                         .get_first(date_field)
                         .expect("cannot find value")
                         .as_date()
-                        .unwrap()
-                        .assume_utc()
-                        .unix_timestamp(),
-                    two_secs_ahead.unix_timestamp()
+                        .unwrap(),
+                    DateTime::new_utc(two_secs_ahead)
                 );
                 assert_eq!(
                     retrieved_doc
@@ -181,10 +177,8 @@ mod tests {
                         .get_first(date_field)
                         .expect("cannot find value")
                         .as_date()
-                        .expect("value not of Date type")
-                        .assume_utc()
-                        .unix_timestamp(),
-                    (first_time_stamp + Duration::seconds(offset_sec)).unix_timestamp()
+                        .expect("value not of Date type"),
+                    DateTime::new_utc(first_time_stamp + Duration::seconds(offset_sec)),
                 );
                 assert_eq!(
                     retrieved_doc

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -7,11 +7,12 @@ pub use self::writer::MultiValuedFastFieldWriter;
 #[cfg(test)]
 mod tests {
 
-    use chrono::Duration;
     use futures::executor::block_on;
     use proptest::strategy::Strategy;
     use proptest::{prop_oneof, proptest};
     use test_log::test;
+    use time::format_description::well_known::Rfc3339;
+    use time::{Duration, OffsetDateTime};
 
     use crate::collector::TopDocs;
     use crate::indexer::NoMergePolicy;
@@ -70,7 +71,7 @@ mod tests {
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests()?;
-        let first_time_stamp = chrono::Utc::now();
+        let first_time_stamp = OffsetDateTime::now_utc();
         index_writer.add_document(
             doc!(date_field=>first_time_stamp, date_field=>first_time_stamp, time_i=>1i64),
         )?;
@@ -97,7 +98,7 @@ mod tests {
             let parser = QueryParser::for_index(&index, vec![]);
             let query = parser.parse_query(&format!(
                 "multi_date_field:\"{}\"",
-                first_time_stamp.to_rfc3339()
+                first_time_stamp.format(&Rfc3339)?,
             ))?;
             let results = searcher.search(&query, &TopDocs::with_limit(5))?;
             assert_eq!(results.len(), 1);
@@ -109,8 +110,8 @@ mod tests {
                         .expect("cannot find value")
                         .as_date()
                         .unwrap()
-                        .timestamp(),
-                    first_time_stamp.timestamp()
+                        .unix_timestamp(),
+                    first_time_stamp.unix_timestamp()
                 );
                 assert_eq!(
                     retrieved_doc
@@ -124,7 +125,7 @@ mod tests {
 
         {
             let parser = QueryParser::for_index(&index, vec![date_field]);
-            let query = parser.parse_query(&format!("\"{}\"", two_secs_ahead.to_rfc3339()))?;
+            let query = parser.parse_query(&format!("\"{}\"", two_secs_ahead.format(&Rfc3339)?))?;
             let results = searcher.search(&query, &TopDocs::with_limit(5))?;
 
             assert_eq!(results.len(), 1);
@@ -137,8 +138,8 @@ mod tests {
                         .expect("cannot find value")
                         .as_date()
                         .unwrap()
-                        .timestamp(),
-                    two_secs_ahead.timestamp()
+                        .unix_timestamp(),
+                    two_secs_ahead.unix_timestamp()
                 );
                 assert_eq!(
                     retrieved_doc
@@ -154,8 +155,8 @@ mod tests {
             let parser = QueryParser::for_index(&index, vec![date_field]);
             let range_q = format!(
                 "multi_date_field:[{} TO {}}}",
-                (first_time_stamp + Duration::seconds(1)).to_rfc3339(),
-                (first_time_stamp + Duration::seconds(3)).to_rfc3339()
+                (first_time_stamp + Duration::seconds(1)).format(&Rfc3339)?,
+                (first_time_stamp + Duration::seconds(3)).format(&Rfc3339)?
             );
             let query = parser.parse_query(&range_q)?;
             let results = searcher.search(&query, &TopDocs::with_limit(5))?;
@@ -179,8 +180,8 @@ mod tests {
                         .expect("cannot find value")
                         .as_date()
                         .expect("value not of Date type")
-                        .timestamp(),
-                    (first_time_stamp + Duration::seconds(offset_sec)).timestamp()
+                        .unix_timestamp(),
+                    (first_time_stamp + Duration::seconds(offset_sec)).unix_timestamp()
                 );
                 assert_eq!(
                     retrieved_doc

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -110,6 +110,7 @@ mod tests {
                         .expect("cannot find value")
                         .as_date()
                         .unwrap()
+                        .assume_utc()
                         .unix_timestamp(),
                     first_time_stamp.unix_timestamp()
                 );
@@ -138,6 +139,7 @@ mod tests {
                         .expect("cannot find value")
                         .as_date()
                         .unwrap()
+                        .assume_utc()
                         .unix_timestamp(),
                     two_secs_ahead.unix_timestamp()
                 );
@@ -180,6 +182,7 @@ mod tests {
                         .expect("cannot find value")
                         .as_date()
                         .expect("value not of Date type")
+                        .assume_utc()
                         .unix_timestamp(),
                     (first_time_stamp + Duration::seconds(offset_sec)).unix_timestamp()
                 );

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -72,21 +72,26 @@ mod tests {
         let index = Index::create_in_ram(schema);
         let mut index_writer = index.writer_for_tests()?;
         let first_time_stamp = OffsetDateTime::now_utc();
-        index_writer.add_document(
-            doc!(date_field=>first_time_stamp, date_field=>first_time_stamp, time_i=>1i64),
-        )?;
-        index_writer.add_document(doc!(time_i=>0i64))?;
+        index_writer.add_document(doc!(
+                date_field => DateTime::new_utc(first_time_stamp),
+                date_field => DateTime::new_utc(first_time_stamp),
+                time_i=>1i64))?;
+        index_writer.add_document(doc!(time_i => 0i64))?;
         // add one second
-        index_writer.add_document(
-            doc!(date_field=>first_time_stamp + Duration::seconds(1), time_i=>2i64),
-        )?;
+        index_writer.add_document(doc!(
+            date_field => DateTime::new_utc(first_time_stamp + Duration::seconds(1)),
+            time_i => 2i64))?;
         // add another second
         let two_secs_ahead = first_time_stamp + Duration::seconds(2);
-        index_writer.add_document(doc!(date_field=>two_secs_ahead, date_field=>two_secs_ahead,date_field=>two_secs_ahead, time_i=>3i64))?;
+        index_writer.add_document(doc!(
+            date_field => DateTime::new_utc(two_secs_ahead),
+            date_field => DateTime::new_utc(two_secs_ahead),
+            date_field => DateTime::new_utc(two_secs_ahead),
+            time_i => 3i64))?;
         // add three seconds
-        index_writer.add_document(
-            doc!(date_field=>first_time_stamp + Duration::seconds(3), time_i=>4i64),
-        )?;
+        index_writer.add_document(doc!(
+                date_field => DateTime::new_utc(first_time_stamp + Duration::seconds(3)),
+                time_i => 4i64))?;
         index_writer.commit()?;
 
         let reader = index.reader()?;

--- a/src/fastfield/readers.rs
+++ b/src/fastfield/readers.rs
@@ -1,5 +1,3 @@
-use time::OffsetDateTime;
-
 use super::reader::DynamicFastFieldReader;
 use crate::directory::{CompositeFile, FileSlice};
 use crate::fastfield::{
@@ -7,6 +5,7 @@ use crate::fastfield::{
 };
 use crate::schema::{Cardinality, Field, FieldType, Schema};
 use crate::space_usage::PerFieldSpaceUsage;
+use crate::time::OffsetDateTime;
 use crate::TantivyError;
 
 /// Provides access to all of the BitpackedFastFieldReader.

--- a/src/fastfield/readers.rs
+++ b/src/fastfield/readers.rs
@@ -1,3 +1,5 @@
+use time::OffsetDateTime;
+
 use super::reader::DynamicFastFieldReader;
 use crate::directory::{CompositeFile, FileSlice};
 use crate::fastfield::{
@@ -147,10 +149,10 @@ impl FastFieldReaders {
         self.typed_fast_field_reader(field)
     }
 
-    /// Returns the `i64` fast field reader reader associated to `field`.
+    /// Returns the `date` fast field reader reader associated to `field`.
     ///
-    /// If `field` is not a i64 fast field, this method returns an Error.
-    pub fn date(&self, field: Field) -> crate::Result<DynamicFastFieldReader<crate::DateTime>> {
+    /// If `field` is not a date fast field, this method returns an Error.
+    pub fn date(&self, field: Field) -> crate::Result<DynamicFastFieldReader<OffsetDateTime>> {
         self.check_type(field, FastType::Date, Cardinality::SingleValue)?;
         self.typed_fast_field_reader(field)
     }
@@ -195,13 +197,12 @@ impl FastFieldReaders {
         self.typed_fast_field_multi_reader(field)
     }
 
-    /// Returns a `crate::DateTime` multi-valued fast field reader reader associated to `field`.
+    /// Returns a `time::OffsetDateTime` multi-valued fast field reader reader associated to
+    /// `field`.
     ///
-    /// If `field` is not a `crate::DateTime` multi-valued fast field, this method returns an Error.
-    pub fn dates(
-        &self,
-        field: Field,
-    ) -> crate::Result<MultiValuedFastFieldReader<crate::DateTime>> {
+    /// If `field` is not a `time::OffsetDateTime` multi-valued fast field, this method returns an
+    /// Error.
+    pub fn dates(&self, field: Field) -> crate::Result<MultiValuedFastFieldReader<OffsetDateTime>> {
         self.check_type(field, FastType::Date, Cardinality::MultiValues)?;
         self.typed_fast_field_multi_reader(field)
     }

--- a/src/fastfield/readers.rs
+++ b/src/fastfield/readers.rs
@@ -5,8 +5,7 @@ use crate::fastfield::{
 };
 use crate::schema::{Cardinality, Field, FieldType, Schema};
 use crate::space_usage::PerFieldSpaceUsage;
-use crate::time::OffsetDateTime;
-use crate::TantivyError;
+use crate::{DateTime, TantivyError};
 
 /// Provides access to all of the BitpackedFastFieldReader.
 ///
@@ -151,7 +150,7 @@ impl FastFieldReaders {
     /// Returns the `date` fast field reader reader associated to `field`.
     ///
     /// If `field` is not a date fast field, this method returns an Error.
-    pub fn date(&self, field: Field) -> crate::Result<DynamicFastFieldReader<OffsetDateTime>> {
+    pub fn date(&self, field: Field) -> crate::Result<DynamicFastFieldReader<DateTime>> {
         self.check_type(field, FastType::Date, Cardinality::SingleValue)?;
         self.typed_fast_field_reader(field)
     }
@@ -201,7 +200,7 @@ impl FastFieldReaders {
     ///
     /// If `field` is not a `time::OffsetDateTime` multi-valued fast field, this method returns an
     /// Error.
-    pub fn dates(&self, field: Field) -> crate::Result<MultiValuedFastFieldReader<OffsetDateTime>> {
+    pub fn dates(&self, field: Field) -> crate::Result<MultiValuedFastFieldReader<DateTime>> {
         self.check_type(field, FastType::Date, Cardinality::MultiValues)?;
         self.typed_fast_field_multi_reader(field)
     }

--- a/src/indexer/json_term_writer.rs
+++ b/src/indexer/json_term_writer.rs
@@ -1,12 +1,12 @@
 use fnv::FnvHashMap;
 use murmurhash32::murmurhash2;
-use time::format_description::well_known::Rfc3339;
-use time::{OffsetDateTime, UtcOffset};
 
 use crate::fastfield::FastValue;
 use crate::postings::{IndexingContext, IndexingPosition, PostingsWriter};
 use crate::schema::term::{JSON_END_OF_PATH, JSON_PATH_SEGMENT_SEP};
 use crate::schema::Type;
+use crate::time::format_description::well_known::Rfc3339;
+use crate::time::{OffsetDateTime, UtcOffset};
 use crate::tokenizer::TextAnalyzer;
 use crate::{DocId, Term};
 

--- a/src/indexer/json_term_writer.rs
+++ b/src/indexer/json_term_writer.rs
@@ -1,6 +1,7 @@
-use chrono::Utc;
 use fnv::FnvHashMap;
 use murmurhash32::murmurhash2;
+use time::format_description::well_known::Rfc3339;
+use time::{OffsetDateTime, UtcOffset};
 
 use crate::fastfield::FastValue;
 use crate::postings::{IndexingContext, IndexingPosition, PostingsWriter};
@@ -184,13 +185,13 @@ fn index_json_value<'a>(
 
 enum TextOrDateTime<'a> {
     Text(&'a str),
-    DateTime(crate::DateTime),
+    DateTime(OffsetDateTime),
 }
 
 fn infer_type_from_str(text: &str) -> TextOrDateTime {
-    match chrono::DateTime::parse_from_rfc3339(text) {
+    match OffsetDateTime::parse(text, &Rfc3339) {
         Ok(dt) => {
-            let dt_utc = dt.with_timezone(&Utc);
+            let dt_utc = dt.to_offset(UtcOffset::UTC);
             TextOrDateTime::DateTime(dt_utc)
         }
         Err(_) => TextOrDateTime::Text(text),

--- a/src/indexer/json_term_writer.rs
+++ b/src/indexer/json_term_writer.rs
@@ -8,7 +8,7 @@ use crate::schema::Type;
 use crate::time::format_description::well_known::Rfc3339;
 use crate::time::{OffsetDateTime, UtcOffset};
 use crate::tokenizer::TextAnalyzer;
-use crate::{DocId, Term};
+use crate::{DateTime, DocId, Term};
 
 /// This object is a map storing the last position for a given path for the current document
 /// being indexed.
@@ -152,7 +152,7 @@ fn index_json_value<'a>(
                 );
             }
             TextOrDateTime::DateTime(dt) => {
-                json_term_writer.set_fast_value(dt);
+                json_term_writer.set_fast_value(DateTime::new_utc(dt));
                 postings_writer.subscribe(doc, 0u32, json_term_writer.term(), ctx);
             }
         },

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1135,6 +1135,7 @@ mod tests {
     use byteorder::{BigEndian, ReadBytesExt};
     use futures::executor::block_on;
     use schema::FAST;
+    use time::OffsetDateTime;
 
     use crate::collector::tests::{
         BytesFastFieldTestCollector, FastFieldTestCollector, TEST_COLLECTOR_WITH_SCORE,
@@ -1169,7 +1170,7 @@ mod tests {
         let bytes_score_field = schema_builder.add_bytes_field("score_bytes", FAST);
         let index = Index::create_in_ram(schema_builder.build());
         let reader = index.reader()?;
-        let curr_time = chrono::Utc::now();
+        let curr_time = OffsetDateTime::now_utc();
         {
             let mut index_writer = index.writer_for_tests()?;
             // writing the segment

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1149,8 +1149,8 @@ mod tests {
     };
     use crate::time::OffsetDateTime;
     use crate::{
-        assert_nearly_equals, schema, DocAddress, DocSet, IndexSettings, IndexSortByField,
-        IndexWriter, Order, Searcher, SegmentId,
+        assert_nearly_equals, schema, DateTime, DocAddress, DocSet, IndexSettings,
+        IndexSortByField, IndexWriter, Order, Searcher, SegmentId,
     };
 
     #[test]
@@ -1250,7 +1250,10 @@ mod tests {
                     ]
                 );
                 assert_eq!(
-                    get_doc_ids(vec![Term::from_field_date(date_field, &curr_time)])?,
+                    get_doc_ids(vec![Term::from_field_date(
+                        date_field,
+                        DateTime::new_utc(curr_time)
+                    )])?,
                     vec![DocAddress::new(0, 0), DocAddress::new(0, 3)]
                 );
             }

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1135,7 +1135,6 @@ mod tests {
     use byteorder::{BigEndian, ReadBytesExt};
     use futures::executor::block_on;
     use schema::FAST;
-    use time::OffsetDateTime;
 
     use crate::collector::tests::{
         BytesFastFieldTestCollector, FastFieldTestCollector, TEST_COLLECTOR_WITH_SCORE,
@@ -1148,6 +1147,7 @@ mod tests {
         Cardinality, Document, Facet, FacetOptions, IndexRecordOption, NumericOptions, Term,
         TextFieldIndexing, INDEXED, TEXT,
     };
+    use crate::time::OffsetDateTime;
     use crate::{
         assert_nearly_equals, schema, DocAddress, DocSet, IndexSettings, IndexSortByField,
         IndexWriter, Order, Searcher, SegmentId,

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1177,7 +1177,7 @@ mod tests {
             index_writer.add_document(doc!(
                 text_field => "af b",
                 score_field => 3u64,
-                date_field => curr_time,
+                date_field => DateTime::new_utc(curr_time),
                 bytes_score_field => 3u32.to_be_bytes().as_ref()
             ))?;
             index_writer.add_document(doc!(
@@ -1194,7 +1194,7 @@ mod tests {
             // writing the segment
             index_writer.add_document(doc!(
                 text_field => "af b",
-                date_field => curr_time,
+                date_field => DateTime::new_utc(curr_time),
                 score_field => 11u64,
                 bytes_score_field => 11u32.to_be_bytes().as_ref()
             ))?;

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -1,7 +1,7 @@
 use super::doc_id_mapping::{get_doc_id_mapping_from_field, DocIdMapping};
 use super::operation::AddOperation;
 use crate::core::Segment;
-use crate::fastfield::FastFieldsWriter;
+use crate::fastfield::{FastFieldsWriter, FastValue as _};
 use crate::fieldnorm::{FieldNormReaders, FieldNormsWriter};
 use crate::indexer::json_term_writer::index_json_values;
 use crate::indexer::segment_serializer::SegmentSerializer;
@@ -244,7 +244,7 @@ impl SegmentWriter {
                 FieldType::Date(_) => {
                     for value in values {
                         let date_val = value.as_date().ok_or_else(make_schema_error)?;
-                        term_buffer.set_i64(date_val.assume_utc().unix_timestamp());
+                        term_buffer.set_u64(date_val.to_u64());
                         postings_writer.subscribe(doc_id, 0u32, term_buffer, ctx);
                     }
                 }

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -421,9 +421,9 @@ mod tests {
     use crate::query::PhraseQuery;
     use crate::schema::{IndexRecordOption, Schema, Type, STORED, STRING, TEXT};
     use crate::time::format_description::well_known::Rfc3339;
-    use crate::time::{OffsetDateTime, UtcOffset};
+    use crate::time::OffsetDateTime;
     use crate::tokenizer::{PreTokenizedString, Token};
-    use crate::{DocAddress, DocSet, Document, Index, Postings, Term, TERMINATED};
+    use crate::{DateTime, DocAddress, DocSet, Document, Index, Postings, Term, TERMINATED};
 
     #[test]
     fn test_hashmap_size() {
@@ -523,11 +523,9 @@ mod tests {
         json_term_writer.pop_path_segment();
         json_term_writer.pop_path_segment();
         json_term_writer.push_path_segment("date");
-        json_term_writer.set_fast_value(
-            OffsetDateTime::parse("1985-04-12T23:20:50.52Z", &Rfc3339)
-                .unwrap()
-                .to_offset(UtcOffset::UTC),
-        );
+        json_term_writer.set_fast_value(DateTime::new_utc(
+            OffsetDateTime::parse("1985-04-12T23:20:50.52Z", &Rfc3339).unwrap(),
+        ));
         assert!(term_stream.advance());
         assert_eq!(term_stream.key(), json_term_writer.term().value_bytes());
 

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -244,7 +244,7 @@ impl SegmentWriter {
                 FieldType::Date(_) => {
                     for value in values {
                         let date_val = value.as_date().ok_or_else(make_schema_error)?;
-                        term_buffer.set_i64(date_val.unix_timestamp());
+                        term_buffer.set_i64(date_val.assume_utc().unix_timestamp());
                         postings_writer.subscribe(doc_id, 0u32, term_buffer, ctx);
                     }
                 }

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -414,15 +414,14 @@ pub fn prepare_doc_for_store(doc: Document, schema: &Schema) -> Document {
 
 #[cfg(test)]
 mod tests {
-    use time::format_description::well_known::Rfc3339;
-    use time::{OffsetDateTime, UtcOffset};
-
     use super::compute_initial_table_size;
     use crate::collector::Count;
     use crate::indexer::json_term_writer::JsonTermWriter;
     use crate::postings::TermInfo;
     use crate::query::PhraseQuery;
     use crate::schema::{IndexRecordOption, Schema, Type, STORED, STRING, TEXT};
+    use crate::time::format_description::well_known::Rfc3339;
+    use crate::time::{OffsetDateTime, UtcOffset};
     use crate::tokenizer::{PreTokenizedString, Token};
     use crate::{DocAddress, DocSet, Document, Index, Postings, Term, TERMINATED};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,8 +124,6 @@ mod functional_test;
 #[macro_use]
 mod macros;
 
-pub use chrono;
-
 pub use crate::error::TantivyError;
 
 /// Tantivy result.
@@ -137,9 +135,6 @@ pub type Result<T> = std::result::Result<T, TantivyError>;
 /// Result for an Async io operation.
 #[cfg(feature = "quickwit")]
 pub type AsyncIoResult<T> = std::result::Result<T, crate::error::AsyncIoError>;
-
-/// Tantivy DateTime
-pub type DateTime = chrono::DateTime<chrono::Utc>;
 
 mod core;
 mod indexer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,11 @@ mod functional_test;
 #[macro_use]
 mod macros;
 
+/// Re-export of the `time` crate
+///
+/// Tantivy uses [`time`](https://crates.io/crates/time) for dates.
+pub use time;
+
 pub use crate::error::TantivyError;
 
 /// Tantivy result.

--- a/src/query/more_like_this/more_like_this.rs
+++ b/src/query/more_like_this/more_like_this.rs
@@ -244,13 +244,12 @@ impl MoreLikeThis {
             FieldType::Date(_) => {
                 for value in values {
                     // TODO: Ask if this is the semantic (timestamp) we want
-                    let val = value
+                    let unix_timestamp = value
                         .as_date()
                         .ok_or_else(|| TantivyError::InvalidArgument("invalid value".to_string()))?
-                        .assume_utc()
-                        .unix_timestamp();
-                    if !self.is_noise_word(val.to_string()) {
-                        let term = Term::from_field_i64(field, val);
+                        .to_unix_timestamp();
+                    if !self.is_noise_word(unix_timestamp.to_string()) {
+                        let term = Term::from_field_i64(field, unix_timestamp);
                         *term_frequencies.entry(term).or_insert(0) += 1;
                     }
                 }

--- a/src/query/more_like_this/more_like_this.rs
+++ b/src/query/more_like_this/more_like_this.rs
@@ -247,7 +247,7 @@ impl MoreLikeThis {
                     let val = value
                         .as_date()
                         .ok_or_else(|| TantivyError::InvalidArgument("invalid value".to_string()))?
-                        .timestamp();
+                        .unix_timestamp();
                     if !self.is_noise_word(val.to_string()) {
                         let term = Term::from_field_i64(field, val);
                         *term_frequencies.entry(term).or_insert(0) += 1;

--- a/src/query/more_like_this/more_like_this.rs
+++ b/src/query/more_like_this/more_like_this.rs
@@ -247,6 +247,7 @@ impl MoreLikeThis {
                     let val = value
                         .as_date()
                         .ok_or_else(|| TantivyError::InvalidArgument("invalid value".to_string()))?
+                        .assume_utc()
                         .unix_timestamp();
                     if !self.is_noise_word(val.to_string()) {
                         let term = Term::from_field_i64(field, val);

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -1039,9 +1039,10 @@ mod test {
 
     #[test]
     fn test_json_field_possibly_a_date() {
+        // Subseconds are discarded
         test_parse_query_to_logical_ast_helper(
             r#"json.date:"2019-10-12T07:20:50.52Z""#,
-            r#"(Term(type=Json, field=14, path=date, vtype=Date, DateTime { unix_timestamp: 1570864850 }) "[(0, Term(type=Json, field=14, path=date, vtype=Str, "2019")), (1, Term(type=Json, field=14, path=date, vtype=Str, "10")), (2, Term(type=Json, field=14, path=date, vtype=Str, "12t07")), (3, Term(type=Json, field=14, path=date, vtype=Str, "20")), (4, Term(type=Json, field=14, path=date, vtype=Str, "50")), (5, Term(type=Json, field=14, path=date, vtype=Str, "52z"))]")"#,
+            r#"(Term(type=Json, field=14, path=date, vtype=Date, 2019-10-12T07:20:50Z) "[(0, Term(type=Json, field=14, path=date, vtype=Str, "2019")), (1, Term(type=Json, field=14, path=date, vtype=Str, "10")), (2, Term(type=Json, field=14, path=date, vtype=Str, "12t07")), (3, Term(type=Json, field=14, path=date, vtype=Str, "20")), (4, Term(type=Json, field=14, path=date, vtype=Str, "50")), (5, Term(type=Json, field=14, path=date, vtype=Str, "52z"))]")"#,
             true,
         );
     }

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -4,8 +4,6 @@ use std::ops::Bound;
 use std::str::FromStr;
 
 use tantivy_query_grammar::{UserInputAst, UserInputBound, UserInputLeaf, UserInputLiteral};
-use time::format_description::well_known::Rfc3339;
-use time::{OffsetDateTime, UtcOffset};
 
 use super::logical_ast::*;
 use crate::core::Index;
@@ -17,6 +15,8 @@ use crate::query::{
 use crate::schema::{
     Facet, FacetParseError, Field, FieldType, IndexRecordOption, Schema, Term, Type,
 };
+use crate::time::format_description::well_known::Rfc3339;
+use crate::time::{OffsetDateTime, UtcOffset};
 use crate::tokenizer::{TextAnalyzer, TokenizerManager};
 use crate::Score;
 

--- a/src/schema/document.rs
+++ b/src/schema/document.rs
@@ -3,6 +3,7 @@ use std::io::{self, Read, Write};
 use std::mem;
 
 use common::{BinarySerializable, VInt};
+use time::PrimitiveDateTime;
 
 use super::*;
 use crate::time::OffsetDateTime;
@@ -110,8 +111,15 @@ impl Document {
         self.add_field_value(field, value);
     }
 
-    /// Add a date field
-    pub fn add_date(&mut self, field: Field, value: OffsetDateTime) {
+    /// Add a date field with unspecified time zone offset
+    pub fn add_date(&mut self, field: Field, value: PrimitiveDateTime) {
+        self.add_field_value(field, value);
+    }
+
+    /// Add a date field with time zone offset
+    ///
+    /// The time zone offset is implicitly converted to UTC.
+    pub fn add_date_utc(&mut self, field: Field, value: OffsetDateTime) {
         self.add_field_value(field, value);
     }
 

--- a/src/schema/document.rs
+++ b/src/schema/document.rs
@@ -3,10 +3,9 @@ use std::io::{self, Read, Write};
 use std::mem;
 
 use common::{BinarySerializable, VInt};
-use time::PrimitiveDateTime;
 
 use super::*;
-use crate::time::OffsetDateTime;
+use crate::time::{OffsetDateTime, PrimitiveDateTime};
 use crate::tokenizer::PreTokenizedString;
 
 /// Tantivy's Document is the object that can

--- a/src/schema/document.rs
+++ b/src/schema/document.rs
@@ -3,10 +3,10 @@ use std::io::{self, Read, Write};
 use std::mem;
 
 use common::{BinarySerializable, VInt};
+use time::OffsetDateTime;
 
 use super::*;
 use crate::tokenizer::PreTokenizedString;
-use crate::DateTime;
 
 /// Tantivy's Document is the object that can
 /// be indexed and then searched for.
@@ -111,7 +111,7 @@ impl Document {
     }
 
     /// Add a date field
-    pub fn add_date(&mut self, field: Field, value: DateTime) {
+    pub fn add_date(&mut self, field: Field, value: OffsetDateTime) {
         self.add_field_value(field, value);
     }
 

--- a/src/schema/document.rs
+++ b/src/schema/document.rs
@@ -3,9 +3,9 @@ use std::io::{self, Read, Write};
 use std::mem;
 
 use common::{BinarySerializable, VInt};
-use time::OffsetDateTime;
 
 use super::*;
+use crate::time::OffsetDateTime;
 use crate::tokenizer::PreTokenizedString;
 
 /// Tantivy's Document is the object that can

--- a/src/schema/document.rs
+++ b/src/schema/document.rs
@@ -5,8 +5,8 @@ use std::mem;
 use common::{BinarySerializable, VInt};
 
 use super::*;
-use crate::time::{OffsetDateTime, PrimitiveDateTime};
 use crate::tokenizer::PreTokenizedString;
+use crate::DateTime;
 
 /// Tantivy's Document is the object that can
 /// be indexed and then searched for.
@@ -111,14 +111,7 @@ impl Document {
     }
 
     /// Add a date field with unspecified time zone offset
-    pub fn add_date(&mut self, field: Field, value: PrimitiveDateTime) {
-        self.add_field_value(field, value);
-    }
-
-    /// Add a date field with time zone offset
-    ///
-    /// The time zone offset is implicitly converted to UTC.
-    pub fn add_date_utc(&mut self, field: Field, value: OffsetDateTime) {
+    pub fn add_date(&mut self, field: Field, value: DateTime) {
         self.add_field_value(field, value);
     }
 

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -9,7 +9,7 @@ use crate::schema::{
     Value,
 };
 use crate::time::format_description::well_known::Rfc3339;
-use crate::time::{OffsetDateTime, UtcOffset};
+use crate::time::OffsetDateTime;
 use crate::tokenizer::PreTokenizedString;
 
 /// Possible error that may occur while parsing a field value
@@ -253,7 +253,7 @@ impl FieldType {
                                 expected: "rfc3339 format",
                                 json: JsonValue::String(field_text),
                             })?;
-                        Ok(Value::Date(dt_with_fixed_tz.to_offset(UtcOffset::UTC)))
+                        Ok(dt_with_fixed_tz.into())
                     }
                     FieldType::Str(_) => Ok(Value::Str(field_text)),
                     FieldType::U64(_) | FieldType::I64(_) | FieldType::F64(_) => {
@@ -362,9 +362,8 @@ mod tests {
         let date = doc.get_first(date_field).unwrap();
         assert_eq!(
             format!("{:?}", date),
-            "Date(OffsetDateTime { utc_datetime: PrimitiveDateTime { date: Date { year: 2019, \
-             ordinal: 285 }, time: Time { hour: 5, minute: 20, second: 50, nanosecond: 520000000 \
-             } }, offset: UtcOffset { hours: 0, minutes: 0, seconds: 0 } })"
+            "Date(PrimitiveDateTime { date: Date { year: 2019, ordinal: 285 }, time: Time { hour: \
+             5, minute: 20, second: 50, nanosecond: 520000000 } })"
         );
     }
 

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -350,7 +350,7 @@ mod tests {
     use crate::schema::{Schema, TextOptions, Type, Value, INDEXED};
     use crate::time::{Date, Month, PrimitiveDateTime, Time};
     use crate::tokenizer::{PreTokenizedString, Token};
-    use crate::Document;
+    use crate::{DateTime, Document};
 
     #[test]
     fn test_deserialize_json_date() {
@@ -362,8 +362,7 @@ mod tests {
         let date = doc.get_first(date_field).unwrap();
         assert_eq!(
             format!("{:?}", date),
-            "Date(PrimitiveDateTime { date: Date { year: 2019, ordinal: 285 }, time: Time { hour: \
-             5, minute: 20, second: 50, nanosecond: 520000000 } })"
+            "Date(DateTime { unix_timestamp: 1570857650 })"
         );
     }
 
@@ -376,7 +375,7 @@ mod tests {
         let naive_date = Date::from_calendar_date(1982, Month::September, 17).unwrap();
         let naive_time = Time::from_hms(13, 20, 0).unwrap();
         let date_time = PrimitiveDateTime::new(naive_date, naive_time);
-        doc.add_date(date_field, date_time);
+        doc.add_date(date_field, DateTime::new_primitive(date_time));
         let doc_json = schema.to_json(&doc);
         assert_eq!(doc_json, r#"{"date":["1982-09-17T13:20:00Z"]}"#);
     }

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -361,10 +361,8 @@ mod tests {
         let doc_json = r#"{"date": "2019-10-12T07:20:50.52+02:00"}"#;
         let doc = schema.parse_document(doc_json).unwrap();
         let date = doc.get_first(date_field).unwrap();
-        assert_eq!(
-            format!("{:?}", date),
-            "Date(DateTime { unix_timestamp: 1570857650 })"
-        );
+        // Time zone is converted to UTC and subseconds are discarded
+        assert_eq!("Date(2019-10-12T05:20:50Z)", format!("{:?}", date));
     }
 
     #[test]

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -375,7 +375,7 @@ mod tests {
         let schema = schema_builder.build();
         let naive_date = Date::from_calendar_date(1982, Month::September, 17).unwrap();
         let naive_time = Time::from_hms(13, 20, 0).unwrap();
-        let date_time = PrimitiveDateTime::new(naive_date, naive_time).assume_utc();
+        let date_time = PrimitiveDateTime::new(naive_date, naive_time);
         doc.add_date(date_field, date_time);
         let doc_json = schema.to_json(&doc);
         assert_eq!(doc_json, r#"{"date":["1982-09-17T13:20:00Z"]}"#);

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
-use time::format_description::well_known::Rfc3339;
-use time::{OffsetDateTime, UtcOffset};
 
 use crate::schema::bytes_options::BytesOptions;
 use crate::schema::facet_options::FacetOptions;
@@ -10,6 +8,8 @@ use crate::schema::{
     Facet, IndexRecordOption, JsonObjectOptions, NumericOptions, TextFieldIndexing, TextOptions,
     Value,
 };
+use crate::time::format_description::well_known::Rfc3339;
+use crate::time::{OffsetDateTime, UtcOffset};
 use crate::tokenizer::PreTokenizedString;
 
 /// Possible error that may occur while parsing a field value
@@ -344,11 +344,11 @@ impl FieldType {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
-    use time::{Date, Month, PrimitiveDateTime, Time};
 
     use super::FieldType;
     use crate::schema::field_type::ValueParsingError;
     use crate::schema::{Schema, TextOptions, Type, Value, INDEXED};
+    use crate::time::{Date, Month, PrimitiveDateTime, Time};
     use crate::tokenizer::{PreTokenizedString, Token};
     use crate::Document;
 

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -11,6 +11,7 @@ use crate::schema::{
 use crate::time::format_description::well_known::Rfc3339;
 use crate::time::OffsetDateTime;
 use crate::tokenizer::PreTokenizedString;
+use crate::DateTime;
 
 /// Possible error that may occur while parsing a field value
 /// At this point the JSON is known to be valid.
@@ -253,7 +254,7 @@ impl FieldType {
                                 expected: "rfc3339 format",
                                 json: JsonValue::String(field_text),
                             })?;
-                        Ok(dt_with_fixed_tz.into())
+                        Ok(DateTime::new_utc(dt_with_fixed_tz).into())
                     }
                     FieldType::Str(_) => Ok(Value::Str(field_text)),
                     FieldType::U64(_) | FieldType::I64(_) | FieldType::F64(_) => {

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -2,11 +2,10 @@ use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
 use std::{fmt, str};
 
-use time::OffsetDateTime;
-
 use super::Field;
 use crate::fastfield::FastValue;
 use crate::schema::{Facet, Type};
+use crate::time::OffsetDateTime;
 
 /// Size (in bytes) of the buffer of a fast value (u64, i64, f64, or date) term.
 /// <field> + <type byte> + <value len>

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -2,10 +2,11 @@ use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
 use std::{fmt, str};
 
+use time::OffsetDateTime;
+
 use super::Field;
 use crate::fastfield::FastValue;
 use crate::schema::{Facet, Type};
-use crate::DateTime;
 
 /// Size (in bytes) of the buffer of a fast value (u64, i64, f64, or date) term.
 /// <field> + <type byte> + <value len>
@@ -70,7 +71,7 @@ impl Term {
     }
 
     /// Builds a term given a field, and a DateTime value
-    pub fn from_field_date(field: Field, val: &DateTime) -> Term {
+    pub fn from_field_date(field: Field, val: &OffsetDateTime) -> Term {
         Term::from_fast_value(field, val)
     }
 
@@ -126,7 +127,7 @@ impl Term {
     }
 
     /// Sets a `i64` value in the term.
-    pub fn set_date(&mut self, date: crate::DateTime) {
+    pub fn set_date(&mut self, date: OffsetDateTime) {
         self.set_fast_value(date);
     }
 
@@ -266,8 +267,8 @@ where B: AsRef<[u8]>
     ///
     /// Returns None if the term is not of the Date type, or if the term byte representation
     /// is invalid.
-    pub fn as_date(&self) -> Option<crate::DateTime> {
-        self.get_fast_type::<crate::DateTime>()
+    pub fn as_date(&self) -> Option<OffsetDateTime> {
+        self.get_fast_type::<OffsetDateTime>()
     }
 
     /// Returns the text associated with the term.
@@ -374,7 +375,7 @@ fn debug_value_bytes(typ: Type, bytes: &[u8], f: &mut fmt::Formatter) -> fmt::Re
         }
         // TODO pretty print these types too.
         Type::Date => {
-            write_opt(f, get_fast_type::<crate::DateTime>(bytes))?;
+            write_opt(f, get_fast_type::<OffsetDateTime>(bytes))?;
         }
         Type::Facet => {
             let facet_str = str::from_utf8(bytes)

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -5,7 +5,7 @@ use std::{fmt, str};
 use super::Field;
 use crate::fastfield::FastValue;
 use crate::schema::{Facet, Type};
-use crate::time::OffsetDateTime;
+use crate::DateTime;
 
 /// Size (in bytes) of the buffer of a fast value (u64, i64, f64, or date) term.
 /// <field> + <type byte> + <value len>
@@ -70,8 +70,8 @@ impl Term {
     }
 
     /// Builds a term given a field, and a DateTime value
-    pub fn from_field_date(field: Field, val: &OffsetDateTime) -> Term {
-        Term::from_fast_value(field, val)
+    pub fn from_field_date(field: Field, val: DateTime) -> Term {
+        Term::from_fast_value(field, &val)
     }
 
     /// Creates a `Term` given a facet.
@@ -126,7 +126,7 @@ impl Term {
     }
 
     /// Sets a `i64` value in the term.
-    pub fn set_date(&mut self, date: OffsetDateTime) {
+    pub fn set_date(&mut self, date: DateTime) {
         self.set_fast_value(date);
     }
 
@@ -266,8 +266,8 @@ where B: AsRef<[u8]>
     ///
     /// Returns None if the term is not of the Date type, or if the term byte representation
     /// is invalid.
-    pub fn as_date(&self) -> Option<OffsetDateTime> {
-        self.get_fast_type::<OffsetDateTime>()
+    pub fn as_date(&self) -> Option<DateTime> {
+        self.get_fast_type::<DateTime>()
     }
 
     /// Returns the text associated with the term.
@@ -374,7 +374,7 @@ fn debug_value_bytes(typ: Type, bytes: &[u8], f: &mut fmt::Formatter) -> fmt::Re
         }
         // TODO pretty print these types too.
         Type::Date => {
-            write_opt(f, get_fast_type::<OffsetDateTime>(bytes))?;
+            write_opt(f, get_fast_type::<DateTime>(bytes))?;
         }
         Type::Facet => {
             let facet_str = str::from_utf8(bytes)

--- a/src/schema/value.rs
+++ b/src/schema/value.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Map;
 
 use crate::schema::Facet;
-use crate::time::OffsetDateTime;
 use crate::tokenizer::PreTokenizedString;
 use crate::DateTime;
 
@@ -216,12 +215,6 @@ impl From<DateTime> for Value {
     }
 }
 
-impl From<OffsetDateTime> for Value {
-    fn from(dt: OffsetDateTime) -> Value {
-        Value::Date(DateTime::new_utc(dt))
-    }
-}
-
 impl<'a> From<&'a str> for Value {
     fn from(s: &'a str) -> Value {
         Value::Str(s.to_string())
@@ -412,15 +405,18 @@ mod tests {
     use super::Value;
     use crate::time::format_description::well_known::Rfc3339;
     use crate::time::OffsetDateTime;
+    use crate::DateTime;
 
     #[test]
     fn test_serialize_date() {
-        let value =
-            Value::from(OffsetDateTime::parse("1996-12-20T00:39:57+00:00", &Rfc3339).unwrap());
+        let value = Value::from(DateTime::new_utc(
+            OffsetDateTime::parse("1996-12-20T00:39:57+00:00", &Rfc3339).unwrap(),
+        ));
         let serialized_value_json = serde_json::to_string_pretty(&value).unwrap();
         assert_eq!(serialized_value_json, r#""1996-12-20T00:39:57Z""#);
-        let value =
-            Value::from(OffsetDateTime::parse("1996-12-20T00:39:57-01:00", &Rfc3339).unwrap());
+        let value = Value::from(DateTime::new_utc(
+            OffsetDateTime::parse("1996-12-20T00:39:57-01:00", &Rfc3339).unwrap(),
+        ));
         let serialized_value_json = serde_json::to_string_pretty(&value).unwrap();
         // The time zone information gets lost by conversion into `Value::Date` and
         // implicitly becomes UTC.

--- a/src/schema/value.rs
+++ b/src/schema/value.rs
@@ -3,9 +3,9 @@ use std::fmt;
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Map;
-use time::OffsetDateTime;
 
 use crate::schema::Facet;
+use crate::time::OffsetDateTime;
 use crate::tokenizer::PreTokenizedString;
 
 /// Value represents the value of a any field.
@@ -266,10 +266,10 @@ mod binary_serialize {
     use std::io::{self, Read, Write};
 
     use common::{f64_to_u64, u64_to_f64, BinarySerializable};
-    use time::OffsetDateTime;
 
     use super::Value;
     use crate::schema::Facet;
+    use crate::time::OffsetDateTime;
     use crate::tokenizer::PreTokenizedString;
 
     const TEXT_CODE: u8 = 0;
@@ -408,10 +408,9 @@ mod binary_serialize {
 
 #[cfg(test)]
 mod tests {
-    use time::format_description::well_known::Rfc3339;
-    use time::OffsetDateTime;
-
     use super::Value;
+    use crate::time::format_description::well_known::Rfc3339;
+    use crate::time::OffsetDateTime;
 
     #[test]
     fn test_serialize_date() {

--- a/src/schema/value.rs
+++ b/src/schema/value.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use serde::de::Visitor;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Map;
+use time::OffsetDateTime;
 
 use crate::schema::Facet;
 use crate::tokenizer::PreTokenizedString;
-use crate::DateTime;
 
 /// Value represents the value of a any field.
 /// It is an enum over all over all of the possible field type.
@@ -23,7 +23,7 @@ pub enum Value {
     /// 64-bits Float `f64`
     F64(f64),
     /// Signed 64-bits Date time stamp `date`
-    Date(DateTime),
+    Date(OffsetDateTime),
     /// Facet
     Facet(Facet),
     /// Arbitrarily sized byte array
@@ -43,7 +43,7 @@ impl Serialize for Value {
             Value::U64(u) => serializer.serialize_u64(u),
             Value::I64(u) => serializer.serialize_i64(u),
             Value::F64(u) => serializer.serialize_f64(u),
-            Value::Date(ref date) => serializer.serialize_str(&date.to_rfc3339()),
+            Value::Date(ref date) => time::serde::rfc3339::serialize(date, serializer),
             Value::Facet(ref facet) => facet.serialize(serializer),
             Value::Bytes(ref bytes) => serializer.serialize_bytes(bytes),
             Value::JsonObject(ref obj) => obj.serialize(serializer),
@@ -154,7 +154,7 @@ impl Value {
     /// Returns the Date-value, provided the value is of the `Date` type.
     ///
     /// Returns None if the value is not of type `Date`.
-    pub fn as_date(&self) -> Option<&DateTime> {
+    pub fn as_date(&self) -> Option<&OffsetDateTime> {
         if let Value::Date(date) = self {
             Some(date)
         } else {
@@ -209,8 +209,8 @@ impl From<f64> for Value {
     }
 }
 
-impl From<crate::DateTime> for Value {
-    fn from(date_time: crate::DateTime) -> Value {
+impl From<OffsetDateTime> for Value {
+    fn from(date_time: OffsetDateTime) -> Value {
         Value::Date(date_time)
     }
 }
@@ -265,8 +265,8 @@ impl From<serde_json::Value> for Value {
 mod binary_serialize {
     use std::io::{self, Read, Write};
 
-    use chrono::{TimeZone, Utc};
     use common::{f64_to_u64, u64_to_f64, BinarySerializable};
+    use time::OffsetDateTime;
 
     use super::Value;
     use crate::schema::Facet;
@@ -319,7 +319,7 @@ mod binary_serialize {
                 }
                 Value::Date(ref val) => {
                     DATE_CODE.serialize(writer)?;
-                    val.timestamp().serialize(writer)
+                    val.unix_timestamp().serialize(writer)
                 }
                 Value::Facet(ref facet) => {
                     HIERARCHICAL_FACET_CODE.serialize(writer)?;
@@ -358,7 +358,14 @@ mod binary_serialize {
                 }
                 DATE_CODE => {
                     let timestamp = i64::deserialize(reader)?;
-                    Ok(Value::Date(Utc.timestamp(timestamp, 0)))
+                    Ok(Value::Date(
+                        OffsetDateTime::from_unix_timestamp(timestamp).map_err(|err| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!("Invalid UNIX timestamp: {}", err),
+                            )
+                        })?,
+                    ))
                 }
                 HIERARCHICAL_FACET_CODE => Ok(Value::Facet(Facet::deserialize(reader)?)),
                 BYTES_CODE => Ok(Value::Bytes(Vec::<u8>::deserialize(reader)?)),
@@ -401,15 +408,20 @@ mod binary_serialize {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
 
     use super::Value;
-    use crate::DateTime;
 
     #[test]
     fn test_serialize_date() {
-        let value = Value::Date(DateTime::from_str("1996-12-20T00:39:57+00:00").unwrap());
+        let value =
+            Value::Date(OffsetDateTime::parse("1996-12-20T00:39:57+00:00", &Rfc3339).unwrap());
         let serialized_value_json = serde_json::to_string_pretty(&value).unwrap();
-        assert_eq!(serialized_value_json, r#""1996-12-20T00:39:57+00:00""#);
+        assert_eq!(serialized_value_json, r#""1996-12-20T00:39:57Z""#);
+        let value =
+            Value::Date(OffsetDateTime::parse("1996-12-20T00:39:57-01:00", &Rfc3339).unwrap());
+        let serialized_value_json = serde_json::to_string_pretty(&value).unwrap();
+        assert_eq!(serialized_value_json, r#""1996-12-20T00:39:57-01:00""#);
     }
 }


### PR DESCRIPTION
Fixes #1304.

**BREAKING API CHANGE**: The type `DateTime` is no longer (re-)exported. Instead you need to use `time::OffsetDateTime` explicitly.

Remarks:
- Please check the error handling and mappings. `time` returns results instead of panicking like `chrono` does. For the `FastValue` impl I had to use `.expect("valid UNIX timestamp").
- I had to adjust some debug strings in tests that are used for matching test results. Copy&paste from the failed test outputs. Not very handy, please verify.

TODO:
- [x] Add changelog entry