### PR TITLE
fastfield return iterator instead fill vec

### DIFF
--- a/fastfield_codecs/src/blockwise_linear.rs
+++ b/fastfield_codecs/src/blockwise_linear.rs
@@ -300,13 +300,9 @@ impl FastFieldCodec for BlockwiseLinearCodec {
         // If this doesn't overflow the algorithm should be fine
         let theorethical_maximum_offset =
             fastfield_accessor.max_value() - fastfield_accessor.min_value();
-        if fastfield_accessor
+        fastfield_accessor
             .max_value()
-            .checked_add(theorethical_maximum_offset)
-            .is_none()
-        {
-            return None;
-        }
+            .checked_add(theorethical_maximum_offset)?;
 
         let first_val_in_first_block = fastfield_accessor.get_val(0);
         let last_elem_in_first_chunk = CHUNK_SIZE.min(fastfield_accessor.num_vals());

--- a/fastfield_codecs/src/column.rs
+++ b/fastfield_codecs/src/column.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 pub trait Column<T = u64> {
     /// Return the value associated to the given idx.
     ///
@@ -8,23 +10,14 @@ pub trait Column<T = u64> {
     /// May panic if `idx` is greater than the column length.
     fn get_val(&self, idx: u64) -> T;
 
-    /// Fills an output buffer with the fast field values
-    /// associated with the `DocId` going from
-    /// `start` to `start + output.len()`.
-    ///
-    /// Regardless of the type of `Item`, this method works
-    /// - transmuting the output array
-    /// - extracting the `Item`s as if they were `u64`
-    /// - possibly converting the `u64` value to the right type.
+    /// Returns an iterator over given doc range.
     ///
     /// # Panics
     ///
-    /// May panic if `start + output.len()` is greater than
+    /// May panic if `range.end()` is greater than
     /// the segment's `maxdoc`.
-    fn get_range(&self, start: u64, output: &mut [T]) {
-        for (out, idx) in output.iter_mut().zip(start..) {
-            *out = self.get_val(idx);
-        }
+    fn get_range(&self, range: Range<u64>) -> Box<dyn Iterator<Item = T> + '_> {
+        Box::new(range.map(|idx| self.get_val(idx)))
     }
 
     /// Returns the minimum value for this fast field.

--- a/fastfield_codecs/src/column.rs
+++ b/fastfield_codecs/src/column.rs
@@ -1,5 +1,7 @@
 use std::ops::Range;
 
+use crate::ColumnIter;
+
 pub trait Column<T = u64> {
     /// Return the value associated to the given idx.
     ///
@@ -16,8 +18,12 @@ pub trait Column<T = u64> {
     ///
     /// May panic if `range.end()` is greater than
     /// the segment's `maxdoc`.
-    fn get_range(&self, range: Range<u64>) -> Box<dyn Iterator<Item = T> + '_> {
-        Box::new(range.map(|idx| self.get_val(idx)))
+    #[inline]
+    fn get_range(&self, range: Range<u64>) -> ColumnIter<'_, Self, T>
+    where
+        Self: Sized,
+    {
+        ColumnIter::new(self, range)
     }
 
     /// Returns the minimum value for this fast field.

--- a/fastfield_codecs/src/linear.rs
+++ b/fastfield_codecs/src/linear.rs
@@ -204,13 +204,9 @@ impl FastFieldCodec for LinearCodec {
         // If this doesn't overflow the algorithm should be fine
         let theorethical_maximum_offset =
             fastfield_accessor.max_value() - fastfield_accessor.min_value();
-        if fastfield_accessor
+        fastfield_accessor
             .max_value()
-            .checked_add(theorethical_maximum_offset)
-            .is_none()
-        {
-            return None;
-        }
+            .checked_add(theorethical_maximum_offset)?;
 
         let first_val = fastfield_accessor.get_val(0);
         let last_val = fastfield_accessor.get_val(fastfield_accessor.num_vals() as u64 - 1);

--- a/src/fastfield/facet_reader.rs
+++ b/src/fastfield/facet_reader.rs
@@ -76,7 +76,8 @@ impl FacetReader {
 
     /// Return the list of facet ordinals associated to a document.
     pub fn facet_ords(&self, doc: DocId, output: &mut Vec<u64>) {
-        self.term_ords.get_vals(doc, output);
+        output.clear();
+        output.extend(self.term_ords.get_vals(doc))
     }
 }
 

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -477,8 +477,7 @@ mod tests {
             for (doc, i) in (-100i64..10_000i64).enumerate() {
                 assert_eq!(fast_field_reader.get_val(doc as u64), i);
             }
-            let mut buffer = vec![0i64; 100];
-            fast_field_reader.get_range(53, &mut buffer[..]);
+            let buffer: Vec<i64> = fast_field_reader.get_range(53..154).collect();
             for i in 0..100 {
                 assert_eq!(buffer[i], -100i64 + 53i64 + i as i64);
             }
@@ -607,9 +606,7 @@ mod tests {
         let mut all = vec![];
 
         for doc in docs {
-            let mut out = vec![];
-            ff.get_vals(doc, &mut out);
-            all.extend(out);
+            all.extend(ff.get_vals(doc));
         }
         all
     }
@@ -654,8 +651,7 @@ mod tests {
                 vec![1, 0, 0, 0, 1, 2]
             );
 
-            let mut out = vec![];
-            text_fast_field.get_vals(3, &mut out);
+            let out = text_fast_field.get_vals(3u32).collect::<Vec<_>>();
             assert_eq!(out, vec![0, 1]);
 
             let inverted_index = segment_reader.inverted_index(text_field)?;
@@ -840,22 +836,20 @@ mod tests {
         let fast_fields = segment_reader.fast_fields();
         let date_fast_field = fast_fields.date(date_field).unwrap();
         let dates_fast_field = fast_fields.dates(multi_date_field).unwrap();
-        let mut dates = vec![];
         {
             assert_eq!(date_fast_field.get_val(0).into_timestamp_micros(), 1i64);
-            dates_fast_field.get_vals(0u32, &mut dates);
+            let dates = dates_fast_field.get_vals(0u32).collect::<Vec<_>>();
             assert_eq!(dates.len(), 2);
             assert_eq!(dates[0].into_timestamp_micros(), 2i64);
             assert_eq!(dates[1].into_timestamp_micros(), 3i64);
         }
         {
             assert_eq!(date_fast_field.get_val(1).into_timestamp_micros(), 4i64);
-            dates_fast_field.get_vals(1u32, &mut dates);
-            assert!(dates.is_empty());
+            assert!(dates_fast_field.get_vals(1u32).next().is_none());
         }
         {
             assert_eq!(date_fast_field.get_val(2).into_timestamp_micros(), 0i64);
-            dates_fast_field.get_vals(2u32, &mut dates);
+            let dates = dates_fast_field.get_vals(2u32).collect::<Vec<_>>();
             assert_eq!(dates.len(), 2);
             assert_eq!(dates[0].into_timestamp_micros(), 5i64);
             assert_eq!(dates[1].into_timestamp_micros(), 6i64);

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -982,6 +982,67 @@ mod bench {
     use super::*;
     use crate::directory::{CompositeFile, Directory, RamDirectory, WritePtr};
     use crate::fastfield::tests::generate_permutation_gcd;
+    use crate::schema::{NumericOptions, Schema};
+    use crate::Document;
+
+    fn multi_values(num_docs: usize, vals_per_doc: usize) -> Vec<Vec<u64>> {
+        let mut vals = vec![];
+        for _i in 0..num_docs {
+            let mut block = vec![];
+            for j in 0..vals_per_doc {
+                block.push(j as u64);
+            }
+            vals.push(block);
+        }
+
+        vals
+    }
+
+    #[bench]
+    fn bench_multi_value_fflookup(b: &mut Bencher) {
+        let num_docs = 100_000;
+
+        let path = Path::new("test");
+        let directory: RamDirectory = RamDirectory::create();
+        {
+            let options = NumericOptions::default().set_fast(Cardinality::MultiValues);
+            let mut schema_builder = Schema::builder();
+            let field = schema_builder.add_u64_field("field", options);
+            let schema = schema_builder.build();
+
+            let write: WritePtr = directory.open_write(Path::new("test")).unwrap();
+            let mut serializer = CompositeFastFieldSerializer::from_write(write).unwrap();
+            let mut fast_field_writers = FastFieldsWriter::from_schema(&schema);
+            for block in &multi_values(num_docs, 3) {
+                let mut doc = Document::new();
+                for val in block {
+                    doc.add_u64(field, *val);
+                }
+                fast_field_writers.add_document(&doc);
+            }
+            fast_field_writers
+                .serialize(&mut serializer, &HashMap::new(), None)
+                .unwrap();
+            serializer.close().unwrap();
+        }
+        let file = directory.open_read(&path).unwrap();
+        {
+            let fast_fields_composite = CompositeFile::open(&file).unwrap();
+            let data_idx = fast_fields_composite.open_read_with_idx(*FIELD, 0).unwrap();
+            let idx_reader = DynamicFastFieldReader::<u64>::open(data_idx).unwrap();
+
+            let data_vals = fast_fields_composite.open_read_with_idx(*FIELD, 1).unwrap();
+            let vals_reader = DynamicFastFieldReader::<u64>::open(data_vals).unwrap();
+            let fast_field_reader = MultiValuedFastFieldReader::open(idx_reader, vals_reader);
+            b.iter(|| {
+                let mut sum = 0u64;
+                for i in 0u32..num_docs as u32 {
+                    sum += fast_field_reader.get_vals(i).sum::<u64>();
+                }
+                sum
+            });
+        }
+    }
 
     #[bench]
     fn bench_intfastfield_linear_veclookup(b: &mut Bencher) {

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -36,19 +36,17 @@ mod tests {
 
         let searcher = index.reader()?.searcher();
         let segment_reader = searcher.segment_reader(0);
-        let mut vals = Vec::new();
         let multi_value_reader = segment_reader.fast_fields().u64s(field)?;
         {
-            multi_value_reader.get_vals(2, &mut vals);
+            let vals = multi_value_reader.get_vals(2u32).collect::<Vec<_>>();
             assert_eq!(&vals, &[4u64]);
         }
         {
-            multi_value_reader.get_vals(0, &mut vals);
+            let vals = multi_value_reader.get_vals(0u32).collect::<Vec<_>>();
             assert_eq!(&vals, &[1u64, 3u64]);
         }
         {
-            multi_value_reader.get_vals(1, &mut vals);
-            assert!(vals.is_empty());
+            assert!(multi_value_reader.get_vals(1u32).next().is_none());
         }
         Ok(())
     }
@@ -213,15 +211,13 @@ mod tests {
 
         let searcher = index.reader()?.searcher();
         let segment_reader = searcher.segment_reader(0);
-        let mut vals = Vec::new();
         let multi_value_reader = segment_reader.fast_fields().i64s(field).unwrap();
-        multi_value_reader.get_vals(2, &mut vals);
+        let vals = multi_value_reader.get_vals(2u32).collect::<Vec<_>>();
         assert_eq!(&vals, &[-4i64]);
-        multi_value_reader.get_vals(0, &mut vals);
+        let vals = multi_value_reader.get_vals(0u32).collect::<Vec<_>>();
         assert_eq!(&vals, &[1i64, 3i64]);
-        multi_value_reader.get_vals(1, &mut vals);
-        assert!(vals.is_empty());
-        multi_value_reader.get_vals(3, &mut vals);
+        assert!(multi_value_reader.get_vals(1u32).next().is_none());
+        let vals = multi_value_reader.get_vals(3u32).collect::<Vec<_>>();
         assert_eq!(&vals, &[-5i64, -20i64, 1i64]);
         Ok(())
     }
@@ -245,15 +241,13 @@ mod tests {
 
         let searcher = index.reader()?.searcher();
         let segment_reader = searcher.segment_reader(0);
-        let mut vals = Vec::new();
         let multi_value_reader = segment_reader.fast_fields().bools(bool_field).unwrap();
-        multi_value_reader.get_vals(2, &mut vals);
+        let vals = multi_value_reader.get_vals(2u32).collect::<Vec<_>>();
         assert_eq!(&vals, &[false]);
-        multi_value_reader.get_vals(0, &mut vals);
+        let vals = multi_value_reader.get_vals(0u32).collect::<Vec<_>>();
         assert_eq!(&vals, &[true, false]);
-        multi_value_reader.get_vals(1, &mut vals);
-        assert!(vals.is_empty());
-        multi_value_reader.get_vals(3, &mut vals);
+        assert!(multi_value_reader.get_vals(1u32).next().is_none());
+        let vals = multi_value_reader.get_vals(3u32).collect::<Vec<_>>();
         assert_eq!(&vals, &[true, true, false]);
         Ok(())
     }

--- a/src/fastfield/multivalued/reader.rs
+++ b/src/fastfield/multivalued/reader.rs
@@ -41,17 +41,9 @@ impl<Item: FastValue> MultiValuedFastFieldReader<Item> {
 
     /// Returns the array of values associated to the given `doc`.
     #[inline]
-    fn get_vals_for_range(&self, range: Range<u64>, vals: &mut Vec<Item>) {
-        let len = (range.end - range.start) as usize;
-        vals.resize(len, Item::make_zero());
-        self.vals_reader.get_range(range.start, &mut vals[..]);
-    }
-
-    /// Returns the array of values associated to the given `doc`.
-    #[inline]
-    pub fn get_vals(&self, doc: DocId, vals: &mut Vec<Item>) {
+    pub fn get_vals(&self, doc: DocId) -> Box<dyn Iterator<Item = Item> + '_> {
         let range = self.range(doc);
-        self.get_vals_for_range(range, vals);
+        self.vals_reader.get_range(range)
     }
 
     /// Returns the minimum value for this fast field.

--- a/src/fastfield/multivalued/reader.rs
+++ b/src/fastfield/multivalued/reader.rs
@@ -18,7 +18,9 @@ pub struct MultiValuedFastFieldReader<Item: FastValue> {
     vals_reader: DynamicFastFieldReader<Item>,
 }
 
-impl<Item: FastValue> MultiValuedFastFieldReader<Item> {
+impl<Item: FastValue> MultiValuedFastFieldReader<Item>
+where DynamicFastFieldReader<Item>: Column<Item>
+{
     pub(crate) fn open(
         idx_reader: DynamicFastFieldReader<u64>,
         vals_reader: DynamicFastFieldReader<Item>,
@@ -41,7 +43,7 @@ impl<Item: FastValue> MultiValuedFastFieldReader<Item> {
 
     /// Returns the array of values associated to the given `doc`.
     #[inline]
-    pub fn get_vals(&self, doc: DocId) -> Box<dyn Iterator<Item = Item> + '_> {
+    pub fn get_vals(&self, doc: DocId) -> impl Iterator<Item = Item> + '_ {
         let range = self.range(doc);
         self.vals_reader.get_range(range)
     }

--- a/src/fastfield/reader.rs
+++ b/src/fastfield/reader.rs
@@ -40,40 +40,39 @@ impl<Item: FastValue> DynamicFastFieldReader<Item> {
         mut bytes: OwnedBytes,
         codec_type: FastFieldCodecType,
     ) -> crate::Result<DynamicFastFieldReader<Item>> {
-        let reader = match codec_type {
-            FastFieldCodecType::Bitpacked => {
-                DynamicFastFieldReader::Bitpacked(BitpackedCodec::open_from_bytes(bytes)?.into())
-            }
-            FastFieldCodecType::Linear => {
-                DynamicFastFieldReader::Linear(LinearCodec::open_from_bytes(bytes)?.into())
-            }
-            FastFieldCodecType::BlockwiseLinear => DynamicFastFieldReader::BlockwiseLinear(
-                BlockwiseLinearCodec::open_from_bytes(bytes)?.into(),
-            ),
-            FastFieldCodecType::Gcd => {
-                let codec_type = FastFieldCodecType::deserialize(&mut bytes)?;
-                match codec_type {
-                    FastFieldCodecType::Bitpacked => DynamicFastFieldReader::BitpackedGCD(
-                        open_gcd_from_bytes::<BitpackedCodec>(bytes)?.into(),
-                    ),
-                    FastFieldCodecType::Linear => DynamicFastFieldReader::LinearGCD(
-                        open_gcd_from_bytes::<LinearCodec>(bytes)?.into(),
-                    ),
-                    FastFieldCodecType::BlockwiseLinear => {
-                        DynamicFastFieldReader::BlockwiseLinearGCD(
-                            open_gcd_from_bytes::<BlockwiseLinearCodec>(bytes)?.into(),
-                        )
-                    }
-                    FastFieldCodecType::Gcd => {
-                        return Err(DataCorruption::comment_only(
+        let reader =
+            match codec_type {
+                FastFieldCodecType::Bitpacked => DynamicFastFieldReader::Bitpacked(
+                    BitpackedCodec::open_from_bytes(bytes)?.into(),
+                ),
+                FastFieldCodecType::Linear => {
+                    DynamicFastFieldReader::Linear(LinearCodec::open_from_bytes(bytes)?.into())
+                }
+                FastFieldCodecType::BlockwiseLinear => DynamicFastFieldReader::BlockwiseLinear(
+                    BlockwiseLinearCodec::open_from_bytes(bytes)?.into(),
+                ),
+                FastFieldCodecType::Gcd => {
+                    let codec_type = FastFieldCodecType::deserialize(&mut bytes)?;
+                    match codec_type {
+                        FastFieldCodecType::Bitpacked => DynamicFastFieldReader::BitpackedGCD(
+                            open_gcd_from_bytes::<BitpackedCodec>(bytes)?.into(),
+                        ),
+                        FastFieldCodecType::Linear => DynamicFastFieldReader::LinearGCD(
+                            open_gcd_from_bytes::<LinearCodec>(bytes)?.into(),
+                        ),
+                        FastFieldCodecType::BlockwiseLinear => {
+                            DynamicFastFieldReader::BlockwiseLinearGCD(
+                                open_gcd_from_bytes::<BlockwiseLinearCodec>(bytes)?.into(),
+                            )
+                        }
+                        FastFieldCodecType::Gcd => return Err(DataCorruption::comment_only(
                             "Gcd codec wrapped into another gcd codec. This combination is not \
                              allowed.",
                         )
-                        .into())
+                        .into()),
                     }
                 }
-            }
-        };
+            };
         Ok(reader)
     }
 

--- a/src/fastfield/reader.rs
+++ b/src/fastfield/reader.rs
@@ -97,17 +97,6 @@ impl<Item: FastValue> Column<Item> for DynamicFastFieldReader<Item> {
             Self::BlockwiseLinearGCD(reader) => reader.get_val(idx),
         }
     }
-    #[inline]
-    fn get_range(&self, start: u64, output: &mut [Item]) {
-        match self {
-            Self::Bitpacked(reader) => reader.get_range(start, output),
-            Self::Linear(reader) => reader.get_range(start, output),
-            Self::BlockwiseLinear(reader) => reader.get_range(start, output),
-            Self::BitpackedGCD(reader) => reader.get_range(start, output),
-            Self::LinearGCD(reader) => reader.get_range(start, output),
-            Self::BlockwiseLinearGCD(reader) => reader.get_range(start, output),
-        }
-    }
     fn min_value(&self) -> Item {
         match self {
             Self::Bitpacked(reader) => reader.min_value(),
@@ -167,24 +156,6 @@ impl<Item: FastValue, D: Column> FastFieldReaderCodecWrapper<Item, D> {
         let data = self.reader.get_val(idx);
         Item::from_u64(data)
     }
-
-    /// Internally `multivalued` also use SingleValue Fast fields.
-    /// It works as follows... A first column contains the list of start index
-    /// for each document, a second column contains the actual values.
-    ///
-    /// The values associated to a given doc, are then
-    ///  `second_column[first_column.get(doc)..first_column.get(doc+1)]`.
-    ///
-    /// Which means single value fast field reader can be indexed internally with
-    /// something different from a `DocId`. For this use case, we want to use `u64`
-    /// values.
-    ///
-    /// See `get_range` for an actual documentation about this method.
-    pub(crate) fn get_range_u64(&self, start: u64, output: &mut [Item]) {
-        for (i, out) in output.iter_mut().enumerate() {
-            *out = self.get_u64(start + (i as u64));
-        }
-    }
 }
 
 impl<Item: FastValue, C: Column + Clone> Column<Item> for FastFieldReaderCodecWrapper<Item, C> {
@@ -198,23 +169,6 @@ impl<Item: FastValue, C: Column + Clone> Column<Item> for FastFieldReaderCodecWr
     // `maxdoc`.
     fn get_val(&self, idx: u64) -> Item {
         self.get_u64(idx)
-    }
-
-    /// Fills an output buffer with the fast field values
-    /// associated with the `DocId` going from
-    /// `start` to `start + output.len()`.
-    ///
-    /// Regardless of the type of `Item`, this method works
-    /// - transmuting the output array
-    /// - extracting the `Item`s as if they were `u64`
-    /// - possibly converting the `u64` value to the right type.
-    ///
-    /// # Panics
-    ///
-    /// May panic if `start + output.len()` is greater than
-    /// the segment's `maxdoc`.
-    fn get_range(&self, start: u64, output: &mut [Item]) {
-        self.get_range_u64(start, output);
     }
 
     /// Returns the minimum value for this fast field.

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -471,15 +471,13 @@ mod tests_indexsorting {
 
         let multi_numbers = index.schema().get_field("multi_numbers").unwrap();
         let multifield = fast_fields.u64s(multi_numbers).unwrap();
-        let mut vals = vec![];
-        multifield.get_vals(0u32, &mut vals);
+        let vals = multifield.get_vals(0u32).collect::<Vec<_>>();
         assert_eq!(vals, &[] as &[u64]);
-        let mut vals = vec![];
-        multifield.get_vals(1u32, &mut vals);
+
+        let vals = multifield.get_vals(1u32).collect::<Vec<_>>();
         assert_eq!(vals, &[5, 6]);
 
-        let mut vals = vec![];
-        multifield.get_vals(2u32, &mut vals);
+        let vals = multifield.get_vals(2u32).collect::<Vec<_>>();
         assert_eq!(vals, &[3]);
         Ok(())
     }

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -1535,13 +1535,11 @@ mod tests {
             let ff_reader = segment_reader.fast_fields().u64s(multi_numbers).unwrap();
             let bool_ff_reader = segment_reader.fast_fields().bools(multi_bools).unwrap();
             for doc in segment_reader.doc_ids_alive() {
-                let mut vals = vec![];
-                ff_reader.get_vals(doc, &mut vals);
+                let vals = ff_reader.get_vals(doc).collect::<Vec<_>>();
                 assert_eq!(vals.len(), 2);
                 assert_eq!(vals[0], vals[1]);
 
-                let mut bool_vals = vec![];
-                bool_ff_reader.get_vals(doc, &mut bool_vals);
+                let bool_vals = bool_ff_reader.get_vals(doc).collect::<Vec<_>>();
                 assert_eq!(bool_vals.len(), 2);
                 assert_ne!(bool_vals[0], bool_vals[1]);
 

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -578,6 +578,7 @@ impl IndexMerger {
             stats: FastFieldStats,
         }
         impl<'a> Column for FieldIndexAccessProvider<'a> {
+            #[inline]
             fn get_val(&self, doc: u64) -> u64 {
                 self.offsets[doc as usize]
             }

--- a/src/indexer/merger_sorted_index_test.rs
+++ b/src/indexer/merger_sorted_index_test.rs
@@ -383,9 +383,7 @@ mod tests {
         assert_eq!(fast_field.get_val(5), 1_000u64);
 
         let get_vals = |fast_field: &MultiValuedFastFieldReader<u64>, doc_id: u32| -> Vec<u64> {
-            let mut vals = vec![];
-            fast_field.get_vals(doc_id, &mut vals);
-            vals
+            fast_field.get_vals(doc_id).collect()
         };
         let fast_fields = segment_reader.fast_fields();
         let fast_field = fast_fields.u64s(multi_numbers).unwrap();

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -639,10 +639,7 @@ Survey in 2016, 2017, and 2018."#;
     #[test]
     fn test_collapse_overlapped_ranges() {
         assert_eq!(&collapse_overlapped_ranges(&[0..1, 2..3,]), &[0..1, 2..3]);
-        assert_eq!(
-            collapse_overlapped_ranges(&vec![0..1, 1..2,]),
-            vec![0..1, 1..2]
-        );
+        assert_eq!(collapse_overlapped_ranges(&[0..1, 1..2,]), &[0..1, 1..2]);
         assert_eq!(collapse_overlapped_ranges(&[0..2, 1..2,]), vec![0..2]);
         assert_eq!(collapse_overlapped_ranges(&[0..2, 1..3,]), vec![0..3]);
         assert_eq!(collapse_overlapped_ranges(&[0..3, 1..2,]), vec![0..3]);


### PR DESCRIPTION
return iterator from get_vals method. This will allow to save on unnecessary vec allocations.
