### PR TITLE
Bugfix in the document deserialization.

### DIFF
--- a/src/schema/document.rs
+++ b/src/schema/document.rs
@@ -213,6 +213,8 @@ impl BinarySerializable for Document {
 #[cfg(test)]
 mod tests {
 
+    use common::BinarySerializable;
+
     use crate::schema::*;
 
     #[test]
@@ -222,5 +224,17 @@ mod tests {
         let mut doc = Document::default();
         doc.add_text(text_field, "My title");
         assert_eq!(doc.field_values().len(), 1);
+    }
+
+    #[test]
+    fn test_doc_serialization_issue() {
+        let mut doc = Document::default();
+        doc.add_json_object(Field::from_field_id(0), serde_json::json!({"key": 2u64}).as_object().unwrap().clone());
+        doc.add_text(Field::from_field_id(1), "hello");
+        assert_eq!(doc.field_values().len(), 2);
+        let mut payload: Vec<u8> = Vec::new();
+        doc.serialize(&mut payload).unwrap();
+        assert_eq!(payload.len(), 26);
+        Document::deserialize(&mut &payload[..]).unwrap();
     }
 }

--- a/src/schema/value.rs
+++ b/src/schema/value.rs
@@ -388,8 +388,9 @@ mod binary_serialize {
                     }
                 }
                 JSON_OBJ_CODE => {
-                    let map = serde_json::from_reader(reader)?;
-                    Ok(Value::JsonObject(map))
+                    let mut de = serde_json::Deserializer::from_reader(reader);
+                    let json_map = <serde_json::Map::<String, serde_json::Value> as serde::Deserialize>::deserialize(&mut de)?;
+                    Ok(Value::JsonObject(json_map))
                 }
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidData,


### PR DESCRIPTION
Deserializing a json field does not expect the
end of the document anymore.

This behavior is well documented in serde_json.
https://docs.serde.rs/serde_json/fn.from_reader.html

Closes #1366