### PR TITLE
Removes all usage of block_on, and use a oneshot channel instead.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ fs2={ version = "0.4.3", optional = true }
 levenshtein_automata = "0.2"
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 crossbeam = "0.8.1"
-futures = { version = "0.3.15", features = ["thread-pool"] }
 tantivy-query-grammar = { version="0.15.0", path="./query-grammar" }
 tantivy-bitpacker = { version="0.1", path="./bitpacker" }
 common = { version = "0.2", path = "./common/", package = "tantivy-common" }
@@ -72,6 +71,7 @@ criterion = "0.3.5"
 test-log = "0.2.8"
 env_logger = "0.9.0"
 pprof = {version= "0.7", features=["flamegraph", "criterion"]}
+futures = "0.3.15"
 
 [dev-dependencies.fail]
 version = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["search", "information", "retrieval"]
 edition = "2018"
 
 [dependencies]
+oneshot = "0.1"
 base64 = "0.13"
 byteorder = "1.4.3"
 crc32fast = "1.2.1"

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -284,8 +284,6 @@ pub(crate) fn f64_to_fastfield_u64(val: f64, field_type: &Type) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-
-    use futures::executor::block_on;
     use serde_json::Value;
 
     use super::agg_req::{Aggregation, Aggregations, BucketAggregation};
@@ -348,7 +346,7 @@ mod tests {
                 .searchable_segment_ids()
                 .expect("Searchable segments failed.");
             let mut index_writer = index.writer_for_tests()?;
-            block_on(index_writer.merge(&segment_ids))?;
+            index_writer.merge(&segment_ids).wait()?;
             index_writer.wait_merging_threads()?;
         }
 
@@ -549,7 +547,7 @@ mod tests {
                 .searchable_segment_ids()
                 .expect("Searchable segments failed.");
             let mut index_writer = index.writer_for_tests()?;
-            block_on(index_writer.merge(&segment_ids))?;
+            index_writer.merge(&segment_ids).wait()?;
             index_writer.wait_merging_threads()?;
         }
 
@@ -984,7 +982,7 @@ mod tests {
                     .searchable_segment_ids()
                     .expect("Searchable segments failed.");
                 let mut index_writer = index.writer_for_tests()?;
-                block_on(index_writer.merge(&segment_ids))?;
+                index_writer.merge(&segment_ids).wait()?;
                 index_writer.wait_merging_threads()?;
             }
 

--- a/src/directory/file_watcher.rs
+++ b/src/directory/file_watcher.rs
@@ -53,7 +53,9 @@ impl FileWatcher {
                         if metafile_has_changed {
                             info!("Meta file {:?} was modified", path);
                             current_checksum_opt = Some(checksum);
-                            futures::executor::block_on(callbacks.broadcast());
+                            // We actually ignore callbacks failing here.
+                            // We just wait for the end of their execution.
+                            let _ = callbacks.broadcast().wait();
                         }
                     }
 

--- a/src/directory/watch_event_router.rs
+++ b/src/directory/watch_event_router.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, RwLock, Weak};
 
-use futures::channel::oneshot;
-use futures::{Future, TryFutureExt};
+use crate::FutureResult;
 
 /// Cloneable wrapper for callbacks registered when watching files of a `Directory`.
 #[derive(Clone)]
@@ -74,12 +73,11 @@ impl WatchCallbackList {
     }
 
     /// Triggers all callbacks
