### PR TITLE
FileHandle: Change from boxed to Arc.

### DIFF
--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -111,7 +111,7 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     ///
     /// Users of `Directory` should typically call `Directory::open_read(...)`,
     /// while `Directory` implementor should implement `get_file_handle()`.
-    fn get_file_handle(&self, path: &Path) -> Result<Box<dyn FileHandle>, OpenReadError>;
+    fn get_file_handle(&self, path: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError>;
 
     /// Once a virtual file is open, its data may not
     /// change.

--- a/src/directory/file_slice.rs
+++ b/src/directory/file_slice.rs
@@ -51,8 +51,7 @@ impl FileHandle for &'static [u8] {
 }
 
 impl<B> From<B> for FileSlice
-where
-    B: StableDeref + Deref<Target = [u8]> + 'static + Send + Sync,
+where B: StableDeref + Deref<Target = [u8]> + 'static + Send + Sync
 {
     fn from(bytes: B) -> FileSlice {
         FileSlice::new(Arc::new(OwnedBytes::new(bytes)))
@@ -236,11 +235,11 @@ impl FileHandle for OwnedBytes {
 #[cfg(test)]
 mod tests {
     use std::io;
+    use std::sync::Arc;
 
     use common::HasLen;
 
     use super::{FileHandle, FileSlice};
-    use std::sync::Arc;
 
     #[test]
     fn test_file_slice() -> io::Result<()> {

--- a/src/directory/file_slice.rs
+++ b/src/directory/file_slice.rs
@@ -51,10 +51,11 @@ impl FileHandle for &'static [u8] {
 }
 
 impl<B> From<B> for FileSlice
-where B: StableDeref + Deref<Target = [u8]> + 'static + Send + Sync
+where
+    B: StableDeref + Deref<Target = [u8]> + 'static + Send + Sync,
 {
     fn from(bytes: B) -> FileSlice {
-        FileSlice::new(Box::new(OwnedBytes::new(bytes)))
+        FileSlice::new(Arc::new(OwnedBytes::new(bytes)))
     }
 }
 
@@ -75,7 +76,7 @@ impl fmt::Debug for FileSlice {
 
 impl FileSlice {
     /// Wraps a FileHandle.
-    pub fn new(file_handle: Box<dyn FileHandle>) -> Self {
+    pub fn new(file_handle: Arc<dyn FileHandle>) -> Self {
         let num_bytes = file_handle.len();
         FileSlice::new_with_num_bytes(file_handle, num_bytes)
     }
@@ -83,9 +84,9 @@ impl FileSlice {
     /// Wraps a FileHandle.
     #[doc(hidden)]
     #[must_use]
-    pub fn new_with_num_bytes(file_handle: Box<dyn FileHandle>, num_bytes: usize) -> Self {
+    pub fn new_with_num_bytes(file_handle: Arc<dyn FileHandle>, num_bytes: usize) -> Self {
         FileSlice {
-            data: Arc::from(file_handle),
+            data: file_handle,
             range: 0..num_bytes,
         }
     }
@@ -239,10 +240,11 @@ mod tests {
     use common::HasLen;
 
     use super::{FileHandle, FileSlice};
+    use std::sync::Arc;
 
     #[test]
     fn test_file_slice() -> io::Result<()> {
-        let file_slice = FileSlice::new(Box::new(b"abcdef".as_ref()));
+        let file_slice = FileSlice::new(Arc::new(b"abcdef".as_ref()));
         assert_eq!(file_slice.len(), 6);
         assert_eq!(file_slice.slice_from(2).read_bytes()?.as_slice(), b"cdef");
         assert_eq!(file_slice.slice_to(2).read_bytes()?.as_slice(), b"ab");
@@ -286,7 +288,7 @@ mod tests {
 
     #[test]
     fn test_slice_simple_read() -> io::Result<()> {
-        let slice = FileSlice::new(Box::new(&b"abcdef"[..]));
+        let slice = FileSlice::new(Arc::new(&b"abcdef"[..]));
         assert_eq!(slice.len(), 6);
         assert_eq!(slice.read_bytes()?.as_ref(), b"abcdef");
         assert_eq!(slice.slice(1..4).read_bytes()?.as_ref(), b"bcd");
@@ -295,7 +297,7 @@ mod tests {
 
     #[test]
     fn test_slice_read_slice() -> io::Result<()> {
-        let slice_deref = FileSlice::new(Box::new(&b"abcdef"[..]));
+        let slice_deref = FileSlice::new(Arc::new(&b"abcdef"[..]));
         assert_eq!(slice_deref.read_bytes_slice(1..4)?.as_ref(), b"bcd");
         Ok(())
     }
@@ -303,7 +305,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "end of requested range exceeds the fileslice length (10 > 6)")]
     fn test_slice_read_slice_invalid_range_exceeds() {
-        let slice_deref = FileSlice::new(Box::new(&b"abcdef"[..]));
+        let slice_deref = FileSlice::new(Arc::new(&b"abcdef"[..]));
         assert_eq!(
             slice_deref.read_bytes_slice(0..10).unwrap().as_ref(),
             b"bcd"

--- a/src/directory/footer.rs
+++ b/src/directory/footer.rs
@@ -156,6 +156,7 @@ impl<W: TerminatingWrite> TerminatingWrite for FooterProxy<W> {
 mod tests {
 
     use std::io;
+    use std::sync::Arc;
 
     use common::BinarySerializable;
 
@@ -168,7 +169,7 @@ mod tests {
         let footer = Footer::new(123);
         footer.append_footer(&mut buf).unwrap();
         let owned_bytes = OwnedBytes::new(buf);
-        let fileslice = FileSlice::new(Box::new(owned_bytes));
+        let fileslice = FileSlice::new(Arc::new(owned_bytes));
         let (footer_deser, _body) = Footer::extract_footer(fileslice).unwrap();
         assert_eq!(footer_deser.crc(), footer.crc());
     }
@@ -181,7 +182,7 @@ mod tests {
 
         let owned_bytes = OwnedBytes::new(buf);
 
-        let fileslice = FileSlice::new(Box::new(owned_bytes));
+        let fileslice = FileSlice::new(Arc::new(owned_bytes));
         let err = Footer::extract_footer(fileslice).unwrap_err();
         assert_eq!(
             err.to_string(),
@@ -198,7 +199,7 @@ mod tests {
 
         let owned_bytes = OwnedBytes::new(buf);
 
-        let fileslice = FileSlice::new(Box::new(owned_bytes));
+        let fileslice = FileSlice::new(Arc::new(owned_bytes));
         let err = Footer::extract_footer(fileslice).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
         assert_eq!(
@@ -217,7 +218,7 @@ mod tests {
 
         let owned_bytes = OwnedBytes::new(buf);
 
-        let fileslice = FileSlice::new(Box::new(owned_bytes));
+        let fileslice = FileSlice::new(Arc::new(owned_bytes));
         let err = Footer::extract_footer(fileslice).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert_eq!(

--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -269,9 +269,9 @@ impl ManagedDirectory {
 }
 
 impl Directory for ManagedDirectory {
-    fn get_file_handle(&self, path: &Path) -> Result<Box<dyn FileHandle>, OpenReadError> {
+    fn get_file_handle(&self, path: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError> {
         let file_slice = self.open_read(path)?;
-        Ok(Box::new(file_slice))
+        Ok(Arc::new(file_slice))
     }
 
     fn open_read(&self, path: &Path) -> result::Result<FileSlice, OpenReadError> {

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -310,7 +310,7 @@ pub(crate) fn atomic_write(path: &Path, content: &[u8]) -> io::Result<()> {
 }
 
 impl Directory for MmapDirectory {
-    fn get_file_handle(&self, path: &Path) -> result::Result<Box<dyn FileHandle>, OpenReadError> {
+    fn get_file_handle(&self, path: &Path) -> result::Result<Arc<dyn FileHandle>, OpenReadError> {
         debug!("Open Read {:?}", path);
         let full_path = self.resolve_path(path);
 
@@ -331,7 +331,7 @@ impl Directory for MmapDirectory {
             })
             .unwrap_or_else(OwnedBytes::empty);
 
-        Ok(Box::new(owned_bytes))
+        Ok(Arc::new(owned_bytes))
     }
 
     /// Any entry associated to the path in the mmap will be

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -160,9 +160,9 @@ impl RamDirectory {
 }
 
 impl Directory for RamDirectory {
-    fn get_file_handle(&self, path: &Path) -> Result<Box<dyn FileHandle>, OpenReadError> {
+    fn get_file_handle(&self, path: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError> {
         let file_slice = self.open_read(path)?;
-        Ok(Box::new(file_slice))
+        Ok(Arc::new(file_slice))
     }
 
     fn open_read(&self, path: &Path) -> result::Result<FileSlice, OpenReadError> {

--- a/src/termdict/sstable_termdict/termdict.rs
+++ b/src/termdict/sstable_termdict/termdict.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::sync::Arc;
 
 use common::BinarySerializable;
 use once_cell::sync::Lazy;
@@ -138,7 +139,7 @@ impl TermDictionary {
     }
 
     pub fn from_bytes(owned_bytes: OwnedBytes) -> crate::Result<TermDictionary> {
-        TermDictionary::open(FileSlice::new(Box::new(owned_bytes)))
+        TermDictionary::open(FileSlice::new(Arc::new(owned_bytes)))
     }
 
     /// Creates an empty term dictionary which contains no terms.


### PR DESCRIPTION
Changing from a Box<dyn FileHandle> to an Arc<dyn FileHandle> would
allow for a user of tantivy to manage file handles outside of tantivy
and be able to manage their life cycle.

I'm currently working with tantivy and one of the thing I wanted to do was to manage file access outside of tantivy in a way that file access is abstracted completely from tantivy. I got everything working on my end, but I needed to make this change to tantivy because I needed shared ownership of a given FileHandle.

I believe this change is safe to other user of tantivy, but I am new to both Tantivy & Rust, so maybe there's something else that needs to change to make this happen.