### PR TITLE
RFC: Use a more general but still object-safe signature for Query::query_terms.

### DIFF
--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use super::boolean_weight::BooleanWeight;
 use crate::query::{Occur, Query, SumWithCoordsCombiner, TermQuery, Weight};
 use crate::schema::{IndexRecordOption, Term};
@@ -160,9 +158,9 @@ impl Query for BooleanQuery {
         )))
     }
 
-    fn query_terms(&self, terms: &mut BTreeMap<Term, bool>) {
+    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
         for (_occur, subquery) in &self.subqueries {
-            subquery.query_terms(terms);
+            subquery.query_terms(visitor);
         }
     }
 }

--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -158,7 +158,7 @@ impl Query for BooleanQuery {
         )))
     }
 
-    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
+    fn query_terms<'a>(&'a self, visitor: &mut dyn FnMut(&'a Term, bool)) {
         for (_occur, subquery) in &self.subqueries {
             subquery.query_terms(visitor);
         }

--- a/src/query/boost_query.rs
+++ b/src/query/boost_query.rs
@@ -48,7 +48,7 @@ impl Query for BoostQuery {
         Ok(boosted_weight)
     }
 
-    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
+    fn query_terms<'a>(&'a self, visitor: &mut dyn FnMut(&'a Term, bool)) {
         self.query.query_terms(visitor)
     }
 }

--- a/src/query/boost_query.rs
+++ b/src/query/boost_query.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::fmt;
 
 use crate::fastfield::AliveBitSet;
@@ -49,8 +48,8 @@ impl Query for BoostQuery {
         Ok(boosted_weight)
     }
 
-    fn query_terms(&self, terms: &mut BTreeMap<Term, bool>) {
-        self.query.query_terms(terms)
+    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
+        self.query.query_terms(visitor)
     }
 }
 

--- a/src/query/disjunction_max_query.rs
+++ b/src/query/disjunction_max_query.rs
@@ -105,7 +105,7 @@ impl Query for DisjunctionMaxQuery {
         )))
     }
 
-    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
+    fn query_terms<'a>(&'a self, visitor: &mut dyn FnMut(&'a Term, bool)) {
         for disjunct in &self.disjuncts {
             disjunct.query_terms(visitor);
         }

--- a/src/query/disjunction_max_query.rs
+++ b/src/query/disjunction_max_query.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use tantivy_query_grammar::Occur;
 
 use crate::query::{BooleanWeight, DisjunctionMaxCombiner, Query, Weight};
@@ -107,9 +105,9 @@ impl Query for DisjunctionMaxQuery {
         )))
     }
 
