### PR TITLE
Bugfix in the document deserialization.

### DIFF
--- a/src/schema/document.rs
+++ b/src/schema/document.rs
@@ -213,6 +213,8 @@ impl BinarySerializable for Document {
 #[cfg(test)]
 mod tests {
 
+    use common::BinarySerializable;
+
     use crate::schema::*;
 
     #[test]
@@ -222,5 +224,23 @@ mod tests {
         let mut doc = Document::default();
         doc.add_text(text_field, "My title");
         assert_eq!(doc.field_values().len(), 1);
+    }
+
+    #[test]
+    fn test_doc_serialization_issue() {
+        let mut doc = Document::default();
+        doc.add_json_object(
+            Field::from_field_id(0),
+            serde_json::json!({"key": 2u64})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+        doc.add_text(Field::from_field_id(1), "hello");
+        assert_eq!(doc.field_values().len(), 2);
+        let mut payload: Vec<u8> = Vec::new();
+        doc.serialize(&mut payload).unwrap();
+        assert_eq!(payload.len(), 26);
+        Document::deserialize(&mut &payload[..]).unwrap();
     }
 }


### PR DESCRIPTION
Deserializing a json field does not expect the
end of the document anymore.

This behavior is well documented in serde_json.
https://docs.serde.rs/serde_json/fn.from_reader.html

Closes #1366