### PR TITLE
Collapse overlapped highlighted ranges

### DIFF
--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -198,7 +198,7 @@ fn collapse_overlapped_ranges(ranges: &Vec<Range<usize>>) -> Vec<Range<usize>> {
 
     for range in ranges {
         if current.end > range.start {
-            current = current.start..range.end;
+            current = current.start..std::cmp::max(current.end, range.end);
         } else {
             result.push(current);
             current = range.clone();
@@ -618,6 +618,7 @@ Survey in 2016, 2017, and 2018."#;
         assert_eq!(collapse_overlapped_ranges(&vec![0..1, 1..2, ]), vec![0..1, 1..2]);
         assert_eq!(collapse_overlapped_ranges(&vec![0..2, 1..2, ]), vec![0..2]);
         assert_eq!(collapse_overlapped_ranges(&vec![0..2, 1..3, ]), vec![0..3]);
+        assert_eq!(collapse_overlapped_ranges(&vec![0..3, 1..2, ]), vec![0..3]);
     }
 
     #[test]

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -220,7 +220,7 @@ fn collapse_overlapped_ranges(ranges: &[Range<usize>]) -> Vec<Range<usize>> {
     result
 }
 
-fn is_sorted(mut it: impl Iterator<Item=usize>) -> bool {
+fn is_sorted(mut it: impl Iterator<Item = usize>) -> bool {
     if let Some(first) = it.next() {
         let mut prev = first;
         for item in it {
@@ -367,10 +367,10 @@ mod tests {
 
     use maplit::btreemap;
 
-    use super::{search_fragments, select_best_fragment_combination, collapse_overlapped_ranges};
+    use super::{collapse_overlapped_ranges, search_fragments, select_best_fragment_combination};
     use crate::query::QueryParser;
     use crate::schema::{IndexRecordOption, Schema, TextFieldIndexing, TextOptions, TEXT};
-    use crate::tokenizer::{SimpleTokenizer, NgramTokenizer};
+    use crate::tokenizer::{NgramTokenizer, SimpleTokenizer};
     use crate::{Index, SnippetGenerator};
 
     const TEST_TEXT: &str = r#"Rust is a systems programming language sponsored by
@@ -638,11 +638,17 @@ Survey in 2016, 2017, and 2018."#;
 
     #[test]
     fn test_collapse_overlapped_ranges() {
-        assert_eq!(collapse_overlapped_ranges(&vec![0..1, 2..3, ]), vec![0..1, 2..3]);
-        assert_eq!(collapse_overlapped_ranges(&vec![0..1, 1..2, ]), vec![0..1, 1..2]);
-        assert_eq!(collapse_overlapped_ranges(&vec![0..2, 1..2, ]), vec![0..2]);
-        assert_eq!(collapse_overlapped_ranges(&vec![0..2, 1..3, ]), vec![0..3]);
-        assert_eq!(collapse_overlapped_ranges(&vec![0..3, 1..2, ]), vec![0..3]);
+        assert_eq!(
+            collapse_overlapped_ranges(&vec![0..1, 2..3,]),
+            vec![0..1, 2..3]
+        );
+        assert_eq!(
+            collapse_overlapped_ranges(&vec![0..1, 1..2,]),
+            vec![0..1, 1..2]
+        );
+        assert_eq!(collapse_overlapped_ranges(&vec![0..2, 1..2,]), vec![0..2]);
+        assert_eq!(collapse_overlapped_ranges(&vec![0..2, 1..3,]), vec![0..3]);
+        assert_eq!(collapse_overlapped_ranges(&vec![0..3, 1..2,]), vec![0..3]);
     }
 
     #[test]
@@ -653,7 +659,12 @@ Survey in 2016, 2017, and 2018."#;
         terms.insert(String::from("ab"), 0.9);
         terms.insert(String::from("bc"), 1.0);
 
-        let fragments = search_fragments(&From::from(NgramTokenizer::all_ngrams(2, 2)), text, &terms, 3);
+        let fragments = search_fragments(
+            &From::from(NgramTokenizer::all_ngrams(2, 2)),
+            text,
+            &terms,
+            3,
+        );
 
         assert_eq!(fragments.len(), 1);
         {

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -79,7 +79,7 @@ impl Snippet {
         let mut html = String::new();
         let mut start_from: usize = 0;
 
-        for item in collapse_overlapped_ranges(&self.highlighted).iter() {
+        for item in collapse_overlapped_ranges(&self.highlighted) {
             html.push_str(&encode_minimal(&self.fragment[start_from..item.start]));
             html.push_str(HIGHLIGHTEN_PREFIX);
             html.push_str(&encode_minimal(&self.fragment[item.clone()]));
@@ -187,11 +187,11 @@ fn select_best_fragment_combination(fragments: &[FragmentCandidate], text: &str)
 }
 
 /// Returns ranges that are collapsed into non-overlapped ranges.
-fn collapse_overlapped_ranges(ranges: &Vec<Range<usize>>) -> Vec<Range<usize>> {
+fn collapse_overlapped_ranges(ranges: &[Range<usize>]) -> Vec<Range<usize>> {
     let mut result = Vec::new();
-    let mut ranges = ranges.iter();
+    let mut ranges_it = ranges.iter();
 
-    let mut current = match ranges.next() {
+    let mut current = match ranges_it.next() {
         Some(range) => range.clone(),
         None => return result,
     };

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -188,14 +188,15 @@ fn select_best_fragment_combination(fragments: &[FragmentCandidate], text: &str)
 
 /// Returns ranges that are collapsed into non-overlapped ranges.
 fn collapse_overlapped_ranges(ranges: &Vec<Range<usize>>) -> Vec<Range<usize>> {
-    if ranges.is_empty() {
-        return Vec::new();
-    }
-
     let mut result = Vec::new();
-    let mut current = ranges[0].clone();
+    let mut ranges = ranges.iter();
 
-    for range in ranges.iter().skip(1) {
+    let mut current = match ranges.next() {
+        Some(range) => range.clone(),
+        None => return result,
+    };
+
+    for range in ranges {
         if current.end > range.start {
             current = current.start..range.end;
         } else {

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -187,7 +187,18 @@ fn select_best_fragment_combination(fragments: &[FragmentCandidate], text: &str)
 }
 
 /// Returns ranges that are collapsed into non-overlapped ranges.
+///
+/// ## Examples
+/// - [0..1, 2..3] -> [0..1, 2..3]  # no overlap
+/// - [0..1, 1..2] -> [0..1, 1..2]  # no overlap
+/// - [0..2, 1..2] -> [0..2]  # collapsed
+/// - [0..2, 1..3] -> [0..3]  # collapsed
+/// - [0..3, 1..2] -> [0..3]  # second range's end is also inside of the first range
+///
+/// Note: This function assumes `ranges` is sorted by `Range.start` in ascending order.
 fn collapse_overlapped_ranges(ranges: &[Range<usize>]) -> Vec<Range<usize>> {
+    debug_assert!(is_sorted(ranges.iter().map(|range| range.start)));
+
     let mut result = Vec::new();
     let mut ranges_it = ranges.iter();
 
@@ -207,6 +218,19 @@ fn collapse_overlapped_ranges(ranges: &[Range<usize>]) -> Vec<Range<usize>> {
 
     result.push(current);
     result
+}
+
+fn is_sorted(mut it: impl Iterator<Item=usize>) -> bool {
+    if let Some(first) = it.next() {
+        let mut prev = first;
+        for item in it {
+            if item < prev {
+                return false;
+            }
+            prev = item;
+        }
+    }
+    true
 }
 
 /// `SnippetGenerator`

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -346,7 +346,7 @@ mod tests {
     use super::{search_fragments, select_best_fragment_combination, collapse_overlapped_ranges};
     use crate::query::QueryParser;
     use crate::schema::{IndexRecordOption, Schema, TextFieldIndexing, TextOptions, TEXT};
-    use crate::tokenizer::{SimpleTokenizer, NgramTokenizer, Tokenizer};
+    use crate::tokenizer::{SimpleTokenizer, NgramTokenizer};
     use crate::{Index, SnippetGenerator};
 
     const TEST_TEXT: &str = r#"Rust is a systems programming language sponsored by
@@ -629,7 +629,6 @@ Survey in 2016, 2017, and 2018."#;
         terms.insert(String::from("bc"), 1.0);
 
         let fragments = search_fragments(&From::from(NgramTokenizer::all_ngrams(2, 2)), text, &terms, 3);
-        println!("{:?}", fragments);
 
         assert_eq!(fragments.len(), 1);
         {


### PR DESCRIPTION
Hi. This fixes a problem that occurs when calling `Snippet.to_html()` and the `snippet.highlighted` are overlapped ranges like this:
```
[0..2, 1..3]
```
This type of ranges is generated by `NgramTokenizer`, for example.

### Error
In that case, there will be an error on calling `Snippet.to_html()`, which is caused by slicing `String` with invalid indices.
```
begin <= end (2 <= 1) when slicing `abc`
thread 'snippet::tests::test_snippet_with_overlapped_highlighted_ranges' panicked at 'begin <= end (2 <= 1) when slicing `abc`', library/core/src/str/mod.rs:111:5
stack backtrace:
...
   9: tantivy::snippet::Snippet::to_html
             at ./src/snippet/mod.rs:84:44
```

### Fix
This PR collapses overlapped ranges into non-overlapped ones to fix the problem like this:
```
[0..2, 1..3] -> [0..3]
```
