### PR TITLE
Add a lenient query parser

### DIFF
--- a/query-grammar/Cargo.toml
+++ b/query-grammar/Cargo.toml
@@ -14,4 +14,4 @@ edition = "2018"
 [dependencies]
 combine = {version="4", default-features=false, features=[] }
 once_cell = "1.7.2"
-regex ={ version = "1.5.4", default-features = false, features = ["std"] }
+regex ={ version = "1.5.4", default-features = false, features = ["std", "unicode-perl"] }

--- a/query-grammar/src/lib.rs
+++ b/query-grammar/src/lib.rs
@@ -5,6 +5,7 @@ use combine::parser::Parser;
 
 pub use crate::occur::Occur;
 use crate::query_grammar::parse_to_ast;
+pub use crate::query_grammar::SPECIAL_CHARS_NO_SPACE;
 pub use crate::user_input_ast::{UserInputAst, UserInputBound, UserInputLeaf, UserInputLiteral};
 
 pub struct Error;

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -15,6 +15,9 @@ use crate::Occur;
 
 // Note: '-' char is only forbidden at the beginning of a field name, would be clearer to add it to
 // special characters.
+pub const SPECIAL_CHARS_NO_SPACE: &[char] = &[
+    '+', '^', '`', ':', '{', '}', '"', '[', ']', '(', ')', '~', '!', '\\', '*',
+];
 const SPECIAL_CHARS: &[char] = &[
     '+', '^', '`', ':', '{', '}', '"', '[', ']', '(', ')', '~', '!', '\\', '*', ' ',
 ];


### PR DESCRIPTION
* #5 
* Question: Is there some way of consolidating the special chars with no spaces and one without?
* If a query cannot be passed all the special characters are removed from the query string. If that fails to be compiled into an AST then an empty query (which should return no results) will be returned.
* Add `unicode-perl` as a feature flag to `regex` due to
  ```
  ---- query_grammar::test::test_field_name_re stdout ----
  thread 'query_grammar::test::test_field_name_re' panicked at 'called `Result::unwrap()` on an `Err` value: Syntax(
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  regex parse error:
      \\(\+|\^|`|:|\{|\}|"|\[|\]|\(|\)|\~|!|\\|\*|\s)
                                                  ^^
  error: Unicode-aware Perl class not found (make sure the unicode-perl feature is enabled)
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  )', query-grammar/src/query_grammar.rs:573:82
  ```