### PR TITLE
handle empty segments for merge

### DIFF
--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -510,10 +510,12 @@ impl IndexWriter {
         Ok(self.committed_opstamp)
     }
 
-    /// Merges a given list of segments
+    /// Merges a given list of segments.
+    ///
+    /// If all segments are empty no new segment will be created.
     ///
     /// `segment_ids` is required to be non-empty.
-    pub fn merge(&mut self, segment_ids: &[SegmentId]) -> FutureResult<()> {
+    pub fn merge(&mut self, segment_ids: &[SegmentId]) -> FutureResult<Option<SegmentMeta>> {
         let merge_operation = self.segment_updater.make_merge_operation(segment_ids);
         let segment_updater = self.segment_updater.clone();
         segment_updater.start_merge(merge_operation)

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -200,6 +200,7 @@ impl IndexMerger {
                 readers.push(reader);
             }
         }
+
         let max_doc = readers.iter().map(|reader| reader.num_docs()).sum();
         if let Some(sort_by_field) = index_settings.sort_by_field.as_ref() {
             readers = Self::sort_readers_by_min_sort_field(readers, sort_by_field)?;

--- a/src/indexer/segment_manager.rs
+++ b/src/indexer/segment_manager.rs
@@ -173,6 +173,7 @@ impl SegmentManager {
                 .to_string();
             return Err(TantivyError::InvalidArgument(error_msg));
         }
+
         Ok(segment_entries)
     }
 
@@ -186,7 +187,7 @@ impl SegmentManager {
     pub(crate) fn end_merge(
         &self,
         before_merge_segment_ids: &[SegmentId],
-        after_merge_segment_entry: SegmentEntry,
+        after_merge_segment_entry: Option<SegmentEntry>,
     ) -> crate::Result<SegmentsStatus> {
         let mut registers_lock = self.write();
         let segments_status = registers_lock
@@ -207,7 +208,9 @@ impl SegmentManager {
         for segment_id in before_merge_segment_ids {
             target_register.remove_segment(segment_id);
         }
-        target_register.add_segment_entry(after_merge_segment_entry);
+        if let Some(entry) = after_merge_segment_entry {
+            target_register.add_segment_entry(entry);
+        }
         Ok(segments_status)
     }
 

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -597,7 +597,7 @@ impl SegmentUpdater {
                 after_merge_segment_entry.as_ref().map(|entry| entry.meta())
             );
             {
-                if let Some(mut after_merge_segment_entry) = after_merge_segment_entry.as_mut() {
+                if let Some(after_merge_segment_entry) = after_merge_segment_entry.as_mut() {
                     let mut delete_cursor = after_merge_segment_entry.delete_cursor().clone();
                     if let Some(delete_operation) = delete_cursor.get() {
                         let committed_opstamp = segment_updater.load_meta().opstamp;

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -91,7 +91,15 @@ fn merge(
     index: &Index,
     mut segment_entries: Vec<SegmentEntry>,
     target_opstamp: Opstamp,
-) -> crate::Result<SegmentEntry> {
+) -> crate::Result<Option<SegmentEntry>> {
+    let num_docs = segment_entries
+        .iter()
+        .map(|segment| segment.meta().num_docs() as u64)
+        .sum::<u64>();
+    if num_docs == 0 {
+        return Ok(None);
+    }
+
     // first we need to apply deletes to our segment.
     let merged_segment = index.new_segment();
 
@@ -120,7 +128,7 @@ fn merge(
     let merged_segment_id = merged_segment.id();
 
     let segment_meta = index.new_segment_meta(merged_segment_id, num_docs);
-    Ok(SegmentEntry::new(segment_meta, delete_cursor, None))
+    Ok(Some(SegmentEntry::new(segment_meta, delete_cursor, None)))
 }
 
 /// Advanced: Merges a list of segments from different indices in a new index.
@@ -475,7 +483,7 @@ impl SegmentUpdater {
     // suggested and the moment when it ended up being executed.)
     //
     // `segment_ids` is required to be non-empty.
-    pub fn start_merge(&self, merge_operation: MergeOperation) -> FutureResult<SegmentMeta> {
+    pub fn start_merge(&self, merge_operation: MergeOperation) -> FutureResult<()> {
         assert!(
             !merge_operation.segment_ids().is_empty(),
             "Segment_ids cannot be empty."
@@ -512,9 +520,8 @@ impl SegmentUpdater {
                 merge_operation.target_opstamp(),
             ) {
                 Ok(after_merge_segment_entry) => {
-                    let segment_meta_res =
-                        segment_updater.end_merge(merge_operation, after_merge_segment_entry);
-                    let _send_result = merging_future_send.send(segment_meta_res);
+                    let res = segment_updater.end_merge(merge_operation, after_merge_segment_entry);
+                    let _send_result = merging_future_send.send(res);
                 }
                 Err(merge_error) => {
                     warn!(
@@ -522,8 +529,10 @@ impl SegmentUpdater {
                         merge_operation.segment_ids().to_vec(),
                         merge_error
                     );
+                    if cfg!(test) {
+                        panic!("{:?}", merge_error);
+                    }
                     let _send_result = merging_future_send.send(Err(merge_error));
-                    assert!(!cfg!(test), "Merge failed.");
                 }
             }
         });
@@ -573,35 +582,39 @@ impl SegmentUpdater {
     fn end_merge(
         &self,
         merge_operation: MergeOperation,
-        mut after_merge_segment_entry: SegmentEntry,
-    ) -> crate::Result<SegmentMeta> {
+        mut after_merge_segment_entry: Option<SegmentEntry>,
+    ) -> crate::Result<()> {
         let segment_updater = self.clone();
-        let after_merge_segment_meta = after_merge_segment_entry.meta().clone();
         self.schedule_task(move || {
-            info!("End merge {:?}", after_merge_segment_entry.meta());
+            info!(
+                "End merge {:?}",
+                after_merge_segment_entry.as_ref().map(|entry| entry.meta())
+            );
             {
-                let mut delete_cursor = after_merge_segment_entry.delete_cursor().clone();
-                if let Some(delete_operation) = delete_cursor.get() {
-                    let committed_opstamp = segment_updater.load_meta().opstamp;
-                    if delete_operation.opstamp < committed_opstamp {
-                        let index = &segment_updater.index;
-                        let segment = index.segment(after_merge_segment_entry.meta().clone());
-                        if let Err(advance_deletes_err) = advance_deletes(
-                            segment,
-                            &mut after_merge_segment_entry,
-                            committed_opstamp,
-                        ) {
-                            error!(
-                                "Merge of {:?} was cancelled (advancing deletes failed): {:?}",
-                                merge_operation.segment_ids(),
-                                advance_deletes_err
-                            );
-                            assert!(!cfg!(test), "Merge failed.");
+                if let Some(mut after_merge_segment_entry) = after_merge_segment_entry.as_mut() {
+                    let mut delete_cursor = after_merge_segment_entry.delete_cursor().clone();
+                    if let Some(delete_operation) = delete_cursor.get() {
+                        let committed_opstamp = segment_updater.load_meta().opstamp;
+                        if delete_operation.opstamp < committed_opstamp {
+                            let index = &segment_updater.index;
+                            let segment = index.segment(after_merge_segment_entry.meta().clone());
+                            if let Err(advance_deletes_err) = advance_deletes(
+                                segment,
+                                &mut after_merge_segment_entry,
+                                committed_opstamp,
+                            ) {
+                                error!(
+                                    "Merge of {:?} was cancelled (advancing deletes failed): {:?}",
+                                    merge_operation.segment_ids(),
+                                    advance_deletes_err
+                                );
+                                assert!(!cfg!(test), "Merge failed.");
 
-                            // ... cancel merge
-                            // `merge_operations` are tracked. As it is dropped, the
-                            // the segment_ids will be available again for merge.
-                            return Err(advance_deletes_err);
+                                // ... cancel merge
+                                // `merge_operations` are tracked. As it is dropped, the
+                                // the segment_ids will be available again for merge.
+                                return Err(advance_deletes_err);
+                            }
                         }
                     }
                 }
@@ -622,7 +635,7 @@ impl SegmentUpdater {
             Ok(())
         })
         .wait()?;
-        Ok(after_merge_segment_meta)
+        Ok(())
     }
 
     /// Wait for current merging threads.


### PR DESCRIPTION
Optionally create a segment on merge
Create no segment when all segments to merge are empty

fixes #1189
