### PR TITLE
make errors cloneable

### DIFF
--- a/src/directory/error.rs
+++ b/src/directory/error.rs
@@ -1,10 +1,11 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::{fmt, io};
 
 use crate::Version;
 
 /// Error while trying to acquire a directory lock.
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum LockError {
     /// Failed to acquired a lock as it is already held by another
     /// client.
@@ -16,11 +17,18 @@ pub enum LockError {
     LockBusy,
     /// Trying to acquire a lock failed with an `IoError`
     #[error("Failed to acquire the lock due to an io:Error.")]
-    IoError(io::Error),
+    IoError(Arc<io::Error>),
+}
+
+impl LockError {
+    /// Wraps an io error.
+    pub fn wrap_io_error(io_error: io::Error) -> Self {
+        Self::IoError(Arc::new(io_error))
+    }
 }
 
 /// Error that may occur when opening a directory
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum OpenDirectoryError {
     /// The underlying directory does not exists.
     #[error("Directory does not exist: '{0}'.")]
@@ -30,12 +38,12 @@ pub enum OpenDirectoryError {
     NotADirectory(PathBuf),
     /// Failed to create a temp directory.
     #[error("Failed to create a temporary directory: '{0}'.")]
-    FailedToCreateTempDir(io::Error),
+    FailedToCreateTempDir(Arc<io::Error>),
     /// IoError
     #[error("IoError '{io_error:?}' while create directory in: '{directory_path:?}'.")]
     IoError {
         /// underlying io Error.
-        io_error: io::Error,
+        io_error: Arc<io::Error>,
         /// directory we tried to open.
         directory_path: PathBuf,
     },
@@ -45,14 +53,14 @@ impl OpenDirectoryError {
     /// Wraps an io error.
     pub fn wrap_io_error(io_error: io::Error, directory_path: PathBuf) -> Self {
         Self::IoError {
-            io_error,
+            io_error: Arc::new(io_error),
             directory_path,
         }
     }
 }
 
 /// Error that may occur when starting to write in a file
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum OpenWriteError {
     /// Our directory is WORM, writing an existing file is forbidden.
     /// Checkout the `Directory` documentation.
@@ -63,7 +71,7 @@ pub enum OpenWriteError {
     #[error("IoError '{io_error:?}' while opening file for write: '{filepath}'.")]
     IoError {
         /// The underlying `io::Error`.
-        io_error: io::Error,
+        io_error: Arc<io::Error>,
         /// File path of the file that tantivy failed to open for write.
         filepath: PathBuf,
     },
@@ -72,11 +80,15 @@ pub enum OpenWriteError {
 impl OpenWriteError {
     /// Wraps an io error.
     pub fn wrap_io_error(io_error: io::Error, filepath: PathBuf) -> Self {
-        Self::IoError { io_error, filepath }
+        Self::IoError {
+            io_error: Arc::new(io_error),
+            filepath,
+        }
     }
 }
 /// Type of index incompatibility between the library and the index found on disk
 /// Used to catch and provide a hint to solve this incompatibility issue
+#[derive(Clone)]
 pub enum Incompatibility {
     /// This library cannot decompress the index found on disk
     CompressionMismatch {
@@ -135,7 +147,7 @@ impl fmt::Debug for Incompatibility {
 }
 
 /// Error that may occur when accessing a file read
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum OpenReadError {
     /// The file does not exists.
     #[error("Files does not exists: {0:?}")]
@@ -146,7 +158,7 @@ pub enum OpenReadError {
     )]
     IoError {
         /// The underlying `io::Error`.
-        io_error: io::Error,
+        io_error: Arc<io::Error>,
         /// File path of the file that tantivy failed to open for read.
         filepath: PathBuf,
     },
@@ -158,11 +170,14 @@ pub enum OpenReadError {
 impl OpenReadError {
     /// Wraps an io error.
     pub fn wrap_io_error(io_error: io::Error, filepath: PathBuf) -> Self {
-        Self::IoError { io_error, filepath }
+        Self::IoError {
+            io_error: Arc::new(io_error),
+            filepath,
+        }
     }
 }
 /// Error that may occur when trying to delete a file
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum DeleteError {
     /// The file does not exists.
     #[error("File does not exists: '{0}'.")]
@@ -172,7 +187,7 @@ pub enum DeleteError {
     #[error("The following IO error happened while deleting file '{filepath}': '{io_error:?}'.")]
     IoError {
         /// The underlying `io::Error`.
-        io_error: io::Error,
+        io_error: Arc<io::Error>,
         /// File path of the file that tantivy failed to delete.
         filepath: PathBuf,
     },

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -242,16 +242,13 @@ impl ManagedDirectory {
     /// Verify checksum of a managed file
     pub fn validate_checksum(&self, path: &Path) -> result::Result<bool, OpenReadError> {
         let reader = self.directory.open_read(path)?;
-        let (footer, data) =
-            Footer::extract_footer(reader).map_err(|io_error| OpenReadError::IoError {
-                io_error,
-                filepath: path.to_path_buf(),
-            })?;
+        let (footer, data) = Footer::extract_footer(reader)
+            .map_err(|io_error| OpenReadError::wrap_io_error(io_error, path.to_path_buf()))?;
         let bytes = data
             .read_bytes()
             .map_err(|io_error| OpenReadError::IoError {
+                io_error: Arc::new(io_error),
                 filepath: path.to_path_buf(),
-                io_error,
             })?;
         let mut hasher = Hasher::new();
         hasher.update(bytes.as_slice());

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -172,7 +172,7 @@ impl Directory for RamDirectory {
     fn delete(&self, path: &Path) -> result::Result<(), DeleteError> {
         fail_point!("RamDirectory::delete", |_| {
             Err(DeleteError::IoError {
-                io_error: io::Error::from(io::ErrorKind::Other),
+                io_error: Arc::new(io::Error::from(io::ErrorKind::Other)),
                 filepath: path.to_path_buf(),
             })
         });
@@ -184,7 +184,7 @@ impl Directory for RamDirectory {
             .fs
             .read()
             .map_err(|e| OpenReadError::IoError {
-                io_error: io::Error::new(io::ErrorKind::Other, e.to_string()),
+                io_error: Arc::new(io::Error::new(io::ErrorKind::Other, e.to_string())),
                 filepath: path.to_path_buf(),
             })?
             .exists(path))
@@ -208,7 +208,7 @@ impl Directory for RamDirectory {
             self.open_read(path)?
                 .read_bytes()
                 .map_err(|io_error| OpenReadError::IoError {
-                    io_error,
+                    io_error: Arc::new(io_error),
                     filepath: path.to_path_buf(),
                 })?;
         Ok(bytes.as_slice().to_owned())


### PR DESCRIPTION
make errors cloneable by wrapping io::Error in an `Arc`

The debouncer experiment showed, that there is some value when errors are `Clone`. I think it's quite easy to provide that convenience in tantivy 