### PR TITLE
Support for SnippetGenerator in async context

### DIFF
--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -210,8 +210,8 @@ impl SegmentRangeCollector {
                 let key = range
                     .key
                     .clone()
-                    .map(|key| Key::Str(key))
-                    .unwrap_or(range_to_key(&range.range, &field_type));
+                    .map(Key::Str)
+                    .unwrap_or_else(|| range_to_key(&range.range, &field_type));
                 let to = if range.range.end == u64::MAX {
                     None
                 } else {

--- a/src/core/inverted_index_reader.rs
+++ b/src/core/inverted_index_reader.rs
@@ -230,4 +230,13 @@ impl InvertedIndexReader {
         }
         Ok(())
     }
+
+    /// Returns the number of documents containing the term asynchronously.
+    pub async fn doc_freq_async(&self, term: &Term) -> crate::AsyncIoResult<u32> {
+        Ok(self
+            .get_term_info_async(term)
+            .await?
+            .map(|term_info| term_info.doc_freq)
+            .unwrap_or(0u32))
+    }
 }

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -134,6 +134,19 @@ impl Searcher {
         Ok(total_doc_freq)
     }
 
+    /// Return the overall number of documents containing
+    /// the given term in an asynchronous manner.
+    #[cfg(feature = "quickwit")]
+    pub async fn doc_freq_async(&self, term: &Term) -> crate::Result<u64> {
+        let mut total_doc_freq = 0;
+        for segment_reader in &self.inner.segment_readers {
+            let inverted_index = segment_reader.inverted_index(term.field())?;
+            let doc_freq = inverted_index.doc_freq_async(term).await?;
+            total_doc_freq += u64::from(doc_freq);
+        }
+        Ok(total_doc_freq)
+    }
+
     /// Return the list of segment readers
     pub fn segment_readers(&self) -> &[SegmentReader] {
         &self.inner.segment_readers

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -69,7 +69,12 @@ impl Snippet {
         }
     }
 
-    /// Returns a hignlightned html from the `Snippet`.
+    /// Returns `true` if the snippet is empty.
+    pub fn is_empty(&self) -> bool {
+        self.highlighted.len() == 0
+    }
+
+    /// Returns a highlighted html from the `Snippet`.
     pub fn to_html(&self) -> String {
         let mut html = String::new();
         let mut start_from: usize = 0;
@@ -230,6 +235,20 @@ pub struct SnippetGenerator {
 }
 
 impl SnippetGenerator {
+    /// Creates a new snippet generator
+    pub fn new(
+        terms_text: BTreeMap<String, Score>,
+        tokenizer: TextAnalyzer,
+        field: Field,
+        max_num_chars: usize,
+    ) -> Self {
+        SnippetGenerator {
+            terms_text,
+            tokenizer,
+            field,
+            max_num_chars,
+        }
+    }
     /// Creates a new snippet generator
     pub fn create(
         searcher: &Searcher,
@@ -460,6 +479,7 @@ Survey in 2016, 2017, and 2018."#;
         let snippet = select_best_fragment_combination(&fragments[..], text);
         assert_eq!(snippet.fragment, "");
         assert_eq!(snippet.to_html(), "");
+        assert!(snippet.is_empty());
     }
 
     #[test]
@@ -473,6 +493,7 @@ Survey in 2016, 2017, and 2018."#;
         let snippet = select_best_fragment_combination(&fragments[..], text);
         assert_eq!(snippet.fragment, "");
         assert_eq!(snippet.to_html(), "");
+        assert!(snippet.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Added few methods to allow creating `SinppetGenerator` in an async context outside of Tantivy.
- added `doc_freq_async` to `InvertedIndexReader` 
- added `new` method to `SnippetGenerator`

Closes https://github.com/quickwit-oss/tantivy/issues/1443