### PR TITLE
fix bench for api change

### DIFF
--- a/fastfield_codecs/benches/bench.rs
+++ b/fastfield_codecs/benches/bench.rs
@@ -35,10 +35,10 @@ mod tests {
     ) {
         let mut bytes = vec![];
         S::serialize(&mut bytes, &data, stats_from_vec(data)).unwrap();
-        let reader = R::open_from_bytes(&bytes).unwrap();
+        let reader = R::open_from_bytes(OwnedBytes::new(bytes)).unwrap();
         b.iter(|| {
             for pos in value_iter() {
-                reader.get_u64(pos as u64, &bytes);
+                reader.get_u64(pos as u64);
             }
         });
     }
@@ -49,6 +49,7 @@ mod tests {
         });
     }
 
+    use ownedbytes::OwnedBytes;
     use test::Bencher;
     #[bench]
     fn bench_fastfield_bitpack_create(b: &mut Bencher) {

--- a/fastfield_codecs/src/lib.rs
+++ b/fastfield_codecs/src/lib.rs
@@ -87,7 +87,7 @@ impl FastFieldDataAccess for Vec<u64> {
         self[position as usize]
     }
     fn iter<'b>(&'b self) -> Box<dyn Iterator<Item = u64> + 'b> {
-        Box::new((&self as &[u64]).iter().cloned())
+        Box::new((self as &[u64]).iter().cloned())
     }
 }
 


### PR DESCRIPTION
```
running 6 tests
test tests::bench_fastfield_bitpack_create             ... bench:     107,127 ns/iter (+/- 3,858)
test tests::bench_fastfield_bitpack_get                ... bench:       5,182 ns/iter (+/- 52)
test tests::bench_fastfield_linearinterpol_create      ... bench:     245,936 ns/iter (+/- 4,849)
test tests::bench_fastfield_linearinterpol_get         ... bench:       5,199 ns/iter (+/- 80)
test tests::bench_fastfield_multilinearinterpol_create ... bench:     383,690 ns/iter (+/- 6,445)
test tests::bench_fastfield_multilinearinterpol_get    ... bench:      15,421 ns/iter (+/- 359)
```