### PR TITLE
merge FastFieldCodecReader wit FastFieldDataAccess

### DIFF
--- a/fastfield_codecs/benches/bench.rs
+++ b/fastfield_codecs/benches/bench.rs
@@ -38,7 +38,7 @@ mod tests {
         b.iter(|| {
             let mut sum = 0u64;
             for pos in value_iter() {
-                let val = reader.get_u64(pos as u64);
+                let val = reader.get_val(pos as u64);
                 debug_assert_eq!(data[pos as usize], val);
                 sum = sum.wrapping_add(val);
             }

--- a/fastfield_codecs/benches/bench.rs
+++ b/fastfield_codecs/benches/bench.rs
@@ -27,7 +27,7 @@ mod tests {
     }
     fn bench_get<
         S: FastFieldCodecSerializer,
-        R: FastFieldCodecDeserializer + FastFieldCodecReader,
+        R: FastFieldCodecDeserializer + FastFieldDataAccess,
     >(
         b: &mut Bencher,
         data: &[u64],

--- a/fastfield_codecs/benches/bench.rs
+++ b/fastfield_codecs/benches/bench.rs
@@ -25,7 +25,10 @@ mod tests {
     fn value_iter() -> impl Iterator<Item = u64> {
         0..20_000
     }
-    fn bench_get<S: FastFieldCodecSerializer, R: FastFieldCodecReader>(
+    fn bench_get<
+        S: FastFieldCodecSerializer,
+        R: FastFieldCodecDeserializer + FastFieldCodecReader,
+    >(
         b: &mut Bencher,
         data: &[u64],
     ) {

--- a/fastfield_codecs/src/bitpacked.rs
+++ b/fastfield_codecs/src/bitpacked.rs
@@ -42,7 +42,7 @@ impl FastFieldCodecDeserializer for BitpackedReader {
 }
 impl FastFieldCodecReader for BitpackedReader {
     #[inline]
-    fn get_u64(&self, doc: u64) -> u64 {
+    fn get_val(&self, doc: u64) -> u64 {
         self.min_value_u64 + self.bit_unpacker.get(doc, &self.data)
     }
     #[inline]

--- a/fastfield_codecs/src/bitpacked.rs
+++ b/fastfield_codecs/src/bitpacked.rs
@@ -5,8 +5,7 @@ use ownedbytes::OwnedBytes;
 use tantivy_bitpacker::{compute_num_bits, BitPacker, BitUnpacker};
 
 use crate::{
-    FastFieldCodecDeserializer, FastFieldCodecReader, FastFieldCodecSerializer, FastFieldCodecType,
-    FastFieldDataAccess,
+    FastFieldCodecDeserializer, FastFieldCodecSerializer, FastFieldCodecType, FastFieldDataAccess,
 };
 
 /// Depending on the field type, a different
@@ -40,7 +39,7 @@ impl FastFieldCodecDeserializer for BitpackedReader {
         })
     }
 }
-impl FastFieldCodecReader for BitpackedReader {
+impl FastFieldDataAccess for BitpackedReader {
     #[inline]
     fn get_val(&self, doc: u64) -> u64 {
         self.min_value_u64 + self.bit_unpacker.get(doc, &self.data)

--- a/fastfield_codecs/src/bitpacked.rs
+++ b/fastfield_codecs/src/bitpacked.rs
@@ -5,7 +5,8 @@ use ownedbytes::OwnedBytes;
 use tantivy_bitpacker::{compute_num_bits, BitPacker, BitUnpacker};
 
 use crate::{
-    FastFieldCodecReader, FastFieldCodecSerializer, FastFieldCodecType, FastFieldDataAccess,
+    FastFieldCodecDeserializer, FastFieldCodecReader, FastFieldCodecSerializer, FastFieldCodecType,
+    FastFieldDataAccess,
 };
 
 /// Depending on the field type, a different
@@ -19,7 +20,7 @@ pub struct BitpackedReader {
     pub num_vals: u64,
 }
 
-impl FastFieldCodecReader for BitpackedReader {
+impl FastFieldCodecDeserializer for BitpackedReader {
     /// Opens a fast field given a file.
     fn open_from_bytes(bytes: OwnedBytes) -> io::Result<Self> {
         let footer_offset = bytes.len() - 24;
@@ -38,6 +39,8 @@ impl FastFieldCodecReader for BitpackedReader {
             num_vals,
         })
     }
+}
+impl FastFieldCodecReader for BitpackedReader {
     #[inline]
     fn get_u64(&self, doc: u64) -> u64 {
         self.min_value_u64 + self.bit_unpacker.get(doc, &self.data)

--- a/fastfield_codecs/src/blockwise_linear.rs
+++ b/fastfield_codecs/src/blockwise_linear.rs
@@ -19,7 +19,8 @@ use tantivy_bitpacker::{compute_num_bits, BitPacker, BitUnpacker};
 
 use crate::linear::{get_calculated_value, get_slope};
 use crate::{
-    FastFieldCodecReader, FastFieldCodecSerializer, FastFieldCodecType, FastFieldDataAccess,
+    FastFieldCodecDeserializer, FastFieldCodecReader, FastFieldCodecSerializer, FastFieldCodecType,
+    FastFieldDataAccess,
 };
 
 const CHUNK_SIZE: u64 = 512;
@@ -148,7 +149,7 @@ fn get_interpolation_function(doc: u64, interpolations: &[Function]) -> &Functio
     &interpolations[get_interpolation_position(doc)]
 }
 
-impl FastFieldCodecReader for BlockwiseLinearReader {
+impl FastFieldCodecDeserializer for BlockwiseLinearReader {
     /// Opens a fast field given a file.
     fn open_from_bytes(bytes: OwnedBytes) -> io::Result<Self> {
         let footer_len: u32 = (&bytes[bytes.len() - 4..]).deserialize()?;
@@ -157,7 +158,9 @@ impl FastFieldCodecReader for BlockwiseLinearReader {
         let footer = BlockwiseLinearFooter::deserialize(&mut footer)?;
         Ok(BlockwiseLinearReader { data, footer })
     }
+}
 
+impl FastFieldCodecReader for BlockwiseLinearReader {
     #[inline]
     fn get_u64(&self, idx: u64) -> u64 {
         let interpolation = get_interpolation_function(idx, &self.footer.interpolations);

--- a/fastfield_codecs/src/blockwise_linear.rs
+++ b/fastfield_codecs/src/blockwise_linear.rs
@@ -19,8 +19,7 @@ use tantivy_bitpacker::{compute_num_bits, BitPacker, BitUnpacker};
 
 use crate::linear::{get_calculated_value, get_slope};
 use crate::{
-    FastFieldCodecDeserializer, FastFieldCodecReader, FastFieldCodecSerializer, FastFieldCodecType,
-    FastFieldDataAccess,
+    FastFieldCodecDeserializer, FastFieldCodecSerializer, FastFieldCodecType, FastFieldDataAccess,
 };
 
 const CHUNK_SIZE: u64 = 512;
@@ -160,7 +159,7 @@ impl FastFieldCodecDeserializer for BlockwiseLinearReader {
     }
 }
 
-impl FastFieldCodecReader for BlockwiseLinearReader {
+impl FastFieldDataAccess for BlockwiseLinearReader {
     #[inline]
     fn get_val(&self, idx: u64) -> u64 {
         let interpolation = get_interpolation_function(idx, &self.footer.interpolations);

--- a/fastfield_codecs/src/blockwise_linear.rs
+++ b/fastfield_codecs/src/blockwise_linear.rs
@@ -162,7 +162,7 @@ impl FastFieldCodecDeserializer for BlockwiseLinearReader {
 
 impl FastFieldCodecReader for BlockwiseLinearReader {
     #[inline]
-    fn get_u64(&self, idx: u64) -> u64 {
+    fn get_val(&self, idx: u64) -> u64 {
         let interpolation = get_interpolation_function(idx, &self.footer.interpolations);
         let in_block_idx = idx - interpolation.start_pos;
         let calculated_value = get_calculated_value(

--- a/fastfield_codecs/src/blockwise_linear.rs
+++ b/fastfield_codecs/src/blockwise_linear.rs
@@ -182,6 +182,10 @@ impl FastFieldCodecReader for BlockwiseLinearReader {
     fn max_value(&self) -> u64 {
         self.footer.max_value
     }
+    #[inline]
+    fn num_vals(&self) -> u64 {
+        self.footer.num_vals
+    }
 }
 
 /// Same as LinearSerializer, but working on chunks of CHUNK_SIZE elements.

--- a/fastfield_codecs/src/lib.rs
+++ b/fastfield_codecs/src/lib.rs
@@ -18,6 +18,7 @@ pub trait FastFieldCodecReader: Sized {
     fn get_u64(&self, doc: u64) -> u64;
     fn min_value(&self) -> u64;
     fn max_value(&self) -> u64;
+    fn num_vals(&self) -> u64;
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
@@ -183,6 +184,7 @@ mod tests {
         let actual_compression = out.len() as f32 / (data.len() as f32 * 8.0);
 
         let reader = R::open_from_bytes(OwnedBytes::new(out)).unwrap();
+        assert_eq!(reader.num_vals(), data.len() as u64);
         for (doc, orig_val) in data.iter().enumerate() {
             let val = reader.get_u64(doc as u64);
             if val != *orig_val {

--- a/fastfield_codecs/src/lib.rs
+++ b/fastfield_codecs/src/lib.rs
@@ -20,13 +20,13 @@ pub trait FastFieldCodecDeserializer: Sized {
 }
 
 pub trait FastFieldCodecReader: Sized {
-    fn get_u64(&self, doc: u64) -> u64;
+    fn get_val(&self, doc: u64) -> u64;
     fn min_value(&self) -> u64;
     fn max_value(&self) -> u64;
     fn num_vals(&self) -> u64;
     /// Returns a iterator over the data
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = u64> + 'a> {
-        Box::new((0..self.num_vals()).map(|idx| self.get_u64(idx)))
+        Box::new((0..self.num_vals()).map(|idx| self.get_val(idx)))
     }
 }
 
@@ -198,7 +198,7 @@ mod tests {
         let reader = R::open_from_bytes(OwnedBytes::new(out)).unwrap();
         assert_eq!(reader.num_vals(), data.len() as u64);
         for (doc, orig_val) in data.iter().enumerate() {
-            let val = reader.get_u64(doc as u64);
+            let val = reader.get_val(doc as u64);
             if val != *orig_val {
                 panic!(
                     "val {val:?} does not match orig_val {orig_val:?}, in data set {name}, data \

--- a/fastfield_codecs/src/linear.rs
+++ b/fastfield_codecs/src/linear.rs
@@ -6,7 +6,8 @@ use ownedbytes::OwnedBytes;
 use tantivy_bitpacker::{compute_num_bits, BitPacker, BitUnpacker};
 
 use crate::{
-    FastFieldCodecReader, FastFieldCodecSerializer, FastFieldCodecType, FastFieldDataAccess,
+    FastFieldCodecDeserializer, FastFieldCodecReader, FastFieldCodecSerializer, FastFieldCodecType,
+    FastFieldDataAccess,
 };
 
 /// Depending on the field type, a different
@@ -59,7 +60,7 @@ impl FixedSize for LinearFooter {
     const SIZE_IN_BYTES: usize = 56;
 }
 
-impl FastFieldCodecReader for LinearReader {
+impl FastFieldCodecDeserializer for LinearReader {
     /// Opens a fast field given a file.
     fn open_from_bytes(bytes: OwnedBytes) -> io::Result<Self> {
         let footer_offset = bytes.len() - LinearFooter::SIZE_IN_BYTES;
@@ -75,6 +76,9 @@ impl FastFieldCodecReader for LinearReader {
             slope,
         })
     }
+}
+
+impl FastFieldCodecReader for LinearReader {
     #[inline]
     fn get_u64(&self, doc: u64) -> u64 {
         let calculated_value = get_calculated_value(self.footer.first_val, doc, self.slope);

--- a/fastfield_codecs/src/linear.rs
+++ b/fastfield_codecs/src/linear.rs
@@ -6,8 +6,7 @@ use ownedbytes::OwnedBytes;
 use tantivy_bitpacker::{compute_num_bits, BitPacker, BitUnpacker};
 
 use crate::{
-    FastFieldCodecDeserializer, FastFieldCodecReader, FastFieldCodecSerializer, FastFieldCodecType,
-    FastFieldDataAccess,
+    FastFieldCodecDeserializer, FastFieldCodecSerializer, FastFieldCodecType, FastFieldDataAccess,
 };
 
 /// Depending on the field type, a different
@@ -78,7 +77,7 @@ impl FastFieldCodecDeserializer for LinearReader {
     }
 }
 
-impl FastFieldCodecReader for LinearReader {
+impl FastFieldDataAccess for LinearReader {
     #[inline]
     fn get_val(&self, doc: u64) -> u64 {
         let calculated_value = get_calculated_value(self.footer.first_val, doc, self.slope);

--- a/fastfield_codecs/src/linear.rs
+++ b/fastfield_codecs/src/linear.rs
@@ -89,6 +89,10 @@ impl FastFieldCodecReader for LinearReader {
     fn max_value(&self) -> u64 {
         self.footer.max_value
     }
+    #[inline]
+    fn num_vals(&self) -> u64 {
+        self.footer.num_vals
+    }
 }
 
 /// Fastfield serializer, which tries to guess values by linear interpolation

--- a/fastfield_codecs/src/linear.rs
+++ b/fastfield_codecs/src/linear.rs
@@ -80,7 +80,7 @@ impl FastFieldCodecDeserializer for LinearReader {
 
 impl FastFieldCodecReader for LinearReader {
     #[inline]
-    fn get_u64(&self, doc: u64) -> u64 {
+    fn get_val(&self, doc: u64) -> u64 {
         let calculated_value = get_calculated_value(self.footer.first_val, doc, self.slope);
         (calculated_value + self.bit_unpacker.get(doc, &self.data)) - self.footer.offset
     }

--- a/src/fastfield/gcd.rs
+++ b/src/fastfield/gcd.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU64;
 
 use common::BinarySerializable;
 use fastdivide::DividerU64;
-use fastfield_codecs::{FastFieldCodecDeserializer, FastFieldCodecReader};
+use fastfield_codecs::{FastFieldCodecDeserializer, FastFieldDataAccess};
 use ownedbytes::OwnedBytes;
 
 pub const GCD_DEFAULT: u64 = 1;
@@ -19,7 +19,7 @@ pub struct GCDFastFieldCodec<CodecReader> {
     reader: CodecReader,
 }
 
-impl<C: FastFieldCodecReader + FastFieldCodecDeserializer + Clone> FastFieldCodecDeserializer
+impl<C: FastFieldDataAccess + FastFieldCodecDeserializer + Clone> FastFieldCodecDeserializer
     for GCDFastFieldCodec<C>
 {
     fn open_from_bytes(bytes: OwnedBytes) -> std::io::Result<Self> {
@@ -38,7 +38,7 @@ impl<C: FastFieldCodecReader + FastFieldCodecDeserializer + Clone> FastFieldCode
     }
 }
 
-impl<C: FastFieldCodecReader + Clone> FastFieldCodecReader for GCDFastFieldCodec<C> {
+impl<C: FastFieldDataAccess + Clone> FastFieldDataAccess for GCDFastFieldCodec<C> {
     #[inline]
     fn get_val(&self, doc: u64) -> u64 {
         let mut data = self.reader.get_val(doc);

--- a/src/fastfield/gcd.rs
+++ b/src/fastfield/gcd.rs
@@ -40,8 +40,8 @@ impl<C: FastFieldCodecReader + FastFieldCodecDeserializer + Clone> FastFieldCode
 
 impl<C: FastFieldCodecReader + Clone> FastFieldCodecReader for GCDFastFieldCodec<C> {
     #[inline]
-    fn get_u64(&self, doc: u64) -> u64 {
-        let mut data = self.reader.get_u64(doc);
+    fn get_val(&self, doc: u64) -> u64 {
+        let mut data = self.reader.get_val(doc);
         data *= self.gcd;
         data += self.min_value;
         data

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -326,7 +326,7 @@ mod tests {
             serializer.close().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 37);
+        assert_eq!(file.len(), 45);
         let composite_file = CompositeFile::open(&file)?;
         let file = composite_file.open_read(*FIELD).unwrap();
         let fast_field_reader = DynamicFastFieldReader::<u64>::open(file)?;
@@ -357,7 +357,7 @@ mod tests {
             serializer.close()?;
         }
         let file = directory.open_read(path)?;
-        assert_eq!(file.len(), 62);
+        assert_eq!(file.len(), 70);
         {
             let fast_fields_composite = CompositeFile::open(&file)?;
             let data = fast_fields_composite.open_read(*FIELD).unwrap();
@@ -393,7 +393,7 @@ mod tests {
             serializer.close().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 35);
+        assert_eq!(file.len(), 43);
         {
             let fast_fields_composite = CompositeFile::open(&file).unwrap();
             let data = fast_fields_composite.open_read(*FIELD).unwrap();
@@ -425,7 +425,7 @@ mod tests {
             serializer.close().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 80043);
+        assert_eq!(file.len(), 80051);
         {
             let fast_fields_composite = CompositeFile::open(&file)?;
             let data = fast_fields_composite.open_read(*FIELD).unwrap();
@@ -896,7 +896,7 @@ mod tests {
             serializer.close().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 36);
+        assert_eq!(file.len(), 44);
         let composite_file = CompositeFile::open(&file)?;
         let file = composite_file.open_read(field).unwrap();
         let fast_field_reader = DynamicFastFieldReader::<bool>::open(file)?;
@@ -932,7 +932,7 @@ mod tests {
             serializer.close().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 48);
+        assert_eq!(file.len(), 56);
         let composite_file = CompositeFile::open(&file)?;
         let file = composite_file.open_read(field).unwrap();
         let fast_field_reader = DynamicFastFieldReader::<bool>::open(file)?;
@@ -966,7 +966,7 @@ mod tests {
             serializer.close().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 35);
+        assert_eq!(file.len(), 43);
         let composite_file = CompositeFile::open(&file)?;
         let file = composite_file.open_read(field).unwrap();
         let fast_field_reader = DynamicFastFieldReader::<bool>::open(file)?;

--- a/src/fastfield/reader.rs
+++ b/src/fastfield/reader.rs
@@ -6,7 +6,7 @@ use common::BinarySerializable;
 use fastfield_codecs::bitpacked::BitpackedReader;
 use fastfield_codecs::blockwise_linear::BlockwiseLinearReader;
 use fastfield_codecs::linear::LinearReader;
-use fastfield_codecs::{FastFieldCodecDeserializer, FastFieldCodecReader, FastFieldCodecType};
+use fastfield_codecs::{FastFieldCodecDeserializer, FastFieldCodecType, FastFieldDataAccess};
 
 use super::{FastValue, GCDFastFieldCodec};
 use crate::directory::{CompositeFile, Directory, FileSlice, OwnedBytes, RamDirectory, WritePtr};
@@ -199,7 +199,7 @@ pub struct FastFieldReaderCodecWrapper<Item: FastValue, CodecReader> {
     _phantom: PhantomData<Item>,
 }
 
-impl<Item: FastValue, C: FastFieldCodecReader + FastFieldCodecDeserializer>
+impl<Item: FastValue, C: FastFieldDataAccess + FastFieldCodecDeserializer>
     FastFieldReaderCodecWrapper<Item, C>
 {
     /// Opens a fast field given a file.
@@ -251,7 +251,7 @@ impl<Item: FastValue, C: FastFieldCodecReader + FastFieldCodecDeserializer>
     }
 }
 
-impl<Item: FastValue, C: FastFieldCodecReader + FastFieldCodecDeserializer + Clone>
+impl<Item: FastValue, C: FastFieldDataAccess + FastFieldCodecDeserializer + Clone>
     FastFieldReader<Item> for FastFieldReaderCodecWrapper<Item, C>
 {
     /// Return the value associated to the given document.

--- a/src/fastfield/reader.rs
+++ b/src/fastfield/reader.rs
@@ -228,7 +228,7 @@ impl<Item: FastValue, C: FastFieldCodecReader + FastFieldCodecDeserializer>
 
     #[inline]
     pub(crate) fn get_u64(&self, doc: u64) -> Item {
-        let data = self.reader.get_u64(doc);
+        let data = self.reader.get_val(doc);
         Item::from_u64(data)
     }
 

--- a/src/fastfield/reader.rs
+++ b/src/fastfield/reader.rs
@@ -6,7 +6,7 @@ use common::BinarySerializable;
 use fastfield_codecs::bitpacked::BitpackedReader;
 use fastfield_codecs::blockwise_linear::BlockwiseLinearReader;
 use fastfield_codecs::linear::LinearReader;
-use fastfield_codecs::{FastFieldCodecReader, FastFieldCodecType};
+use fastfield_codecs::{FastFieldCodecDeserializer, FastFieldCodecReader, FastFieldCodecType};
 
 use super::{FastValue, GCDFastFieldCodec};
 use crate::directory::{CompositeFile, Directory, FileSlice, OwnedBytes, RamDirectory, WritePtr};
@@ -199,7 +199,9 @@ pub struct FastFieldReaderCodecWrapper<Item: FastValue, CodecReader> {
     _phantom: PhantomData<Item>,
 }
 
-impl<Item: FastValue, C: FastFieldCodecReader> FastFieldReaderCodecWrapper<Item, C> {
+impl<Item: FastValue, C: FastFieldCodecReader + FastFieldCodecDeserializer>
+    FastFieldReaderCodecWrapper<Item, C>
+{
     /// Opens a fast field given a file.
     pub fn open(file: FileSlice) -> crate::Result<Self> {
         let mut bytes = file.read_bytes()?;
@@ -249,8 +251,8 @@ impl<Item: FastValue, C: FastFieldCodecReader> FastFieldReaderCodecWrapper<Item,
     }
 }
 
-impl<Item: FastValue, C: FastFieldCodecReader + Clone> FastFieldReader<Item>
-    for FastFieldReaderCodecWrapper<Item, C>
+impl<Item: FastValue, C: FastFieldCodecReader + FastFieldCodecDeserializer + Clone>
+    FastFieldReader<Item> for FastFieldReaderCodecWrapper<Item, C>
 {
     /// Return the value associated to the given document.
     ///

--- a/src/fastfield/serializer/mod.rs
+++ b/src/fastfield/serializer/mod.rs
@@ -189,7 +189,7 @@ impl CompositeFastFieldSerializer {
             field_write,
             fastfield_accessor,
         )?;
-        write_gcd_header(field_write, base_value, gcd)?;
+        write_gcd_header(field_write, base_value, gcd, num_vals)?;
         Ok(())
     }
 

--- a/src/fastfield/writer.rs
+++ b/src/fastfield/writer.rs
@@ -2,12 +2,13 @@ use std::collections::HashMap;
 use std::io;
 
 use common;
+use fastfield_codecs::FastFieldDataAccess;
 use fnv::FnvHashMap;
 use tantivy_bitpacker::BlockedBitpacker;
 
 use super::multivalued::MultiValuedFastFieldWriter;
 use super::serializer::FastFieldStats;
-use super::{FastFieldDataAccess, FastFieldType, FastValue};
+use super::{FastFieldType, FastValue};
 use crate::fastfield::{BytesFastFieldWriter, CompositeFastFieldSerializer};
 use crate::indexer::doc_id_mapping::DocIdMapping;
 use crate::postings::UnorderedTermId;


### PR DESCRIPTION
- num_vals to FastFieldCodecReader
- split open_from_bytes to own trait
- rename get_u64 to get_val
- merge FastFieldCodecReader and FastFieldDataAccess traits