-    pub fn broadcast(&self) -> impl Future<Output = ()> {
+    pub fn broadcast(&self) -> FutureResult<()> {
         let callbacks = self.list_callback();
-        let (sender, receiver) = oneshot::channel();
-        let result = receiver.unwrap_or_else(|_| ());
+        let (result, sender) = FutureResult::create("One of the callback panicked.");
         if callbacks.is_empty() {
-            let _ = sender.send(());
+            let _ = sender.send(Ok(()));
             return result;
         }
         let spawn_res = std::thread::Builder::new()
@@ -88,7 +86,7 @@ impl WatchCallbackList {
                 for callback in callbacks {
                     callback.call();
                 }
-                let _ = sender.send(());
+                let _ = sender.send(Ok(()));
             });
         if let Err(err) = spawn_res {
             error!(
@@ -106,8 +104,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
-    use futures::executor::block_on;
-
     use crate::directory::{WatchCallback, WatchCallbackList};
 
     #[test]
@@ -118,22 +114,18 @@ mod tests {
         let inc_callback = WatchCallback::new(move || {
             counter_clone.fetch_add(1, Ordering::SeqCst);
         });
-        block_on(watch_event_router.broadcast());
+        watch_event_router.broadcast().wait().unwrap();
         assert_eq!(0, counter.load(Ordering::SeqCst));
         let handle_a = watch_event_router.subscribe(inc_callback);
         assert_eq!(0, counter.load(Ordering::SeqCst));
-        block_on(watch_event_router.broadcast());
+        watch_event_router.broadcast().wait().unwrap();
         assert_eq!(1, counter.load(Ordering::SeqCst));
-        block_on(async {
-            (
-                watch_event_router.broadcast().await,
-                watch_event_router.broadcast().await,
-                watch_event_router.broadcast().await,
-            )
-        });
+        watch_event_router.broadcast().wait().unwrap();
+        watch_event_router.broadcast().wait().unwrap();
+        watch_event_router.broadcast().wait().unwrap();
         assert_eq!(4, counter.load(Ordering::SeqCst));
         mem::drop(handle_a);
-        block_on(watch_event_router.broadcast());
+        watch_event_router.broadcast().wait().unwrap();
         assert_eq!(4, counter.load(Ordering::SeqCst));
     }
 
@@ -150,19 +142,15 @@ mod tests {
         let handle_a = watch_event_router.subscribe(inc_callback(1));
         let handle_a2 = watch_event_router.subscribe(inc_callback(10));
         assert_eq!(0, counter.load(Ordering::SeqCst));
-        block_on(async {
-            futures::join!(
-                watch_event_router.broadcast(),
-                watch_event_router.broadcast()
-            )
-        });
+        watch_event_router.broadcast().wait().unwrap();
+        watch_event_router.broadcast().wait().unwrap();
         assert_eq!(22, counter.load(Ordering::SeqCst));
         mem::drop(handle_a);
-        block_on(watch_event_router.broadcast());
+        watch_event_router.broadcast().wait().unwrap();
         assert_eq!(32, counter.load(Ordering::SeqCst));
         mem::drop(handle_a2);
-        block_on(watch_event_router.broadcast());
-        block_on(watch_event_router.broadcast());
+        watch_event_router.broadcast().wait().unwrap();
+        watch_event_router.broadcast().wait().unwrap();
         assert_eq!(32, counter.load(Ordering::SeqCst));
     }
 
@@ -176,15 +164,12 @@ mod tests {
         });
         let handle_a = watch_event_router.subscribe(inc_callback);
         assert_eq!(0, counter.load(Ordering::SeqCst));
-        block_on(async {
-            let future1 = watch_event_router.broadcast();
-            let future2 = watch_event_router.broadcast();
-            futures::join!(future1, future2)
-        });
+        watch_event_router.broadcast().wait().unwrap();
+        watch_event_router.broadcast().wait().unwrap();
         assert_eq!(2, counter.load(Ordering::SeqCst));
         mem::drop(handle_a);
         let _ = watch_event_router.broadcast();
-        block_on(watch_event_router.broadcast());
+        watch_event_router.broadcast().wait().unwrap();
         assert_eq!(2, counter.load(Ordering::SeqCst));
     }
 }

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -501,8 +501,7 @@ mod tests {
             .map(SegmentReader::segment_id)
             .collect();
         assert_eq!(segment_ids.len(), 2);
-        let merge_future = index_writer.merge(&segment_ids[..]);
-        futures::executor::block_on(merge_future)?;
+        index_writer.merge(&segment_ids[..]).wait().unwrap();
         reader.reload()?;
         assert_eq!(reader.searcher().segment_readers().len(), 1);
         Ok(())

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -8,7 +8,6 @@ pub use self::writer::MultiValuedFastFieldWriter;
 mod tests {
 
     use chrono::Duration;
-    use futures::executor::block_on;
     use proptest::strategy::Strategy;
     use proptest::{prop_oneof, proptest};
     use test_log::test;
@@ -268,7 +267,7 @@ mod tests {
                 IndexingOp::Merge => {
                     let segment_ids = index.searchable_segment_ids()?;
                     if segment_ids.len() >= 2 {
-                        block_on(index_writer.merge(&segment_ids))?;
+                        index_writer.merge(&segment_ids).wait()?;
                         index_writer.segment_updater().wait_merging_thread()?;
                     }
                 }
@@ -283,7 +282,7 @@ mod tests {
                 .searchable_segment_ids()
                 .expect("Searchable segments failed.");
             if !segment_ids.is_empty() {
-                block_on(index_writer.merge(&segment_ids)).unwrap();
+                index_writer.merge(&segment_ids).wait()?;
                 assert!(index_writer.wait_merging_threads().is_ok());
             }
         }

--- a/src/future_result.rs
+++ b/src/future_result.rs
@@ -1,0 +1,149 @@
+// Copyright (C) 2021 Quickwit, Inc.
+//
+// Quickwit is offered under the AGPL v3.0 and as commercial software.
+// For commercial licensing, contact us at hello@quickwit.io.
+//
+// AGPL:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::Poll;
+
+use crate::TantivyError;
+
+/// `FutureResult` is a handle that makes it possible to wait for the completion
+/// of an ongoing task.
+///
+/// Contrary to some `Future`, it does not need to be polled for the task to
+/// progress. Dropping the `FutureResult` does not cancel the task being executed
+/// either.
+///
+/// - In a sync context, you can call `FutureResult::wait()`. The function
+/// does not rely on `block_on`.
+/// - In an async context, you can call simply use `FutureResult` as a future.
+pub struct FutureResult<T> {
+    inner: Inner<T>,
+}
+
+enum Inner<T> {
+    FailedBeforeStart(Option<TantivyError>),
+    InProgress {
+        receiver: oneshot::Receiver<crate::Result<T>>,
+        error_msg_if_failure: &'static str,
+    },
+}
+
+impl<T> From<TantivyError> for FutureResult<T> {
+    fn from(err: TantivyError) -> Self {
+        FutureResult {
+            inner: Inner::FailedBeforeStart(Some(err)),
+        }
+    }
+}
+
+impl<T> FutureResult<T> {
+    pub(crate) fn create(
+        error_msg_if_failure: &'static str,
+    ) -> (Self, oneshot::Sender<crate::Result<T>>) {
+        let (sender, receiver) = oneshot::channel();
+        let inner: Inner<T> = Inner::InProgress {
+            receiver,
+            error_msg_if_failure,
+        };
+        (FutureResult { inner }, sender)
+    }
+
+    /// Blocks until the scheduled result is available.
+    ///
+    /// In an async context, you should simply use `ScheduledResult` as a future.
+    pub fn wait(self) -> crate::Result<T> {
+        match self.inner {
+            Inner::FailedBeforeStart(err) => Err(err.unwrap()),
+            Inner::InProgress {
+                receiver,
+                error_msg_if_failure,
+            } => receiver.recv().unwrap_or_else(|_| {
+                Err(crate::TantivyError::SystemError(
+                    error_msg_if_failure.to_string(),
+                ))
+            }),
+        }
+    }
+}
+
+impl<T> Future for FutureResult<T> {
+    type Output = crate::Result<T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        unsafe {
+            match &mut Pin::get_unchecked_mut(self).inner {
+                Inner::FailedBeforeStart(err) => Poll::Ready(Err(err.take().unwrap())),
+                Inner::InProgress {
+                    receiver,
+                    error_msg_if_failure,
+                } => match Future::poll(Pin::new_unchecked(receiver), cx) {
+                    Poll::Ready(oneshot_res) => {
+                        let res = oneshot_res.unwrap_or_else(|_| {
+                            Err(crate::TantivyError::SystemError(
+                                error_msg_if_failure.to_string(),
+                            ))
+                        });
+                        Poll::Ready(res)
+                    }
+                    Poll::Pending => Poll::Pending,
+                },
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::executor::block_on;
+
+    use super::FutureResult;
+    use crate::TantivyError;
+
+    #[test]
+    fn test_scheduled_result_failed_to_schedule() {
+        let scheduled_result: FutureResult<()> = FutureResult::from(TantivyError::Poisoned);
+        let res = block_on(scheduled_result);
+        assert!(matches!(res, Err(TantivyError::Poisoned)));
+    }
+
+    #[test]
+    fn test_scheduled_result_error() {
+        let (scheduled_result, tx): (FutureResult<()>, _) = FutureResult::create("failed");
+        drop(tx);
+        let res = block_on(scheduled_result);
+        assert!(matches!(res, Err(TantivyError::SystemError(_))));
+    }
+
+    #[test]
+    fn test_scheduled_result_sent_success() {
+        let (scheduled_result, tx): (FutureResult<u64>, _) = FutureResult::create("failed");
+        tx.send(Ok(2u64)).unwrap();
+        assert_eq!(block_on(scheduled_result).unwrap(), 2u64);
+    }
+
+    #[test]
+    fn test_scheduled_result_sent_error() {
+        let (scheduled_result, tx): (FutureResult<u64>, _) = FutureResult::create("failed");
+        tx.send(Err(TantivyError::Poisoned)).unwrap();
+        let res = block_on(scheduled_result);
+        assert!(matches!(res, Err(TantivyError::Poisoned)));
+    }
+}

--- a/src/future_result.rs
+++ b/src/future_result.rs
@@ -1,23 +1,3 @@
-// Copyright (C) 2021 Quickwit, Inc.
-//
-// Quickwit is offered under the AGPL v3.0 and as commercial software.
-// For commercial licensing, contact us at hello@quickwit.io.
-//
-// AGPL:
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
-//
-
 use std::future::Future;
 use std::pin::Pin;
 use std::task::Poll;

--- a/src/future_result.rs
+++ b/src/future_result.rs
@@ -105,6 +105,7 @@ mod tests {
     }
 
     #[test]
+
     fn test_scheduled_result_error() {
         let (scheduled_result, tx): (FutureResult<()>, _) = FutureResult::create("failed");
         drop(tx);

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -465,8 +465,8 @@ impl IndexWriter {
     }
 
     /// Detects and removes the files that are not used by the index anymore.
-    pub async fn garbage_collect_files(&self) -> crate::Result<GarbageCollectionResult> {
-        self.segment_updater.schedule_garbage_collect().await
+    pub fn garbage_collect_files(&self) -> FutureResult<GarbageCollectionResult> {
+        self.segment_updater.schedule_garbage_collect()
     }
 
     /// Deletes all documents from the index

--- a/src/indexer/merger_sorted_index_test.rs
+++ b/src/indexer/merger_sorted_index_test.rs
@@ -1,7 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use futures::executor::block_on;
-
     use crate::collector::TopDocs;
     use crate::core::Index;
     use crate::fastfield::{AliveBitSet, FastFieldReader, MultiValuedFastFieldReader};
@@ -50,7 +48,7 @@ mod tests {
                 .searchable_segment_ids()
                 .expect("Searchable segments failed.");
             let mut index_writer = index.writer_for_tests().unwrap();
-            assert!(block_on(index_writer.merge(&segment_ids)).is_ok());
+            assert!(index_writer.merge(&segment_ids).wait().is_ok());
             assert!(index_writer.wait_merging_threads().is_ok());
         }
         index
@@ -140,7 +138,7 @@ mod tests {
         {
             let segment_ids = index.searchable_segment_ids()?;
             let mut index_writer = index.writer_for_tests()?;
-            block_on(index_writer.merge(&segment_ids))?;
+            index_writer.merge(&segment_ids).wait()?;
             index_writer.wait_merging_threads()?;
         }
         Ok(index)

--- a/src/indexer/prepared_commit.rs
+++ b/src/indexer/prepared_commit.rs
@@ -35,7 +35,7 @@ impl<'a> PreparedCommit<'a> {
     /// Proceeds to commit.
     /// See `.commit_async()`.
     pub fn commit(self) -> crate::Result<Opstamp> {
-        self.commit_async().wait()
+        self.commit_future().wait()
     }
 
     /// Proceeds to commit.
@@ -43,7 +43,7 @@ impl<'a> PreparedCommit<'a> {
     /// Unfortunately, contrary to what `PrepareCommit` may suggests,
     /// this operation is not at all really light.
     /// At this point deletes have not been flushed yet.
-    pub fn commit_async(self) -> FutureResult<Opstamp> {
+    pub fn commit_future(self) -> FutureResult<Opstamp> {
         info!("committing {}", self.opstamp);
         self.index_writer
             .segment_updater()

--- a/src/indexer/prepared_commit.rs
+++ b/src/indexer/prepared_commit.rs
@@ -33,7 +33,7 @@ impl<'a> PreparedCommit<'a> {
     }
 
     /// Proceeds to commit.
-    /// See `.commit_async()`.
+    /// See `.commit_future()`.
     pub fn commit(self) -> crate::Result<Opstamp> {
         self.commit_future().wait()
     }

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -355,7 +355,7 @@ impl SegmentUpdater {
             return crate::TantivyError::SystemError("Segment updater killed".to_string()).into();
         }
         let (scheduled_result, sender) =
-            FutureResult::create("A segment_updater future did not success. This  never happen.");
+            FutureResult::create("A segment_updater future did not succeed. This should never happen.");
         self.pool.spawn(|| {
             let task_result = task();
             let _ = sender.send(task_result);

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -539,17 +539,17 @@ impl SegmentUpdater {
                 merge_operation.target_opstamp(),
             ) {
                 Ok(after_merge_segment_entry) => {
-                    let segment_meta =
+                    let segment_meta_res =
                         segment_updater.end_merge(merge_operation, after_merge_segment_entry);
-                    let _send_result = merging_future_send.send(segment_meta);
+                    let _send_result = merging_future_send.send(segment_meta_res);
                 }
-                Err(e) => {
+                Err(merge_error) => {
                     warn!(
                         "Merge of {:?} was cancelled: {:?}",
                         merge_operation.segment_ids().to_vec(),
-                        e
+                        merge_error
                     );
-                    // ... cancel merge
+                    let _send_result = merging_future_send.send(Err(merge_error));
                     assert!(!cfg!(test), "Merge failed.");
                 }
             }

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -354,8 +354,9 @@ impl SegmentUpdater {
         if !self.is_alive() {
             return crate::TantivyError::SystemError("Segment updater killed".to_string()).into();
         }
-        let (scheduled_result, sender) =
-            FutureResult::create("A segment_updater future did not succeed. This should never happen.");
+        let (scheduled_result, sender) = FutureResult::create(
+            "A segment_updater future did not succeed. This should never happen.",
+        );
         self.pool.spawn(|| {
             let task_result = task();
             let _ = sender.send(task_result);

--- a/src/query/term_query/term_scorer.rs
+++ b/src/query/term_query/term_scorer.rs
@@ -125,7 +125,6 @@ impl Scorer for TermScorer {
 
 #[cfg(test)]
 mod tests {
-    use futures::executor::block_on;
     use proptest::prelude::*;
 
     use crate::merge_policy::NoMergePolicy;
@@ -321,9 +320,7 @@ mod tests {
                 .collect();
             test_block_wand_aux(&term_query, &searcher)?;
         }
-        {
-            let _ = block_on(writer.merge(&segment_ids[..]));
-        }
+        writer.merge(&segment_ids[..]).wait().unwrap();
         {
             reader.reload()?;
             let searcher = reader.searcher();

--- a/src/schema/text_options.rs
+++ b/src/schema/text_options.rs
@@ -106,7 +106,7 @@ impl TextFieldIndexing {
 
     /// Returns the tokenizer that will be used for this field.
     pub fn tokenizer(&self) -> &str {
-        &self.tokenizer.name()
+        self.tokenizer.name()
     }
 
     /// Sets fieldnorms

--- a/src/store/index/mod.rs
+++ b/src/store/index/mod.rs
@@ -41,7 +41,6 @@ mod tests {
 
     use std::io;
 
-    use futures::executor::block_on;
     use proptest::strategy::{BoxedStrategy, Strategy};
 
     use super::{SkipIndex, SkipIndexBuilder};
@@ -145,7 +144,7 @@ mod tests {
         index_writer.delete_term(Term::from_field_text(text, "testb"));
         index_writer.commit()?;
         let segment_ids = index.searchable_segment_ids()?;
-        block_on(index_writer.merge(&segment_ids))?;
+        index_writer.merge(&segment_ids).wait().unwrap();
         let reader = index.reader()?;
         let searcher = reader.searcher();
         assert_eq!(searcher.num_docs(), 30);

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -55,8 +55,6 @@ pub mod tests {
 
     use std::path::Path;
 
-    use futures::executor::block_on;
-
     use super::*;
     use crate::directory::{Directory, RamDirectory, WritePtr};
     use crate::fastfield::AliveBitSet;
@@ -269,7 +267,7 @@ pub mod tests {
                 .searchable_segment_ids()
                 .expect("Searchable segments failed.");
             let mut index_writer = index.writer_for_tests().unwrap();
-            assert!(block_on(index_writer.merge(&segment_ids)).is_ok());
+            assert!(index_writer.merge(&segment_ids).wait().is_ok());
             assert!(index_writer.wait_merging_threads().is_ok());
         }
 
@@ -316,7 +314,7 @@ pub mod tests {
         {
             let segment_ids = index.searchable_segment_ids()?;
             let mut index_writer = index.writer_for_tests()?;
-            block_on(index_writer.merge(&segment_ids))?;
+            index_writer.merge(&segment_ids).wait()?;
             index_writer.wait_merging_threads()?;
         }
 

--- a/src/tokenizer/ascii_folding_filter.rs
+++ b/src/tokenizer/ascii_folding_filter.rs
@@ -1625,9 +1625,9 @@ mod tests {
 
     #[test]
     fn test_to_ascii() {
-        let mut input = "Rámon".to_string();
+        let input = "Rámon".to_string();
         let mut buffer = String::new();
-        to_ascii(&mut input, &mut buffer);
+        to_ascii(&input, &mut buffer);
         assert_eq!("Ramon", buffer);
     }
 


### PR DESCRIPTION
Calling `block_on` panics in certain context.
For instance, it panics when it is called in a the context of another
call to block.

Using it in tantivy is unnecessary. We replace it by a thin wrapper
around a oneshot channel that supports both async/sync.