### PR TITLE
Expose helpers to generate json field writer terms 

### DIFF
--- a/src/indexer/json_term_writer.rs
+++ b/src/indexer/json_term_writer.rs
@@ -200,30 +200,30 @@ fn infer_type_from_str(text: &str) -> TextOrDateTime {
 }
 
 // Tries to infer a JSON type from a string
-pub(crate) fn infer_fast_value_term(
+pub(crate) fn convert_to_fast_value_and_get_term(
     json_term_writer: &mut JsonTermWriter,
     phrase: &str,
 ) -> Option<Term> {
     if let Ok(dt) = OffsetDateTime::parse(phrase, &Rfc3339) {
         let dt_utc = dt.to_offset(UtcOffset::UTC);
-        return Some(generate_term_from_json_writer(
+        return Some(set_fastvalue_and_get_term(
             json_term_writer,
             DateTime::from_utc(dt_utc),
         ));
     }
     if let Ok(u64_val) = str::parse::<u64>(phrase) {
-        return Some(generate_term_from_json_writer(json_term_writer, u64_val));
+        return Some(set_fastvalue_and_get_term(json_term_writer, u64_val));
     }
     if let Ok(i64_val) = str::parse::<i64>(phrase) {
-        return Some(generate_term_from_json_writer(json_term_writer, i64_val));
+        return Some(set_fastvalue_and_get_term(json_term_writer, i64_val));
     }
     if let Ok(f64_val) = str::parse::<f64>(phrase) {
-        return Some(generate_term_from_json_writer(json_term_writer, f64_val));
+        return Some(set_fastvalue_and_get_term(json_term_writer, f64_val));
     }
     None
 }
 // helper function to generate a Term from a json fastvalue
-pub(crate) fn generate_term_from_json_writer<T: FastValue>(
+pub(crate) fn set_fastvalue_and_get_term<T: FastValue>(
     json_term_writer: &mut JsonTermWriter,
     value: T,
 ) -> Term {
@@ -232,7 +232,7 @@ pub(crate) fn generate_term_from_json_writer<T: FastValue>(
 }
 
 // helper function to generate a list of terms with their positions from a textual json value
-pub(crate) fn generate_terms_from_json_writer(
+pub(crate) fn set_string_and_get_terms(
     json_term_writer: &mut JsonTermWriter,
     value: &str,
     text_analyzer: &TextAnalyzer,

--- a/src/indexer/json_term_writer.rs
+++ b/src/indexer/json_term_writer.rs
@@ -199,6 +199,29 @@ fn infer_type_from_str(text: &str) -> TextOrDateTime {
     }
 }
 
+// Tries to infer a JSON type from a string
+pub(crate) fn infer_fast_value_term(
+    json_term_writer: &mut JsonTermWriter,
+    phrase: &str,
+) -> Option<Term> {
+    if let Ok(dt) = OffsetDateTime::parse(phrase, &Rfc3339) {
+        let dt_utc = dt.to_offset(UtcOffset::UTC);
+        return Some(generate_term_from_json_writer(
+            json_term_writer,
+            DateTime::from_utc(dt_utc),
+        ));
+    }
+    if let Ok(u64_val) = str::parse::<u64>(phrase) {
+        return Some(generate_term_from_json_writer(json_term_writer, u64_val));
+    }
+    if let Ok(i64_val) = str::parse::<i64>(phrase) {
+        return Some(generate_term_from_json_writer(json_term_writer, i64_val));
+    }
+    if let Ok(f64_val) = str::parse::<f64>(phrase) {
+        return Some(generate_term_from_json_writer(json_term_writer, f64_val));
+    }
+    None
+}
 // helper function to generate a Term from a json fastvalue
 pub(crate) fn generate_term_from_json_writer<T: FastValue>(
     json_term_writer: &mut JsonTermWriter,

--- a/src/indexer/json_term_writer.rs
+++ b/src/indexer/json_term_writer.rs
@@ -257,8 +257,11 @@ pub struct JsonTermWriter<'a> {
 }
 
 impl<'a> JsonTermWriter<'a> {
-    // Prepares writing terms for a given field
-    pub fn initialize(field: Field, json_path: &str, term_buffer: &'a mut Term) -> Self {
+    pub fn from_field_and_json_path(
+        field: Field,
+        json_path: &str,
+        term_buffer: &'a mut Term,
+    ) -> Self {
         term_buffer.set_field(Type::Json, field);
         let mut json_term_writer = Self::wrap(term_buffer);
         for segment in json_path.split('.') {

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -25,7 +25,9 @@ use crossbeam::channel;
 use smallvec::SmallVec;
 
 pub use self::index_writer::IndexWriter;
-pub(crate) use self::json_term_writer::JsonTermWriter;
+pub(crate) use self::json_term_writer::{
+    generate_term_from_json_writer, generate_terms_from_json_writer, JsonTermWriter,
+};
 pub use self::log_merge_policy::LogMergePolicy;
 pub use self::merge_operation::MergeOperation;
 pub use self::merge_policy::{MergeCandidate, MergePolicy, NoMergePolicy};

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -26,7 +26,7 @@ use smallvec::SmallVec;
 
 pub use self::index_writer::IndexWriter;
 pub(crate) use self::json_term_writer::{
-    generate_terms_from_json_writer, infer_fast_value_term, JsonTermWriter,
+    convert_to_fast_value_and_get_term, set_string_and_get_terms, JsonTermWriter,
 };
 pub use self::log_merge_policy::LogMergePolicy;
 pub use self::merge_operation::MergeOperation;

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -26,7 +26,7 @@ use smallvec::SmallVec;
 
 pub use self::index_writer::IndexWriter;
 pub(crate) use self::json_term_writer::{
-    generate_term_from_json_writer, generate_terms_from_json_writer, JsonTermWriter,
+    generate_terms_from_json_writer, infer_fast_value_term, JsonTermWriter,
 };
 pub use self::log_merge_policy::LogMergePolicy;
 pub use self::merge_operation::MergeOperation;

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -7,7 +7,9 @@ use tantivy_query_grammar::{UserInputAst, UserInputBound, UserInputLeaf, UserInp
 
 use super::logical_ast::*;
 use crate::core::Index;
-use crate::indexer::JsonTermWriter;
+use crate::indexer::{
+    generate_term_from_json_writer, generate_terms_from_json_writer, JsonTermWriter,
+};
 use crate::query::{
     AllQuery, BooleanQuery, BoostQuery, EmptyQuery, Occur, PhraseQuery, Query, RangeQuery,
     TermQuery,
@@ -660,26 +662,22 @@ fn generate_literals_for_str(
     Ok(Some(LogicalLiteral::Phrase(terms)))
 }
 
-enum NumValue {
-    U64(u64),
-    I64(i64),
-    F64(f64),
-    DateTime(OffsetDateTime),
-}
-
-fn infer_type_num(phrase: &str) -> Option<NumValue> {
+fn infer_fast_value_term(json_term_writer: &mut JsonTermWriter, phrase: &str) -> Option<Term> {
     if let Ok(dt) = OffsetDateTime::parse(phrase, &Rfc3339) {
         let dt_utc = dt.to_offset(UtcOffset::UTC);
-        return Some(NumValue::DateTime(dt_utc));
+        return Some(generate_term_from_json_writer(
+            json_term_writer,
+            DateTime::from_utc(dt_utc),
+        ));
     }
     if let Ok(u64_val) = str::parse::<u64>(phrase) {
-        return Some(NumValue::U64(u64_val));
+        return Some(generate_term_from_json_writer(json_term_writer, u64_val));
     }
     if let Ok(i64_val) = str::parse::<i64>(phrase) {
-        return Some(NumValue::I64(i64_val));
+        return Some(generate_term_from_json_writer(json_term_writer, i64_val));
     }
     if let Ok(f64_val) = str::parse::<f64>(phrase) {
-        return Some(NumValue::F64(f64_val));
+        return Some(generate_term_from_json_writer(json_term_writer, f64_val));
     }
     None
 }
@@ -694,38 +692,12 @@ fn generate_literals_for_json_object(
 ) -> Result<Vec<LogicalLiteral>, QueryParserError> {
     let mut logical_literals = Vec::new();
     let mut term = Term::new();
-    term.set_field(Type::Json, field);
-    let mut json_term_writer = JsonTermWriter::wrap(&mut term);
-    for segment in json_path.split('.') {
-        json_term_writer.push_path_segment(segment);
+    let mut json_term_writer = JsonTermWriter::initialize(field, json_path, &mut term);
+    if let Some(term) = infer_fast_value_term(&mut json_term_writer, phrase) {
+        logical_literals.push(LogicalLiteral::Term(term));
     }
-    if let Some(num_value) = infer_type_num(phrase) {
-        match num_value {
-            NumValue::U64(u64_val) => {
-                json_term_writer.set_fast_value(u64_val);
-            }
-            NumValue::I64(i64_val) => {
-                json_term_writer.set_fast_value(i64_val);
-            }
-            NumValue::F64(f64_val) => {
-                json_term_writer.set_fast_value(f64_val);
-            }
-            NumValue::DateTime(dt_val) => {
-                json_term_writer.set_fast_value(DateTime::from_utc(dt_val));
-            }
-        }
-        logical_literals.push(LogicalLiteral::Term(json_term_writer.term().clone()));
-    }
-    json_term_writer.close_path_and_set_type(Type::Str);
+    let terms = generate_terms_from_json_writer(&mut json_term_writer, phrase, text_analyzer);
     drop(json_term_writer);
-    let term_num_bytes = term.as_slice().len();
-    let mut token_stream = text_analyzer.token_stream(phrase);
-    let mut terms: Vec<(usize, Term)> = Vec::new();
-    token_stream.process(&mut |token| {
-        term.truncate(term_num_bytes);
-        term.append_bytes(token.text.as_bytes());
-        terms.push((token.position, term.clone()));
-    });
     if terms.len() <= 1 {
         for (_, term) in terms {
             logical_literals.push(LogicalLiteral::Term(term));

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -7,7 +7,9 @@ use tantivy_query_grammar::{UserInputAst, UserInputBound, UserInputLeaf, UserInp
 
 use super::logical_ast::*;
 use crate::core::Index;
-use crate::indexer::{generate_terms_from_json_writer, infer_fast_value_term, JsonTermWriter};
+use crate::indexer::{
+    convert_to_fast_value_and_get_term, set_string_and_get_terms, JsonTermWriter,
+};
 use crate::query::{
     AllQuery, BooleanQuery, BoostQuery, EmptyQuery, Occur, PhraseQuery, Query, RangeQuery,
     TermQuery,
@@ -671,10 +673,10 @@ fn generate_literals_for_json_object(
     let mut logical_literals = Vec::new();
     let mut term = Term::new();
     let mut json_term_writer = JsonTermWriter::initialize(field, json_path, &mut term);
-    if let Some(term) = infer_fast_value_term(&mut json_term_writer, phrase) {
+    if let Some(term) = convert_to_fast_value_and_get_term(&mut json_term_writer, phrase) {
         logical_literals.push(LogicalLiteral::Term(term));
     }
-    let terms = generate_terms_from_json_writer(&mut json_term_writer, phrase, text_analyzer);
+    let terms = set_string_and_get_terms(&mut json_term_writer, phrase, text_analyzer);
     drop(json_term_writer);
     if terms.len() <= 1 {
         for (_, term) in terms {

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -672,7 +672,8 @@ fn generate_literals_for_json_object(
 ) -> Result<Vec<LogicalLiteral>, QueryParserError> {
     let mut logical_literals = Vec::new();
     let mut term = Term::new();
-    let mut json_term_writer = JsonTermWriter::initialize(field, json_path, &mut term);
+    let mut json_term_writer =
+        JsonTermWriter::from_field_and_json_path(field, json_path, &mut term);
     if let Some(term) = convert_to_fast_value_and_get_term(&mut json_term_writer, phrase) {
         logical_literals.push(LogicalLiteral::Term(term));
     }


### PR DESCRIPTION
Added an easy "constructor" for given field + path to pass on to helper functions.
Adds two helper functions, unfortunately they cannot have the same signature as text types need a bit more work and generate more than one Term.

I'm not sure about the function naming.

closes #1302