### PR TITLE
use defaults in meta.json

### DIFF
--- a/examples/aggregation.rs
+++ b/examples/aggregation.rs
@@ -20,9 +20,7 @@ fn main() -> tantivy::Result<()> {
     let mut schema_builder = Schema::builder();
     let text_fieldtype = schema::TextOptions::default()
         .set_indexing_options(
-            TextFieldIndexing::default()
-                .set_tokenizer("default")
-                .set_index_option(IndexRecordOption::WithFreqs),
+            TextFieldIndexing::default().set_index_option(IndexRecordOption::WithFreqs),
         )
         .set_stored();
     let text_field = schema_builder.add_text_field("text", text_fieldtype);

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -314,9 +314,7 @@ mod tests {
         let mut schema_builder = Schema::builder();
         let text_fieldtype = crate::schema::TextOptions::default()
             .set_indexing_options(
-                TextFieldIndexing::default()
-                    .set_tokenizer("default")
-                    .set_index_option(IndexRecordOption::WithFreqs),
+                TextFieldIndexing::default().set_index_option(IndexRecordOption::WithFreqs),
             )
             .set_stored();
         let text_field = schema_builder.add_text_field("text", text_fieldtype);
@@ -461,9 +459,7 @@ mod tests {
         let mut schema_builder = Schema::builder();
         let text_fieldtype = crate::schema::TextOptions::default()
             .set_indexing_options(
-                TextFieldIndexing::default()
-                    .set_tokenizer("default")
-                    .set_index_option(IndexRecordOption::WithFreqs),
+                TextFieldIndexing::default().set_index_option(IndexRecordOption::WithFreqs),
             )
             .set_stored();
         let text_field = schema_builder.add_text_field("text", text_fieldtype);
@@ -957,9 +953,7 @@ mod tests {
             let mut schema_builder = Schema::builder();
             let text_fieldtype = crate::schema::TextOptions::default()
                 .set_indexing_options(
-                    TextFieldIndexing::default()
-                        .set_tokenizer("default")
-                        .set_index_option(IndexRecordOption::WithFreqs),
+                    TextFieldIndexing::default().set_index_option(IndexRecordOption::WithFreqs),
                 )
                 .set_stored();
             let text_field = schema_builder.add_text_field("text", text_fieldtype);

--- a/src/core/index_meta.rs
+++ b/src/core/index_meta.rs
@@ -239,7 +239,7 @@ impl InnerSegmentMeta {
 ///
 /// Contains settings which are applied on the whole
 /// index, like presort documents.
-#[derive(Clone, Default, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct IndexSettings {
     /// Sorts the documents by information
     /// provided in `IndexSortByField`
@@ -254,7 +254,7 @@ pub struct IndexSettings {
 /// Presorting documents can greatly performance
 /// in some scenarios, by applying top n
 /// optimizations.
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct IndexSortByField {
     /// The field to sort the documents by
     pub field: String,
@@ -262,7 +262,7 @@ pub struct IndexSortByField {
     pub order: Order,
 }
 /// The order to sort by
-#[derive(Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Order {
     /// Ascending Order
     Asc,
@@ -298,12 +298,12 @@ pub struct IndexMeta {
     pub schema: Schema,
     /// Opstamp associated to the last `commit` operation.
     pub opstamp: Opstamp,
-    #[serde(skip_serializing_if = "Option::is_none")]
     /// Payload associated to the last commit.
     ///
     /// Upon commit, clients can optionally add a small `String` payload to their commit
     /// to help identify this commit.
     /// This payload is entirely unused by tantivy.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<String>,
 }
 
@@ -374,6 +374,7 @@ impl fmt::Debug for IndexMeta {
 mod tests {
 
     use super::IndexMeta;
+    use crate::core::index_meta::UntrackedIndexMeta;
     use crate::schema::{Schema, TEXT};
     use crate::{IndexSettings, IndexSortByField, Order};
 
@@ -402,5 +403,10 @@ mod tests {
             json,
             r#"{"index_settings":{"sort_by_field":{"field":"text","order":"Asc"},"docstore_compression":"lz4"},"segments":[],"schema":[{"name":"text","type":"text","options":{"indexing":{"record":"position","fieldnorms":true,"tokenizer":"default"},"stored":false}}],"opstamp":0}"#
         );
+
+        let deser_meta: UntrackedIndexMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(index_metas.index_settings, deser_meta.index_settings);
+        assert_eq!(index_metas.schema, deser_meta.schema);
+        assert_eq!(index_metas.opstamp, deser_meta.opstamp);
     }
 }

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1157,9 +1157,7 @@ mod tests {
         let mut schema_builder = schema::Schema::builder();
         let text_fieldtype = schema::TextOptions::default()
             .set_indexing_options(
-                TextFieldIndexing::default()
-                    .set_tokenizer("default")
-                    .set_index_option(IndexRecordOption::WithFreqs),
+                TextFieldIndexing::default().set_index_option(IndexRecordOption::WithFreqs),
             )
             .set_stored();
         let text_field = schema_builder.add_text_field("text", text_fieldtype);

--- a/src/query/phrase_query/mod.rs
+++ b/src/query/phrase_query/mod.rs
@@ -126,9 +126,7 @@ pub mod tests {
         let mut schema_builder = Schema::builder();
         use crate::schema::{IndexRecordOption, TextFieldIndexing, TextOptions};
         let no_positions = TextOptions::default().set_indexing_options(
-            TextFieldIndexing::default()
-                .set_tokenizer("default")
-                .set_index_option(IndexRecordOption::WithFreqs),
+            TextFieldIndexing::default().set_index_option(IndexRecordOption::WithFreqs),
         );
 
         let text_field = schema_builder.add_text_field("text", no_positions);

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -183,7 +183,7 @@ impl FieldType {
         }
     }
 
-    /// returns true if the field is normed.
+    /// returns true if the field is normed (see [fieldnorms](crate::fieldnorm)).
     pub fn has_fieldnorms(&self) -> bool {
         match *self {
             FieldType::Str(ref text_options) => text_options

--- a/src/schema/index_record_option.rs
+++ b/src/schema/index_record_option.rs
@@ -29,6 +29,12 @@ pub enum IndexRecordOption {
     WithFreqsAndPositions,
 }
 
+impl Default for IndexRecordOption {
+    fn default() -> Self {
+        IndexRecordOption::Basic
+    }
+}
+
 impl IndexRecordOption {
     /// Returns true if this option includes encoding
     /// term frequencies.


### PR DESCRIPTION
This change allows to have unset fields in meta.json and fall back to their defaults
Currently it is required to explicitly put e.g. fieldnorms: false
