### PR TITLE
support order by sub_aggregation

### DIFF
--- a/src/aggregation/agg_result.rs
+++ b/src/aggregation/agg_result.rs
@@ -34,7 +34,7 @@ impl AggregationResults {
         } else {
             // Validation is be done during request parsing, so we can't reach this state.
             Err(TantivyError::InternalError(format!(
-                "Can't find aggregation in {}",
+                "Can't find aggregation {:?} in sub_aggregations",
                 name
             )))
         }
@@ -124,9 +124,9 @@ impl AggregationResult {
         agg_property: &str,
     ) -> crate::Result<Option<f64>> {
         match self {
-            AggregationResult::BucketResult(_bucket) => Err(TantivyError::InvalidArgument(
-                "bucket aggregation not supported to retrieve value, only metrics aggregations \
-                 are supported."
+            AggregationResult::BucketResult(_bucket) => Err(TantivyError::InternalError(
+                "Tried to retrieve value from bucket aggregation. This is not supported and \
+                 should not happen during collection, but should be catched during validation"
                     .to_string(),
             )),
             AggregationResult::MetricResult(metric) => metric.get_value(agg_property),

--- a/src/aggregation/agg_result.rs
+++ b/src/aggregation/agg_result.rs
@@ -32,10 +32,11 @@ impl AggregationResults {
         if let Some(agg) = self.0.get(name) {
             agg.get_value_from_aggregation(name, agg_property)
         } else {
-            // Should return an error here? Missing aggregation could be intentional to save
-            // memory.
-            // Validation can be done during request parsing
-            Ok(None)
+            // Validation is be done during request parsing, so we can't reach this state.
+            Err(TantivyError::InternalError(format!(
+                "Can't find aggregation in {}",
+                name
+            )))
         }
     }
 
@@ -55,8 +56,6 @@ impl AggregationResults {
         results: IntermediateAggregationResults,
         req: &AggregationsInternal,
     ) -> crate::Result<Self> {
-        // let mut result = HashMap::default();
-
         // Important assumption:
         // When the tree contains buckets/metric, we expect it to have all buckets/metrics from the
         // request

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -425,7 +425,7 @@ fn intermediate_buckets_to_final_buckets_fill_gaps(
     buckets: Vec<IntermediateHistogramBucketEntry>,
     histogram_req: &HistogramAggregation,
     sub_aggregation: &AggregationsInternal,
-) -> Vec<BucketEntry> {
+) -> crate::Result<Vec<BucketEntry>> {
     // Generate the the full list of buckets without gaps.
     //
     // The bounds are the min max from the current buckets, optionally extended by
@@ -468,7 +468,7 @@ fn intermediate_buckets_to_final_buckets_fill_gaps(
         .map(|intermediate_bucket| {
             BucketEntry::from_intermediate_and_req(intermediate_bucket, sub_aggregation)
         })
-        .collect_vec()
+        .collect::<crate::Result<Vec<_>>>()
 }
 
 // Convert to BucketEntry
@@ -476,7 +476,7 @@ pub(crate) fn intermediate_buckets_to_final_buckets(
     buckets: Vec<IntermediateHistogramBucketEntry>,
     histogram_req: &HistogramAggregation,
     sub_aggregation: &AggregationsInternal,
-) -> Vec<BucketEntry> {
+) -> crate::Result<Vec<BucketEntry>> {
     if histogram_req.min_doc_count() == 0 {
         // With min_doc_count != 0, we may need to add buckets, so that there are no
         // gaps, since intermediate result does not contain empty buckets (filtered to
@@ -488,7 +488,7 @@ pub(crate) fn intermediate_buckets_to_final_buckets(
             .into_iter()
             .filter(|bucket| bucket.doc_count >= histogram_req.min_doc_count())
             .map(|bucket| BucketEntry::from_intermediate_and_req(bucket, sub_aggregation))
-            .collect_vec()
+            .collect::<crate::Result<Vec<_>>>()
     }
 }
 

--- a/src/aggregation/bucket/mod.rs
+++ b/src/aggregation/bucket/mod.rs
@@ -131,4 +131,10 @@ fn custom_order_serde_test() {
     let order_deser = serde_json::from_str(&order_str).unwrap();
 
     assert_eq!(order, order_deser);
+
+    let order_deser: serde_json::Result<CustomOrder> = serde_json::from_str(&"{}");
+    assert!(order_deser.is_err());
+
+    let order_deser: serde_json::Result<CustomOrder> = serde_json::from_str(&"[]");
+    assert!(order_deser.is_err());
 }

--- a/src/aggregation/bucket/mod.rs
+++ b/src/aggregation/bucket/mod.rs
@@ -11,8 +11,124 @@ mod histogram;
 mod range;
 mod term_agg;
 
+use std::collections::HashMap;
+
 pub(crate) use histogram::SegmentHistogramCollector;
 pub use histogram::*;
 pub(crate) use range::SegmentRangeCollector;
 pub use range::*;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 pub use term_agg::*;
+
+/// Order for buckets in a bucket aggregation.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Order {
+    /// Asc order
+    #[serde(rename = "asc")]
+    Asc,
+    /// Desc order
+    #[serde(rename = "desc")]
+    Desc,
+}
+
+impl Default for Order {
+    fn default() -> Self {
+        Order::Desc
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+/// Order property by which to apply the order
+pub enum OrderTarget {
+    /// The key of the bucket
+    Key,
+    /// The doc count of the bucket
+    Count,
+    /// Order by value of the sub aggregation metric with identified by given `String`.
+    ///
+    /// Only single value metrics are supported currently
+    SubAggregation(String),
+}
+
+impl Default for OrderTarget {
+    fn default() -> Self {
+        OrderTarget::Count
+    }
+}
+impl From<&str> for OrderTarget {
+    fn from(val: &str) -> Self {
+        match val {
+            "_key" => OrderTarget::Key,
+            "_count" => OrderTarget::Count,
+            _ => OrderTarget::SubAggregation(val.to_string()),
+        }
+    }
+}
+
+impl ToString for OrderTarget {
+    fn to_string(&self) -> String {
+        match self {
+            OrderTarget::Key => "_key".to_string(),
+            OrderTarget::Count => "_count".to_string(),
+            OrderTarget::SubAggregation(agg) => agg.to_string(),
+        }
+    }
+}
+
+/// Set the order. target is either "_count", "_key", or the name of
+/// a metric sub_aggregation.
+///
+/// De/Serializes to elasticsearch compatible JSON.
+///
+/// Examples in JSON format:
+/// { "_count": "asc" }
+/// { "_key": "asc" }
+/// { "average_price": "asc" }
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct CustomOrder {
+    /// The target property by which to sort by
+    pub target: OrderTarget,
+    /// The order asc or desc
+    pub order: Order,
+}
+
+impl Serialize for CustomOrder {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        let map: HashMap<String, Order> =
+            std::iter::once((self.target.to_string(), self.order)).collect();
+        map.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for CustomOrder {
+    fn deserialize<D>(deserializer: D) -> Result<CustomOrder, D::Error>
+    where D: Deserializer<'de> {
+        HashMap::<String, Order>::deserialize(deserializer).and_then(|map| {
+            if let Some((key, value)) = map.into_iter().next() {
+                Ok(CustomOrder {
+                    target: key.as_str().into(),
+                    order: value,
+                })
+            } else {
+                Err(de::Error::custom(
+                    "unexpected empty map in order".to_string(),
+                ))
+            }
+        })
+    }
+}
+
+#[test]
+fn custom_order_serde_test() {
+    let order = CustomOrder {
+        target: OrderTarget::Key,
+        order: Order::Desc,
+    };
+
+    let order_str = serde_json::to_string(&order).unwrap();
+    assert_eq!(order_str, "{\"_key\":\"desc\"}");
+    let order_deser = serde_json::from_str(&order_str).unwrap();
+
+    assert_eq!(order, order_deser);
+}

--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -7,7 +7,7 @@ use crate::aggregation::agg_req_with_accessor::{
     AggregationsWithAccessor, BucketAggregationWithAccessor,
 };
 use crate::aggregation::intermediate_agg_result::{
-    IntermediateBucketResult, IntermediateRangeBucketEntry,
+    IntermediateBucketResult, IntermediateRangeBucketEntry, IntermediateRangeBucketResult,
 };
 use crate::aggregation::segment_agg_result::SegmentAggregationResultsCollector;
 use crate::aggregation::{f64_from_fastfield_u64, f64_to_fastfield_u64, Key};
@@ -166,7 +166,9 @@ impl SegmentRangeCollector {
             })
             .collect::<crate::Result<_>>()?;
 
-        Ok(IntermediateBucketResult::Range(buckets))
+        Ok(IntermediateBucketResult::Range(
+            IntermediateRangeBucketResult { buckets },
+        ))
     }
 
     pub(crate) fn from_req_and_validate(

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -104,6 +104,10 @@ pub struct TermsAggregation {
     /// Set the order. `String` is here a target, which is either "_count", "_key", or the name of
     /// a metric sub_aggregation.
     ///
+    /// Single value metrics like average can be adressed by its name.
+    /// Multi value metrics like stats are required to adress their field by name e.g.
+    /// "stats.avg"
+    ///
     /// Examples in JSON format:
     /// { "_count": "asc" }
     /// { "_key": "asc" }

--- a/src/aggregation/collector.rs
+++ b/src/aggregation/collector.rs
@@ -86,8 +86,8 @@ impl Collector for AggregationCollector {
         &self,
         segment_fruits: Vec<<Self::Child as SegmentCollector>::Fruit>,
     ) -> crate::Result<Self::Fruit> {
-        merge_fruits(segment_fruits)
-            .map(|res| AggregationResults::from_intermediate_and_req(res, self.agg.clone()))
+        let res = merge_fruits(segment_fruits)?;
+        AggregationResults::from_intermediate_and_req(res, self.agg.clone())
     }
 }
 

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::aggregation::f64_from_fastfield_u64;
 use crate::fastfield::{DynamicFastFieldReader, FastFieldReader};
 use crate::schema::Type;
-use crate::DocId;
+use crate::{DocId, TantivyError};
 
 /// A multi-value metric aggregation that computes stats of numeric values that are
 /// extracted from the aggregated documents.
@@ -51,6 +51,23 @@ pub struct Stats {
     pub max: Option<f64>,
     /// The average of the values. None for count == 0.
     pub avg: Option<f64>,
+}
+
+impl Stats {
+    pub(crate) fn get_value(&self, agg_property: &str) -> crate::Result<Option<f64>> {
+        match agg_property {
+            "count" => Ok(Some(self.count as f64)),
+            "sum" => Ok(Some(self.sum)),
+            "standard_deviation" => Ok(self.standard_deviation),
+            "min" => Ok(self.min),
+            "max" => Ok(self.max),
+            "avg" => Ok(self.avg),
+            _ => Err(TantivyError::InvalidArgument(format!(
+                "unknown property {} on stats metric aggregation",
+                agg_property
+            ))),
+        }
+    }
 }
 
 /// IntermediateStats contains the mergeable version for stats.

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -247,6 +247,11 @@ impl<T: Clone> VecWithNames<T> {
     fn is_empty(&self) -> bool {
         self.keys.is_empty()
     }
+    fn get(&self, name: &str) -> Option<&T> {
+        self.keys()
+            .position(|key| key == name)
+            .map(|pos| &self.values[pos])
+    }
 }
 
 /// The serialized key is used in a HashMap.
@@ -540,6 +545,7 @@ mod tests {
                 searcher.search(&AllQuery, &collector).unwrap(),
                 agg_req,
             )
+            .unwrap()
         } else {
             let collector = AggregationCollector::from_aggs(agg_req);
 
@@ -975,7 +981,7 @@ mod tests {
             // Test de/serialization roundtrip on intermediate_agg_result
             let res: IntermediateAggregationResults =
                 serde_json::from_str(&serde_json::to_string(&res).unwrap()).unwrap();
-            AggregationResults::from_intermediate_and_req(res, agg_req.clone())
+            AggregationResults::from_intermediate_and_req(res, agg_req.clone()).unwrap()
         } else {
             let collector = AggregationCollector::from_aggs(agg_req.clone());
 

--- a/src/aggregation/segment_agg_result.rs
+++ b/src/aggregation/segment_agg_result.rs
@@ -29,6 +29,17 @@ pub(crate) struct SegmentAggregationResultsCollector {
     num_staged_docs: usize,
 }
 
+impl Default for SegmentAggregationResultsCollector {
+    fn default() -> Self {
+        Self {
+            metrics: Default::default(),
+            buckets: Default::default(),
+            staged_docs: [0; DOC_BLOCK_SIZE],
+            num_staged_docs: Default::default(),
+        }
+    }
+}
+
 impl Debug for SegmentAggregationResultsCollector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SegmentAggregationResultsCollector")
@@ -216,7 +227,7 @@ impl SegmentBucketResultCollector {
                     req.field_type,
                     req.accessor
                         .as_multi()
-                        .expect("unexpected fast field cardinatility"),
+                        .expect("unexpected fast field cardinality"),
                 )?,
             ))),
             BucketAggregationType::Range(range_req) => {
@@ -233,7 +244,7 @@ impl SegmentBucketResultCollector {
                     req.field_type,
                     req.accessor
                         .as_single()
-                        .expect("unexpected fast field cardinatility"),
+                        .expect("unexpected fast field cardinality"),
                 )?,
             ))),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,6 +97,10 @@ pub enum TantivyError {
     /// Index incompatible with current version of Tantivy.
     #[error("{0:?}")]
     IncompatibleIndex(Incompatibility),
+    /// An internal error occurred. This is are internal states that should not be reached.
+    /// e.g. a datastructure is incorrectly inititalized.
+    #[error("Internal error: '{0}'")]
+    InternalError(String),
 }
 
 #[cfg(feature = "quickwit")]

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -188,13 +188,14 @@ impl FieldType {
     /// returns true if the field is fast.
     pub fn is_fast(&self) -> bool {
         match *self {
+            FieldType::Bytes(ref bytes_options) => bytes_options.is_fast(),
             FieldType::Str(ref text_options) => text_options.is_fast(),
             FieldType::U64(ref int_options)
             | FieldType::I64(ref int_options)
             | FieldType::F64(ref int_options)
             | FieldType::Date(ref int_options) => int_options.get_fastfield_cardinality().is_some(),
             FieldType::Facet(_) => true,
-            _ => false,
+            FieldType::JsonObject(_) => false,
         }
     }
 


### PR DESCRIPTION

support order property on term aggregations
order can be by doc_count, key, or a metric sub_aggregation
