### PR TITLE
Make `FruitHandle` and `MultiFruit` public

### DIFF
--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -92,7 +92,7 @@ mod histogram_collector;
 pub use histogram_collector::HistogramCollector;
 
 mod multi_collector;
-pub use self::multi_collector::MultiCollector;
+pub use self::multi_collector::{FruitHandle, MultiCollector, MultiFruit};
 
 mod top_collector;
 

--- a/src/collector/multi_collector.rs
+++ b/src/collector/multi_collector.rs
@@ -5,6 +5,7 @@ use super::{Collector, SegmentCollector};
 use crate::collector::Fruit;
 use crate::{DocId, Score, SegmentOrdinal, SegmentReader, TantivyError};
 
+/// MultiFruit keeps Fruits from every nested Collector
 pub struct MultiFruit {
     sub_fruits: Vec<Option<Box<dyn Fruit>>>,
 }
@@ -79,6 +80,7 @@ impl<TSegmentCollector: SegmentCollector> BoxableSegmentCollector
     }
 }
 
+/// FruitHandle stores reference to the corresponding collector inside MultiCollector
 pub struct FruitHandle<TFruit: Fruit> {
     pos: usize,
     _phantom: PhantomData<TFruit>,


### PR DESCRIPTION
Hi! I've been coding dynamic `Collector` creation in my project and figured out that it was impossible to store `FruitHandle` inside struct or `Vec` because of (in)visibility of `FruitHandle` and `MultiFruit`. Is it ok to make them visible?