### PR TITLE
Expull: replace read_to_end with iterator over bytes

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -11,7 +11,10 @@ mod writer;
 
 pub use bitset::*;
 pub use serialize::{BinarySerializable, DeserializeFrom, FixedSize};
-pub use vint::{read_u32_vint, read_u32_vint_no_advance, serialize_vint_u32, write_u32_vint, VInt};
+pub use vint::{
+    read_u32_vint, read_u32_vint_iter, read_u32_vint_no_advance, serialize_vint_u32,
+    write_u32_vint, VInt,
+};
 pub use writer::{AntiCallToken, CountingWriter, TerminatingWrite};
 
 /// Has length trait


### PR DESCRIPTION
Expotential Unrolled List
read_to_end in expull may consume a lot of memory.
Since it is used by the postinglist record, it contains all docids(+optional positions, term frequencies) for one term, replace copy with iterator
