### PR TITLE
Fix failing nanosec truncation check on mac OS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1150,7 +1150,7 @@ pub mod tests {
         assert_eq!(dt.to_ordinal_date(), now.to_ordinal_date());
         assert_eq!(dt.to_hms_micro(), now.to_hms_micro());
         // We don't store nanosecond level precision.
-        assert_ne!(dt.to_hms_nano(), now.to_hms_nano());
+        assert_eq!(dt.nanosecond(), now.microsecond() * 1000);
 
         let dt = DateTime::from_timestamp_secs(now.unix_timestamp()).into_utc();
         assert_eq!(dt.to_ordinal_date(), now.to_ordinal_date());


### PR DESCRIPTION
Fixes #1421 

Nanosecond level precision is already truncated on some platforms including mac OS.
This PR fixes the failing test by comparing with microsecond, and I believe it's a little more valid test than asserting the inequality.

Related issue found on GitHub: https://github.com/edgedb/edgedb-go/issues/209