-    fn query_terms(&self, terms: &mut BTreeMap<Term, bool>) {
+    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
         for disjunct in &self.disjuncts {
-            disjunct.query_terms(terms);
+            disjunct.query_terms(visitor);
         }
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -64,8 +64,6 @@ pub use self::weight::Weight;
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use crate::query::QueryParser;
     use crate::schema::{Schema, TEXT};
     use crate::{Index, Term};
@@ -80,49 +78,47 @@ mod tests {
         let term_a = Term::from_field_text(text_field, "a");
         let term_b = Term::from_field_text(text_field, "b");
         {
-            let mut terms: BTreeMap<Term, bool> = Default::default();
+            let mut terms: Vec<(Term, bool)> = Default::default();
             query_parser
                 .parse_query("a")
                 .unwrap()
-                .query_terms(&mut terms);
-            let terms: Vec<(&Term, &bool)> = terms.iter().collect();
-            assert_eq!(vec![(&term_a, &false)], terms);
+                .query_terms(&mut |term, pos| terms.push((term.clone(), pos)));
+            assert_eq!(vec![(term_a.clone(), false)], terms);
         }
         {
-            let mut terms: BTreeMap<Term, bool> = Default::default();
+            let mut terms: Vec<(Term, bool)> = Default::default();
             query_parser
                 .parse_query("a b")
                 .unwrap()
-                .query_terms(&mut terms);
-            let terms: Vec<(&Term, &bool)> = terms.iter().collect();
-            assert_eq!(vec![(&term_a, &false), (&term_b, &false)], terms);
+                .query_terms(&mut |term, pos| terms.push((term.clone(), pos)));
+            assert_eq!(
+                vec![(term_a.clone(), false), (term_b.clone(), false)],
+                terms
+            );
         }
         {
-            let mut terms: BTreeMap<Term, bool> = Default::default();
+            let mut terms: Vec<(Term, bool)> = Default::default();
             query_parser
                 .parse_query("\"a b\"")
                 .unwrap()
-                .query_terms(&mut terms);
-            let terms: Vec<(&Term, &bool)> = terms.iter().collect();
-            assert_eq!(vec![(&term_a, &true), (&term_b, &true)], terms);
+                .query_terms(&mut |term, pos| terms.push((term.clone(), pos)));
+            assert_eq!(vec![(term_a.clone(), true), (term_b.clone(), true)], terms);
         }
         {
-            let mut terms: BTreeMap<Term, bool> = Default::default();
+            let mut terms: Vec<(Term, bool)> = Default::default();
             query_parser
                 .parse_query("a a a a a")
                 .unwrap()
-                .query_terms(&mut terms);
-            let terms: Vec<(&Term, &bool)> = terms.iter().collect();
-            assert_eq!(vec![(&term_a, &false)], terms);
+                .query_terms(&mut |term, pos| terms.push((term.clone(), pos)));
+            assert_eq!(vec![(term_a.clone(), false); 5], terms);
         }
         {
-            let mut terms: BTreeMap<Term, bool> = Default::default();
+            let mut terms: Vec<(Term, bool)> = Default::default();
             query_parser
                 .parse_query("a -b")
                 .unwrap()
-                .query_terms(&mut terms);
-            let terms: Vec<(&Term, &bool)> = terms.iter().collect();
-            assert_eq!(vec![(&term_a, &false), (&term_b, &false)], terms);
+                .query_terms(&mut |term, pos| terms.push((term.clone(), pos)));
+            assert_eq!(vec![(term_a, false), (term_b, false)], terms);
         }
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -78,47 +78,34 @@ mod tests {
         let term_a = Term::from_field_text(text_field, "a");
         let term_b = Term::from_field_text(text_field, "b");
         {
-            let mut terms: Vec<(Term, bool)> = Default::default();
-            query_parser
-                .parse_query("a")
-                .unwrap()
-                .query_terms(&mut |term, pos| terms.push((term.clone(), pos)));
-            assert_eq!(vec![(term_a.clone(), false)], terms);
+            let query = query_parser.parse_query("a").unwrap();
+            let mut terms = Vec::new();
+            query.query_terms(&mut |term, pos| terms.push((term, pos)));
+            assert_eq!(vec![(&term_a, false)], terms);
         }
         {
-            let mut terms: Vec<(Term, bool)> = Default::default();
-            query_parser
-                .parse_query("a b")
-                .unwrap()
-                .query_terms(&mut |term, pos| terms.push((term.clone(), pos)));
-            assert_eq!(
-                vec![(term_a.clone(), false), (term_b.clone(), false)],
-                terms
-            );
+            let query = query_parser.parse_query("a b").unwrap();
+            let mut terms = Vec::new();
+            query.query_terms(&mut |term, pos| terms.push((term, pos)));
+            assert_eq!(vec![(&term_a, false), (&term_b, false)], terms);
         }
         {
-            let mut terms: Vec<(Term, bool)> = Default::default();
-            query_parser
-                .parse_query("\"a b\"")
-                .unwrap()
-                .query_terms(&mut |term, pos| terms.push((term.clone(), pos)));
-            assert_eq!(vec![(term_a.clone(), true), (term_b.clone(), true)], terms);
+            let query = query_parser.parse_query("\"a b\"").unwrap();
+            let mut terms = Vec::new();
+            query.query_terms(&mut |term, pos| terms.push((term, pos)));
+            assert_eq!(vec![(&term_a, true), (&term_b, true)], terms);
         }
         {
-            let mut terms: Vec<(Term, bool)> = Default::default();
-            query_parser
-                .parse_query("a a a a a")
-                .unwrap()
-                .query_terms(&mut |term, pos| terms.push((term.clone(), pos)));
-            assert_eq!(vec![(term_a.clone(), false); 5], terms);
+            let query = query_parser.parse_query("a a a a a").unwrap();
+            let mut terms = Vec::new();
+            query.query_terms(&mut |term, pos| terms.push((term, pos)));
+            assert_eq!(vec![(&term_a, false); 5], terms);
         }
         {
-            let mut terms: Vec<(Term, bool)> = Default::default();
-            query_parser
-                .parse_query("a -b")
-                .unwrap()
-                .query_terms(&mut |term, pos| terms.push((term.clone(), pos)));
-            assert_eq!(vec![(term_a, false), (term_b, false)], terms);
+            let query = query_parser.parse_query("a -b").unwrap();
+            let mut terms = Vec::new();
+            query.query_terms(&mut |term, pos| terms.push((term, pos)));
+            assert_eq!(vec![(&term_a, false), (&term_b, false)], terms);
         }
     }
 }

--- a/src/query/phrase_query/phrase_query.rs
+++ b/src/query/phrase_query/phrase_query.rs
@@ -127,7 +127,7 @@ impl Query for PhraseQuery {
         Ok(Box::new(phrase_weight))
     }
 
-    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
+    fn query_terms<'a>(&'a self, visitor: &mut dyn FnMut(&'a Term, bool)) {
         for (_, term) in &self.phrase_terms {
             visitor(term, true);
         }

--- a/src/query/phrase_query/phrase_query.rs
+++ b/src/query/phrase_query/phrase_query.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use super::PhraseWeight;
 use crate::core::searcher::Searcher;
 use crate::query::bm25::Bm25Weight;
@@ -129,9 +127,9 @@ impl Query for PhraseQuery {
         Ok(Box::new(phrase_weight))
     }
 
-    fn query_terms(&self, terms: &mut BTreeMap<Term, bool>) {
+    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
         for (_, term) in &self.phrase_terms {
-            terms.insert(term.clone(), true);
+            visitor(term, true);
         }
     }
 }

--- a/src/query/query.rs
+++ b/src/query/query.rs
@@ -74,7 +74,7 @@ pub trait Query: QueryClone + Send + Sync + downcast_rs::Downcast + fmt::Debug {
     ///
     /// Note that there can be multiple instances of any given term
     /// in a query and deduplication must be handled by the visitor.
-    fn query_terms(&self, _visitor: &mut dyn FnMut(&Term, bool)) {}
+    fn query_terms<'a>(&'a self, _visitor: &mut dyn FnMut(&'a Term, bool)) {}
 }
 
 /// Implements `box_clone`.
@@ -100,7 +100,7 @@ impl Query for Box<dyn Query> {
         self.as_ref().count(searcher)
     }
 
-    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
+    fn query_terms<'a>(&'a self, visitor: &mut dyn FnMut(&'a Term, bool)) {
         self.as_ref().query_terms(visitor);
     }
 }

--- a/src/query/term_query/term_query.rs
+++ b/src/query/term_query/term_query.rs
@@ -120,7 +120,7 @@ impl Query for TermQuery {
             self.specialized_weight(searcher, scoring_enabled)?,
         ))
     }
