### PR TITLE
Cache dependencies in CI to speed up build times.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup toolchain install nightly --component llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
         run: cargo +nightly llvm-cov --all-features --workspace --lcov --output-path lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
             override: true
             components: rustfmt, clippy
 
+    - uses: Swatinem/rust-cache@v2
+
     - name: Build
       run: cargo build --verbose --workspace
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,16 +30,23 @@ jobs:
             override: true
             components: rustfmt, clippy
 
+    - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2
 
     - name: Build
       run: cargo build --verbose --workspace
 
     - name: Run tests
-      run: cargo +stable test --features mmap,brotli-compression,lz4-compression,snappy-compression,zstd-compression,failpoints --verbose --workspace
+      run: cargo +stable nextest run --features mmap,brotli-compression,lz4-compression,snappy-compression,zstd-compression,failpoints --verbose --workspace
+
+    - name: Run doctests
+      run: cargo +stable test --doc --features mmap,brotli-compression,lz4-compression,snappy-compression,zstd-compression,failpoints --verbose --workspace
 
     - name: Run tests quickwit feature
-      run: cargo +stable test --features mmap,quickwit,failpoints --verbose --workspace
+      run: cargo +stable nextest run --features mmap,quickwit,failpoints --verbose --workspace
+
+    - name: Run doctests quickwit feature
+      run: cargo +stable test --doc  --features mmap,quickwit,failpoints --verbose --workspace
 
     - name: Check Formatting
       run: cargo +nightly fmt --all -- --check


### PR DESCRIPTION
I am not sure how effective this is due mixing stable and nightly within a workflow and whether it was tried before, but I have had good experiences using the [`rust-cache`](https://github.com/Swatinem/rust-cache) action myself.