### PR TITLE
Split test into check and test CI jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
-        run: rustup toolchain install nightly --component llvm-tools-preview
+        run: rustup toolchain install nightly --profile minimal --component llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage

--- a/.github/workflows/long_running.yml
+++ b/.github/workflows/long_running.yml
@@ -19,11 +19,10 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
           toolchain: stable
+          profile: minimal
           override: true
-          components: rustfmt, clippy
 
     - name: Run indexing_unsorted
       run: cargo test indexing_unsorted -- --ignored
     - name: Run indexing_sorted
       run: cargo test indexing_sorted -- --ignored
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,15 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        features: [
+            { label: "all", flags: "mmap,brotli-compression,lz4-compression,snappy-compression,zstd-compression,failpoints" },
+            { label: "quickwit", flags: "mmap,quickwit,failpoints" }
+        ]
+
+    name: test-${{ matrix.features.label}}
+
     steps:
     - uses: actions/checkout@v3
 
@@ -58,17 +67,8 @@ jobs:
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2
 
-    - name: Build
-      run: cargo build --verbose --workspace
-
     - name: Run tests
-      run: cargo +stable nextest run --features mmap,brotli-compression,lz4-compression,snappy-compression,zstd-compression,failpoints --verbose --workspace
+      run: cargo +stable nextest run --features ${{ matrix.features.flags }} --verbose --workspace
 
     - name: Run doctests
-      run: cargo +stable test --doc --features mmap,brotli-compression,lz4-compression,snappy-compression,zstd-compression,failpoints --verbose --workspace
-
-    - name: Run tests quickwit feature
-      run: cargo +stable nextest run --features mmap,quickwit,failpoints --verbose --workspace
-
-    - name: Run doctests quickwit feature
-      run: cargo +stable test --doc  --features mmap,quickwit,failpoints --verbose --workspace
+      run: cargo +stable test --doc --features ${{ matrix.features.flags }} --verbose --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,25 +10,50 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install nightly
+      uses: actions-rs/toolchain@v1
+      with:
+            toolchain: nightly
+            profile: minimal
+            components: rustfmt
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+            toolchain: stable
+            profile: minimal
+            components: clippy
+
+    - uses: Swatinem/rust-cache@v2
+
+    - name: Check Formatting
+      run: cargo +nightly fmt --all -- --check
+
+    - uses: actions-rs/clippy-check@v1
+      with:
+        toolchain: stable
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --tests
+
   test:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
-    - name: Install latest nightly to test also against unstable feature flag
-      uses: actions-rs/toolchain@v1
-      with:
-            toolchain: nightly
-            override: true
-            components: rustfmt
 
     - name: Install stable
       uses: actions-rs/toolchain@v1
       with:
             toolchain: stable
+            profile: minimal
             override: true
-            components: rustfmt, clippy
 
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2
@@ -47,13 +72,3 @@ jobs:
 
     - name: Run doctests quickwit feature
       run: cargo +stable test --doc  --features mmap,quickwit,failpoints --verbose --workspace
-
-    - name: Check Formatting
-      run: cargo +nightly fmt --all -- --check
-
-    - uses: actions-rs/clippy-check@v1
-      with:
-        toolchain: stable
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --tests
-


### PR DESCRIPTION
Sorry for not making this part of the earlier CI PR but I did not get this far in time.

~~In contrast to the comment in the workflow definition, the nightly toolchain seems to have been used only for formatting but not for testing in the CI. Hence, this PR drops it to reduce the toolchain installation step. (There can also be only one override toolchain per directory.)~~

EDIT: Still installing a minimal nightly toolchain to keep the existing formatting...

In addition, it proposes splitting up the test job into a check (Rustfmt, Clippy) and test job (unit tests and doc tests) to gain a bit of parallelism in the CI. This seems especially useful to get early feedback for commits which fail due to formatting or linting.