-    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
+    fn query_terms<'a>(&'a self, visitor: &mut dyn FnMut(&'a Term, bool)) {
         visitor(&self.term, false);
     }
 }

--- a/src/query/term_query/term_query.rs
+++ b/src/query/term_query/term_query.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::fmt;
 
 use super::term_weight::TermWeight;
@@ -121,7 +120,7 @@ impl Query for TermQuery {
             self.specialized_weight(searcher, scoring_enabled)?,
         ))
     }
-    fn query_terms(&self, terms: &mut BTreeMap<Term, bool>) {
-        terms.insert(self.term.clone(), false);
+    fn query_terms(&self, visitor: &mut dyn FnMut(&Term, bool)) {
+        visitor(&self.term, false);
     }
 }

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Range;
 
 use htmlescape::encode_minimal;
@@ -255,13 +255,14 @@ impl SnippetGenerator {
         query: &dyn Query,
         field: Field,
     ) -> crate::Result<SnippetGenerator> {
-        let mut terms = BTreeMap::new();
-        query.query_terms(&mut terms);
-        let mut terms_text: BTreeMap<String, Score> = Default::default();
-        for (term, _) in terms {
-            if term.field() != field {
-                continue;
+        let mut terms = BTreeSet::new();
+        query.query_terms(&mut |term, _| {
+            if term.field() == field {
+                terms.insert(term.clone());
             }
+        });
+        let mut terms_text: BTreeMap<String, Score> = Default::default();
+        for term in terms {
             let term_str = if let Some(term_str) = term.as_str() {
                 term_str
             } else {

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -258,7 +258,7 @@ impl SnippetGenerator {
         let mut terms = BTreeSet::new();
         query.query_terms(&mut |term, _| {
             if term.field() == field {
-                terms.insert(term.clone());
+                terms.insert(term);
             }
         });
         let mut terms_text: BTreeMap<String, Score> = Default::default();


### PR DESCRIPTION
`BTreeMap` is a relatively specific data structure and the current signature enforces allocating a new collection and cloning the terms even if the consumer only needs to inspect a subset of the terms.

This PR is a breaking change which aims to avoid this by using a closure to visit each of the terms contained in the query. The closure is passed as a trait object to keep the `Query` trait it self object-safe.

The approach has the downside of pushing deduplication of identical terms into the visitor. But it also gives consumers the option of e.g. counting multiplicities.