### PR TITLE
Fix deps for unicode regex compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ base64 = "0.13.0"
 byteorder = "1.4.3"
 crc32fast = "1.3.2"
 once_cell = "1.10.0"
-regex ={ version = "1.5.5", default-features = false, features = ["std"] }
+regex = { version = "1.5.5", default-features = false, features = ["std", "unicode"] }
 tantivy-fst = "0.3.0"
 memmap2 = { version = "0.5.3", optional = true }
 lz4_flex = { version = "0.9.2", default-features = false, features = ["checked-decode"], optional = true }

--- a/src/collector/multi_collector.rs
+++ b/src/collector/multi_collector.rs
@@ -87,10 +87,10 @@ pub struct FruitHandle<TFruit: Fruit> {
 }
 
 impl<TFruit: Fruit> FruitHandle<TFruit> {
-    // Extract a typed fruit off a multifruit.
-    //
-    // This function involves downcasting and can panic if the multifruit was
-    // created using faulty code.
+    /// Extract a typed fruit off a multifruit.
+    ///
+    /// This function involves downcasting and can panic if the multifruit was
+    /// created using faulty code.
     pub fn extract(self, fruits: &mut MultiFruit) -> TFruit {
         let boxed_fruit = fruits.sub_fruits[self.pos].take().expect("");
         *boxed_fruit


### PR DESCRIPTION
following #1356 

Fixes `./example/json_field.rs` (which fails with v0.17)
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Syntax(
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
regex parse error:
    \\(\+|\^|`|:|\{|\}|"|\[|\]|\(|\)|\~|!|\\|\*|\s)
                                                ^^
error: Unicode-aware Perl class not found (make sure the unicode-perl feature is enabled)
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
)', /home/saroh/.cargo/git/checkouts/tantivy-1e252d10ffb11ab7/3223bdf/query-grammar/src/query_grammar.rs:29:64
``` 
+doc lint

maybe we could add the example somewhere in the doc so they're tested/serve as tests ?
