### PR TITLE
Work on WASM support, part 1/2: Remove the asynchronous code in indexer.

### DIFF
--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -214,7 +214,7 @@ fn index_documents(
     meta.untrack_temp_docstore();
     // update segment_updater inventory to remove tempstore
     let segment_entry = SegmentEntry::new(meta, delete_cursor, alive_bitset_opt);
-    block_on(segment_updater.schedule_add_segment(segment_entry))?;
+    segment_updater.schedule_add_segment(segment_entry)?;
     Ok(())
 }
 
@@ -368,7 +368,7 @@ impl IndexWriter {
     pub fn add_segment(&self, segment_meta: SegmentMeta) -> crate::Result<()> {
         let delete_cursor = self.delete_queue.cursor();
         let segment_entry = SegmentEntry::new(segment_meta, delete_cursor, None);
-        block_on(self.segment_updater.schedule_add_segment(segment_entry))
+        self.segment_updater.schedule_add_segment(segment_entry)
     }
 
     /// Creates a new segment.
@@ -465,8 +465,10 @@ impl IndexWriter {
     }
 
     /// Detects and removes the files that are not used by the index anymore.
-    pub async fn garbage_collect_files(&self) -> crate::Result<GarbageCollectionResult> {
-        self.segment_updater.schedule_garbage_collect().await
+    pub fn garbage_collect_files(
+        &self,
+    ) -> crate::Result<GarbageCollectionResult> {
+        self.segment_updater.schedule_garbage_collect()
     }
 
     /// Deletes all documents from the index
@@ -519,10 +521,10 @@ impl IndexWriter {
     pub fn merge(
         &mut self,
         segment_ids: &[SegmentId],
-    ) -> impl Future<Output = crate::Result<SegmentMeta>> {
+    ) -> crate::Result<SegmentMeta> {
         let merge_operation = self.segment_updater.make_merge_operation(segment_ids);
         let segment_updater = self.segment_updater.clone();
-        async move { segment_updater.start_merge(merge_operation)?.await }
+        segment_updater.start_merge(merge_operation)
     }
 
     /// Closes the current document channel send.

--- a/src/indexer/prepared_commit.rs
+++ b/src/indexer/prepared_commit.rs
@@ -1,7 +1,6 @@
-use futures::executor::block_on;
-
 use super::IndexWriter;
 use crate::Opstamp;
+use futures::executor::block_on;
 
 /// A prepared commit
 pub struct PreparedCommit<'a> {
@@ -37,7 +36,11 @@ impl<'a> PreparedCommit<'a> {
     /// Proceeds to commit.
     /// See `.commit_async()`.
     pub fn commit(self) -> crate::Result<Opstamp> {
-        block_on(self.commit_async())
+        info!("committing {}", self.opstamp);
+        let _ = self.index_writer
+                .segment_updater()
+                .schedule_commit(self.opstamp, self.payload);
+        Ok(self.opstamp)
     }
 
     /// Proceeds to commit.
@@ -45,12 +48,7 @@ impl<'a> PreparedCommit<'a> {
     /// Unfortunately, contrary to what `PrepareCommit` may suggests,
     /// this operation is not at all really light.
     /// At this point deletes have not been flushed yet.
-    pub async fn commit_async(self) -> crate::Result<Opstamp> {
-        info!("committing {}", self.opstamp);
-        self.index_writer
-            .segment_updater()
-            .schedule_commit(self.opstamp, self.payload)
-            .await?;
-        Ok(self.opstamp)
+    pub fn commit_async(self) -> crate::Result<Opstamp> {
+	unimplemented!()
     }
 }


### PR DESCRIPTION
**Warning: This PR is far from a mergeable state, it's intended as a PoC and a support for technical discussions**.

# Motivations:

In order to port Tantivy on wasm (including indexing), there are two main issues in the current Tantivy implementation: 

- the fact that `segment_updater.rs` currently uses asynchronous code, which rely on `futures::executor` to work. This is what's addressed in this pull-request.
- The work being done in parallel in several thread in `index_writer.rs` (not the subject of this PR)

# What this PR does:

In this PR, I removed all asynchronous code and made the code synchronous instead. Which at first glance should not affect the behavior in any way since the current code then uses `futures::executor::block_on` on top of the asynchronous code.

But, when discussing with @fmassot about it, he questioned whether this would alter the logic:

> Interesting, I did not thought about replacing async code by sync code for segment update operations. While reading the code, I discovered something important brought by the  segment updater thread: it is in charge of processing all the segment updates operation one by one. 
> Cf. https://github.com/quickwit-oss/tantivy/blob/2069e3e52b87768ffe6cdce4fe30b8078250e34a/src/indexer/segment_updater.rs#L88-L93

> One operation can do several things. Let's see the different operations:
> - `schedule_add_segment` : it's only adding a segment to the segment manager and considering merge options (it may trigger a task that will be executed in merge dedicated threads).
> - `schedule_commit`: this operation is trickier, it is doing delete purge, segment commit, save of metas, garbage collect.
> - `schedule_garbage_collect`: garbage collect
> - `end_merge`: this operation seems complex too

Using sync instead of async changes this logic.

I'm not entirely sure I understands what he meant, or that he understood what I had in mind, so that's why I'm creating this pull-request, so we can discuss about it more concretely.

# Note: What must be done before merging could be considered:

- [ ] re-add the liveness check of the segment_updater (which has now been removed in all places that used to call `schedule_task`)
- [ ] ensure that this PR doesn't break the logic 
- [ ] Decide what to do with [`tantivy::PreparedCommit::commit_async`](https://docs.rs/tantivy/0.17.0/tantivy/struct.PreparedCommit.html#method.commit_async): should we wrap the now-synchronous implementation in a async function (by spawning a thread) or just drop it? What do we do in WASM ?
- [ ] fix the unit tests (currently the tests haven't been updated to reflect the changes, then they don't even compile at this point)
- [ ] rename a bunch of things (there are still variables names `*_future` even if they don't hold futures anymore.
- [ ] remove unneeded dependencies and fix other warnings