### PR TITLE
add support for phrase slop in query language

### DIFF
--- a/query-grammar/Cargo.toml
+++ b/query-grammar/Cargo.toml
@@ -14,4 +14,4 @@ edition = "2018"
 [dependencies]
 combine = {version="4", default-features=false, features=[] }
 once_cell = "1.7.2"
-regex ={ version = "1.5.4", default-features = false, features = ["std"] }
+regex ={ version = "1.5.4", default-features = false, features = ["std", "unicode"] }

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -49,10 +49,10 @@ fn word<'a>() -> impl Parser<&'a str, Output = String> {
     (
         satisfy(|c: char| {
             !c.is_whitespace()
-                && !['-', '^', '`', ':', '{', '}', '"', '[', ']', '(', ')'].contains(&c)
+                && !['-', '^', '`', ':', '{', '}', '"', '[', ']', '(', ')', '~'].contains(&c)
         }),
         many(satisfy(|c: char| {
-            !c.is_whitespace() && ![':', '^', '{', '}', '"', '[', ']', '(', ')'].contains(&c)
+            !c.is_whitespace() && ![':', '^', '{', '}', '"', '[', ']', '(', ')', '~'].contains(&c)
         })),
     )
         .map(|(s1, s2): (char, String)| format!("{}{}", s1, s2))
@@ -732,11 +732,10 @@ mod test {
     fn test_matching_distance() {
         assert!(parse_to_ast().parse("\"a b\"~").is_err());
         assert!(parse_to_ast().parse("foo:\"a b\"~").is_err());
-        // assert!(parse_to_ast().parse("\"a b\"^2~4").is_err());
-        test_parse_query_to_ast_helper("\"a b\"^2~4", "(*(\"a b\")^2 *\"~4\")");
+        assert!(parse_to_ast().parse("\"a b\"^2~4").is_err());
+        assert!(parse_to_ast().parse("~").is_err());
 
-        test_parse_query_to_ast_helper("~", "\"~\"");
-        test_parse_query_to_ast_helper("a~2", "\"a~2\"");
+        test_parse_query_to_ast_helper("a~2", "\"a\"~2");
         test_parse_query_to_ast_helper("\"a b\"~0", "\"a b\"");
         test_parse_query_to_ast_helper("\"a b\"~1", "\"a b\"~1");
         test_parse_query_to_ast_helper("\"a b\"~3", "\"a b\"~3");

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -49,10 +49,10 @@ fn word<'a>() -> impl Parser<&'a str, Output = String> {
     (
         satisfy(|c: char| {
             !c.is_whitespace()
-                && !['-', '^', '`', ':', '{', '}', '"', '[', ']', '(', ')', '~'].contains(&c)
+                && !['-', '^', '`', ':', '{', '}', '"', '[', ']', '(', ')'].contains(&c)
         }),
         many(satisfy(|c: char| {
-            !c.is_whitespace() && ![':', '^', '{', '}', '"', '[', ']', '(', ')', '~'].contains(&c)
+            !c.is_whitespace() && ![':', '^', '{', '}', '"', '[', ']', '(', ')'].contains(&c)
         })),
     )
         .map(|(s1, s2): (char, String)| format!("{}{}", s1, s2))
@@ -736,13 +736,13 @@ mod test {
     fn test_slop() {
         assert!(parse_to_ast().parse("\"a b\"~").is_err());
         assert!(parse_to_ast().parse("foo:\"a b\"~").is_err());
-        assert!(parse_to_ast().parse("\"a b\"^2~4").is_err());
         assert!(parse_to_ast().parse("\"a b\"~a").is_err());
         assert!(parse_to_ast().parse("\"a b\"~100000000000000000").is_err());
-        assert!(parse_to_ast().parse("~/Documents").is_err());
 
+        test_parse_query_to_ast_helper("\"a b\"^2~4", "(*(\"a b\")^2 *\"~4\")");
         test_parse_query_to_ast_helper("\"~Document\"", "\"~Document\"");
-        test_parse_query_to_ast_helper("a~2", "\"a\"~2");
+        test_parse_query_to_ast_helper("~Document", "\"~Document\"");
+        test_parse_query_to_ast_helper("a~2", "\"a~2\"");
         test_parse_query_to_ast_helper("\"a b\"~0", "\"a b\"");
         test_parse_query_to_ast_helper("\"a b\"~1", "\"a b\"~1");
         test_parse_query_to_ast_helper("\"a b\"~3", "\"a b\"~3");

--- a/query-grammar/src/user_input_ast.rs
+++ b/query-grammar/src/user_input_ast.rs
@@ -40,14 +40,19 @@ impl Debug for UserInputLeaf {
 pub struct UserInputLiteral {
     pub field_name: Option<String>,
     pub phrase: String,
+    pub matching_distance: u32,
 }
 
 impl fmt::Debug for UserInputLiteral {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self.field_name {
-            Some(ref field_name) => write!(formatter, "\"{}\":\"{}\"", field_name, self.phrase),
-            None => write!(formatter, "\"{}\"", self.phrase),
+        if let Some(ref field) = self.field_name {
+            write!(formatter, "\"{}\":", field)?;
         }
+        write!(formatter, "\"{}\"", self.phrase)?;
+        if self.matching_distance > 0 {
+            write!(formatter, "~{}", self.matching_distance)?;
+        }
+        Ok(())
     }
 }
 

--- a/query-grammar/src/user_input_ast.rs
+++ b/query-grammar/src/user_input_ast.rs
@@ -40,7 +40,7 @@ impl Debug for UserInputLeaf {
 pub struct UserInputLiteral {
     pub field_name: Option<String>,
     pub phrase: String,
-    pub matching_distance: u32,
+    pub slop: u32,
 }
 
 impl fmt::Debug for UserInputLiteral {
@@ -49,8 +49,8 @@ impl fmt::Debug for UserInputLiteral {
             write!(formatter, "\"{}\":", field)?;
         }
         write!(formatter, "\"{}\"", self.phrase)?;
-        if self.matching_distance > 0 {
-            write!(formatter, "~{}", self.matching_distance)?;
+        if self.slop > 0 {
+            write!(formatter, "~{}", self.slop)?;
         }
         Ok(())
     }

--- a/src/query/phrase_query/phrase_query.rs
+++ b/src/query/phrase_query/phrase_query.rs
@@ -40,7 +40,12 @@ impl PhraseQuery {
     /// Creates a new `PhraseQuery` given a list of terms and their offsets.
     ///
     /// Can be used to provide custom offset for each term.
-    pub fn new_with_offset(mut terms: Vec<(usize, Term)>) -> PhraseQuery {
+    pub fn new_with_offset(terms: Vec<(usize, Term)>) -> PhraseQuery {
+        PhraseQuery::new_with_offset_and_slop(terms, 0)
+    }
+
+    /// Creates a new `PhraseQuery` given a list of terms, their offsets and a slop
+    pub fn new_with_offset_and_slop(mut terms: Vec<(usize, Term)>, slop: u32) -> PhraseQuery {
         assert!(
             terms.len() > 1,
             "A phrase query is required to have strictly more than one term."
@@ -54,7 +59,7 @@ impl PhraseQuery {
         PhraseQuery {
             field,
             phrase_terms: terms,
-            slop: 0,
+            slop,
         }
     }
 

--- a/src/query/query_parser/logical_ast.rs
+++ b/src/query/query_parser/logical_ast.rs
@@ -74,10 +74,10 @@ impl fmt::Debug for LogicalLiteral {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             LogicalLiteral::Term(ref term) => write!(formatter, "{:?}", term),
-            LogicalLiteral::Phrase(ref terms, distance) => {
+            LogicalLiteral::Phrase(ref terms, slop) => {
                 write!(formatter, "\"{:?}\"", terms)?;
-                if distance > 0 {
-                    write!(formatter, "~{:?}", distance)
+                if slop > 0 {
+                    write!(formatter, "~{:?}", slop)
                 } else {
                     Ok(())
                 }

--- a/src/query/query_parser/logical_ast.rs
+++ b/src/query/query_parser/logical_ast.rs
@@ -8,7 +8,7 @@ use crate::Score;
 #[derive(Clone)]
 pub enum LogicalLiteral {
     Term(Term),
-    Phrase(Vec<(usize, Term)>),
+    Phrase(Vec<(usize, Term)>, u32),
     Range {
         field: Field,
         value_type: Type,
@@ -74,7 +74,14 @@ impl fmt::Debug for LogicalLiteral {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             LogicalLiteral::Term(ref term) => write!(formatter, "{:?}", term),
-            LogicalLiteral::Phrase(ref terms) => write!(formatter, "\"{:?}\"", terms),
+            LogicalLiteral::Phrase(ref terms, distance) => {
+                write!(formatter, "\"{:?}\"", terms)?;
+                if distance > 0 {
+                    write!(formatter, "~{:?}", distance)
+                } else {
+                    Ok(())
+                }
+            }
             LogicalLiteral::Range {
                 ref lower,
                 ref upper,

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -168,6 +168,9 @@ fn trim_ast(logical_ast: LogicalAst) -> Option<LogicalAst> {
 /// It is also possible to define a boost for a some specific field, at the query parser level.
 /// (See [`set_boost(...)`](#method.set_field_boost) ). Typically you may want to boost a title
 /// field.
+///
+/// Phrase terms support the `~` distance operator which allows to set the phrase's matching
+/// distance in words. `"big wolf"~1 will return documents containing the phrase `"big bad wolf"`.
 #[derive(Clone)]
 pub struct QueryParser {
     schema: Schema,


### PR DESCRIPTION
### Breaking changes to the existing query language: 
+ `~` is now allowed unescaped in the field name



The first commit still allows `~` in words, might be a bit flimsy.
Second one exposes distance for all leaves. Do we need to explicitly fail for leaves that do not handle slop/distance + implement it for those who do ? (Term maybe, I haven't checked)


Not realy sure on the name, slop is hard to understand, distance is maybe a little to vague.


closes #1390