### PR TITLE
Expose inner file slice for fieldnorms

### DIFF
--- a/src/core/segment_reader.rs
+++ b/src/core/segment_reader.rs
@@ -128,7 +128,8 @@ impl SegmentReader {
         })
     }
 
-    pub(crate) fn fieldnorms_readers(&self) -> &FieldNormReaders {
+    #[doc(hidden)]
+    pub fn fieldnorms_readers(&self) -> &FieldNormReaders {
         &self.fieldnorm_readers
     }
 

--- a/src/fieldnorm/reader.rs
+++ b/src/fieldnorm/reader.rs
@@ -40,6 +40,11 @@ impl FieldNormReaders {
     pub fn space_usage(&self) -> PerFieldSpaceUsage {
         self.data.space_usage()
     }
+
+    /// Returns a handle to inner file
+    pub fn get_inner_file(&self) -> Arc<CompositeFile> {
+        self.data.clone()
+    }
 }
 
 /// Reads the fieldnorm associated to a document.


### PR DESCRIPTION
We need the inner file slice to fetch fieldnorms in Quickwit.
PR is very trivial, just exposing a couple of stuff.