### PR TITLE
Refact fast field

### DIFF
--- a/fastfield_codecs/benches/bench.rs
+++ b/fastfield_codecs/benches/bench.rs
@@ -4,14 +4,17 @@ extern crate test;
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use fastfield_codecs::bitpacked::BitpackedCodec;
     use fastfield_codecs::blockwise_linear::BlockwiseLinearCodec;
     use fastfield_codecs::linear::LinearCodec;
     use fastfield_codecs::*;
 
     fn get_data() -> Vec<u64> {
+        let mut rng = StdRng::seed_from_u64(2u64);
         let mut data: Vec<_> = (100..55000_u64)
-            .map(|num| num + rand::random::<u8>() as u64)
+            .map(|num| num + rng.gen::<u8>() as u64)
             .collect();
         data.push(99_000);
         data.insert(1000, 2000);
@@ -22,32 +25,59 @@ mod tests {
         data
     }
 
+    #[inline(never)]
     fn value_iter() -> impl Iterator<Item = u64> {
         0..20_000
     }
+    fn get_reader_for_bench<Codec: FastFieldCodec>(data: &[u64]) -> Codec::Reader {
+        let mut bytes = Vec::new();
+        let col = VecColumn::from(&data);
+        let normalized_header = fastfield_codecs::NormalizedHeader {
+            num_vals: col.num_vals(),
+            max_value: col.max_value(),
+        };
+        Codec::serialize(&VecColumn::from(data), &mut bytes).unwrap();
+        Codec::open_from_bytes(OwnedBytes::new(bytes), normalized_header).unwrap()
+    }
     fn bench_get<Codec: FastFieldCodec>(b: &mut Bencher, data: &[u64]) {
-        let mut bytes = vec![];
-        Codec::serialize(&mut bytes, &VecColumn::from(data)).unwrap();
-        let reader = Codec::open_from_bytes(OwnedBytes::new(bytes)).unwrap();
+        let col = get_reader_for_bench::<Codec>(data);
         b.iter(|| {
             let mut sum = 0u64;
             for pos in value_iter() {
-                let val = reader.get_val(pos as u64);
-                debug_assert_eq!(data[pos as usize], val);
+                let val = col.get_val(pos as u64);
                 sum = sum.wrapping_add(val);
             }
             sum
         });
     }
+
+    #[inline(never)]
+    fn bench_get_dynamic_helper(b: &mut Bencher, col: Arc<dyn Column>) {
+        b.iter(|| {
+            let mut sum = 0u64;
+            for pos in value_iter() {
+                let val = col.get_val(pos as u64);
+                sum = sum.wrapping_add(val);
+            }
+            sum
+        });
+    }
+
+    fn bench_get_dynamic<Codec: FastFieldCodec>(b: &mut Bencher, data: &[u64]) {
+        let col = Arc::new(get_reader_for_bench::<Codec>(data));
+        bench_get_dynamic_helper(b, col);
+    }
     fn bench_create<Codec: FastFieldCodec>(b: &mut Bencher, data: &[u64]) {
         let mut bytes = Vec::new();
         b.iter(|| {
             bytes.clear();
-            Codec::serialize(&mut bytes, &VecColumn::from(data)).unwrap();
+            Codec::serialize(&VecColumn::from(data), &mut bytes).unwrap();
         });
     }
 
     use ownedbytes::OwnedBytes;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
     use test::Bencher;
     #[bench]
     fn bench_fastfield_bitpack_create(b: &mut Bencher) {
@@ -70,22 +100,28 @@ mod tests {
         bench_get::<BitpackedCodec>(b, &data);
     }
     #[bench]
+    fn bench_fastfield_bitpack_get_dynamic(b: &mut Bencher) {
+        let data: Vec<_> = get_data();
+        bench_get_dynamic::<BitpackedCodec>(b, &data);
+    }
+    #[bench]
     fn bench_fastfield_linearinterpol_get(b: &mut Bencher) {
         let data: Vec<_> = get_data();
         bench_get::<LinearCodec>(b, &data);
+    }
+    #[bench]
+    fn bench_fastfield_linearinterpol_get_dynamic(b: &mut Bencher) {
+        let data: Vec<_> = get_data();
+        bench_get_dynamic::<LinearCodec>(b, &data);
     }
     #[bench]
     fn bench_fastfield_multilinearinterpol_get(b: &mut Bencher) {
         let data: Vec<_> = get_data();
         bench_get::<BlockwiseLinearCodec>(b, &data);
     }
-    pub fn stats_from_vec(data: &[u64]) -> FastFieldStats {
-        let min_value = data.iter().cloned().min().unwrap_or(0);
-        let max_value = data.iter().cloned().max().unwrap_or(0);
-        FastFieldStats {
-            min_value,
-            max_value,
-            num_vals: data.len() as u64,
-        }
+    #[bench]
+    fn bench_fastfield_multilinearinterpol_get_dynamic(b: &mut Bencher) {
+        let data: Vec<_> = get_data();
+        bench_get_dynamic::<BlockwiseLinearCodec>(b, &data);
     }
 }

--- a/fastfield_codecs/src/bitpacked.rs
+++ b/fastfield_codecs/src/bitpacked.rs
@@ -1,9 +1,9 @@
 use std::io::{self, Write};
 
-use common::BinarySerializable;
 use ownedbytes::OwnedBytes;
 use tantivy_bitpacker::{compute_num_bits, BitPacker, BitUnpacker};
 
+use crate::serialize::NormalizedHeader;
 use crate::{Column, FastFieldCodec, FastFieldCodecType};
 
 /// Depending on the field type, a different
@@ -12,80 +12,25 @@ use crate::{Column, FastFieldCodec, FastFieldCodecType};
 pub struct BitpackedReader {
     data: OwnedBytes,
     bit_unpacker: BitUnpacker,
-    min_value_u64: u64,
-    max_value_u64: u64,
-    num_vals: u64,
+    normalized_header: NormalizedHeader,
 }
 
 impl Column for BitpackedReader {
     #[inline]
     fn get_val(&self, doc: u64) -> u64 {
-        self.min_value_u64 + self.bit_unpacker.get(doc, &self.data)
+        self.bit_unpacker.get(doc, &self.data)
     }
     #[inline]
     fn min_value(&self) -> u64 {
-        self.min_value_u64
+        0
     }
     #[inline]
     fn max_value(&self) -> u64 {
-        self.max_value_u64
+        self.normalized_header.max_value
     }
     #[inline]
     fn num_vals(&self) -> u64 {
-        self.num_vals
-    }
-}
-pub struct BitpackedSerializerLegacy<'a, W: 'a + Write> {
-    bit_packer: BitPacker,
-    write: &'a mut W,
-    min_value: u64,
-    num_vals: u64,
-    amplitude: u64,
-    num_bits: u8,
-}
-
-impl<'a, W: Write> BitpackedSerializerLegacy<'a, W> {
-    /// Creates a new fast field serializer.
-    ///
-    /// The serializer in fact encode the values by bitpacking
-    /// `(val - min_value)`.
-    ///
-    /// It requires a `min_value` and a `max_value` to compute
-    /// compute the minimum number of bits required to encode
-    /// values.
-    pub fn open(
-        write: &'a mut W,
-        min_value: u64,
-        max_value: u64,
-    ) -> io::Result<BitpackedSerializerLegacy<'a, W>> {
-        assert!(min_value <= max_value);
-        let amplitude = max_value - min_value;
-        let num_bits = compute_num_bits(amplitude);
-        let bit_packer = BitPacker::new();
-        Ok(BitpackedSerializerLegacy {
-            bit_packer,
-            write,
-            min_value,
-            num_vals: 0,
-            amplitude,
-            num_bits,
-        })
-    }
-    /// Pushes a new value to the currently open u64 fast field.
-    #[inline]
-    pub fn add_val(&mut self, val: u64) -> io::Result<()> {
-        let val_to_write: u64 = val - self.min_value;
-        self.bit_packer
-            .write(val_to_write, self.num_bits, &mut self.write)?;
-        self.num_vals += 1;
-        Ok(())
-    }
-    pub fn close_field(mut self) -> io::Result<()> {
-        self.bit_packer.close(&mut self.write)?;
-        self.min_value.serialize(&mut self.write)?;
-        self.amplitude.serialize(&mut self.write)?;
-        self.num_vals.serialize(&mut self.write)?;
-        Ok(())
+        self.normalized_header.num_vals
     }
 }
 
@@ -98,50 +43,34 @@ impl FastFieldCodec for BitpackedCodec {
     type Reader = BitpackedReader;
 
     /// Opens a fast field given a file.
-    fn open_from_bytes(bytes: OwnedBytes) -> io::Result<Self::Reader> {
-        let footer_offset = bytes.len() - 24;
-        let (data, mut footer) = bytes.split(footer_offset);
-        let min_value = u64::deserialize(&mut footer)?;
-        let amplitude = u64::deserialize(&mut footer)?;
-        let num_vals = u64::deserialize(&mut footer)?;
-        let max_value = min_value + amplitude;
-        let num_bits = compute_num_bits(amplitude);
+    fn open_from_bytes(
+        data: OwnedBytes,
+        normalized_header: NormalizedHeader,
+    ) -> io::Result<Self::Reader> {
+        let num_bits = compute_num_bits(normalized_header.max_value);
         let bit_unpacker = BitUnpacker::new(num_bits);
         Ok(BitpackedReader {
             data,
             bit_unpacker,
-            min_value_u64: min_value,
-            max_value_u64: max_value,
-            num_vals,
+            normalized_header,
         })
     }
 
     /// Serializes data with the BitpackedFastFieldSerializer.
     ///
-    /// The serializer in fact encode the values by bitpacking
-    /// `(val - min_value)`.
-    ///
-    /// It requires a `min_value` and a `max_value` to compute
-    /// compute the minimum number of bits required to encode
-    /// values.
-    fn serialize(write: &mut impl Write, fastfield_accessor: &dyn Column) -> io::Result<()> {
-        let mut serializer = BitpackedSerializerLegacy::open(
-            write,
-            fastfield_accessor.min_value(),
-            fastfield_accessor.max_value(),
-        )?;
-
-        for val in fastfield_accessor.iter() {
-            serializer.add_val(val)?;
+    /// Ideally, we made a shift upstream on the column so that `col.min_value() == 0`.
+    fn serialize(col: &dyn Column, write: &mut impl Write) -> io::Result<()> {
+        let num_bits = compute_num_bits(col.max_value());
+        let mut bit_packer = BitPacker::new();
+        for val in col.iter() {
+            bit_packer.write(val, num_bits, write)?;
         }
-        serializer.close_field()?;
-
+        bit_packer.close(write)?;
         Ok(())
     }
 
-    fn estimate(fastfield_accessor: &impl Column) -> Option<f32> {
-        let amplitude = fastfield_accessor.max_value() - fastfield_accessor.min_value();
-        let num_bits = compute_num_bits(amplitude);
+    fn estimate(col: &impl Column) -> Option<f32> {
+        let num_bits = compute_num_bits(col.max_value());
         let num_bits_uncompressed = 64;
         Some(num_bits as f32 / num_bits_uncompressed as f32)
     }

--- a/fastfield_codecs/src/blockwise_linear.rs
+++ b/fastfield_codecs/src/blockwise_linear.rs
@@ -1,11 +1,12 @@
-use std::io;
 use std::sync::Arc;
+use std::{io, iter};
 
 use common::{BinarySerializable, CountingWriter, DeserializeFrom};
 use ownedbytes::OwnedBytes;
 use tantivy_bitpacker::{compute_num_bits, BitPacker, BitUnpacker};
 
 use crate::line::Line;
+use crate::serialize::NormalizedHeader;
 use crate::{Column, FastFieldCodec, FastFieldCodecType, VecColumn};
 
 const CHUNK_SIZE: usize = 512;
@@ -35,45 +36,6 @@ impl BinarySerializable for Block {
     }
 }
 
-#[derive(Debug)]
-struct BlockwiseLinearParams {
-    num_vals: u64,
-    min_value: u64,
-    max_value: u64,
-    blocks: Vec<Block>,
-}
-
-impl BinarySerializable for BlockwiseLinearParams {
-    fn serialize<W: io::Write>(&self, wrt: &mut W) -> io::Result<()> {
-        self.num_vals.serialize(wrt)?;
-        self.min_value.serialize(wrt)?;
-        self.max_value.serialize(wrt)?;
-        let expected_num_blocks = compute_num_blocks(self.num_vals);
-        assert_eq!(expected_num_blocks, self.blocks.len());
-        for block in &self.blocks {
-            block.serialize(wrt)?;
-        }
-        Ok(())
-    }
-
-    fn deserialize<R: io::Read>(reader: &mut R) -> io::Result<BlockwiseLinearParams> {
-        let num_vals = u64::deserialize(reader)?;
-        let min_value = u64::deserialize(reader)?;
-        let max_value = u64::deserialize(reader)?;
-        let num_blocks = compute_num_blocks(num_vals);
-        let mut blocks = Vec::with_capacity(num_blocks);
-        for _ in 0..num_blocks {
-            blocks.push(Block::deserialize(reader)?);
-        }
-        Ok(BlockwiseLinearParams {
-            num_vals,
-            min_value,
-            max_value,
-            blocks,
-        })
-    }
-}
-
 fn compute_num_blocks(num_vals: u64) -> usize {
     (num_vals as usize + CHUNK_SIZE - 1) / CHUNK_SIZE
 }
@@ -84,19 +46,27 @@ impl FastFieldCodec for BlockwiseLinearCodec {
     const CODEC_TYPE: crate::FastFieldCodecType = FastFieldCodecType::BlockwiseLinear;
     type Reader = BlockwiseLinearReader;
 
-    fn open_from_bytes(bytes: ownedbytes::OwnedBytes) -> io::Result<Self::Reader> {
+    fn open_from_bytes(
+        bytes: ownedbytes::OwnedBytes,
+        normalized_header: NormalizedHeader,
+    ) -> io::Result<Self::Reader> {
         let footer_len: u32 = (&bytes[bytes.len() - 4..]).deserialize()?;
         let footer_offset = bytes.len() - 4 - footer_len as usize;
         let (data, mut footer) = bytes.split(footer_offset);
-        let mut params = BlockwiseLinearParams::deserialize(&mut footer)?;
+        let num_blocks = compute_num_blocks(normalized_header.num_vals);
+        let mut blocks: Vec<Block> = iter::repeat_with(|| Block::deserialize(&mut footer))
+            .take(num_blocks)
+            .collect::<io::Result<_>>()?;
+
         let mut start_offset = 0;
-        for block in params.blocks.iter_mut() {
+        for block in &mut blocks {
             block.data_start_offset = start_offset;
             start_offset += (block.bit_unpacker.bit_width() as usize) * CHUNK_SIZE / 8;
         }
         Ok(BlockwiseLinearReader {
-            params: Arc::new(params),
+            blocks: Arc::new(blocks),
             data,
+            normalized_header,
         })
     }
 
@@ -134,8 +104,8 @@ impl FastFieldCodec for BlockwiseLinearCodec {
     }
 
     fn serialize(
-        wrt: &mut impl io::Write,
         fastfield_accessor: &dyn crate::Column,
+        wrt: &mut impl io::Write,
     ) -> io::Result<()> {
         let mut buffer = Vec::with_capacity(CHUNK_SIZE);
         let num_vals = fastfield_accessor.num_vals();
@@ -171,20 +141,15 @@ impl FastFieldCodec for BlockwiseLinearCodec {
             });
         }
 
-        let params = BlockwiseLinearParams {
-            num_vals,
-            min_value: fastfield_accessor.min_value(),
-            max_value: fastfield_accessor.max_value(),
-            blocks,
-        };
         bit_packer.close(wrt)?;
 
+        assert_eq!(blocks.len(), compute_num_blocks(num_vals));
+
         let mut counting_wrt = CountingWriter::wrap(wrt);
-
-        params.serialize(&mut counting_wrt)?;
-
+        for block in &blocks {
+            block.serialize(&mut counting_wrt)?;
+        }
         let footer_len = counting_wrt.written_bytes();
-
         (footer_len as u32).serialize(&mut counting_wrt)?;
 
         Ok(())
@@ -193,7 +158,8 @@ impl FastFieldCodec for BlockwiseLinearCodec {
 
 #[derive(Clone)]
 pub struct BlockwiseLinearReader {
-    params: Arc<BlockwiseLinearParams>,
+    blocks: Arc<Vec<Block>>,
+    normalized_header: NormalizedHeader,
     data: OwnedBytes,
 }
 
@@ -202,7 +168,7 @@ impl Column for BlockwiseLinearReader {
     fn get_val(&self, idx: u64) -> u64 {
         let block_id = (idx / CHUNK_SIZE as u64) as usize;
         let idx_within_block = idx % (CHUNK_SIZE as u64);
-        let block = &self.params.blocks[block_id];
+        let block = &self.blocks[block_id];
         let interpoled_val: u64 = block.line.eval(idx_within_block);
         let block_bytes = &self.data[block.data_start_offset..];
         let bitpacked_diff = block.bit_unpacker.get(idx_within_block, block_bytes);
@@ -210,14 +176,14 @@ impl Column for BlockwiseLinearReader {
     }
 
     fn min_value(&self) -> u64 {
-        self.params.min_value
+        0u64
     }
 
     fn max_value(&self) -> u64 {
-        self.params.max_value
+        self.normalized_header.max_value
     }
 
     fn num_vals(&self) -> u64 {
-        self.params.num_vals
+        self.normalized_header.num_vals
     }
 }

--- a/fastfield_codecs/src/column.rs
+++ b/fastfield_codecs/src/column.rs
@@ -34,16 +34,18 @@ pub trait Column<T = u64> {
 
     /// Returns the minimum value for this fast field.
     ///
-    /// The min value does not take in account of possible
-    /// deleted document, and should be considered as a lower bound
-    /// of the actual minimum value.
+    /// This min_value may not be exact.
+    /// For instance, the min value does not take in account of possible
+    /// deleted document. All values are however guaranteed to be higher than
+    /// `.min_value()`.
     fn min_value(&self) -> T;
 
     /// Returns the maximum value for this fast field.
     ///
-    /// The max value does not take in account of possible
-    /// deleted document, and should be considered as an upper bound
-    /// of the actual maximum value
+    /// This max_value may not be exact.
+    /// For instance, the max value does not take in account of possible
+    /// deleted document. All values are however guaranteed to be higher than
+    /// `.max_value()`.
     fn max_value(&self) -> T;
 
     fn num_vals(&self) -> u64;

--- a/fastfield_codecs/src/column.rs
+++ b/fastfield_codecs/src/column.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::sync::Mutex;
 
 use tantivy_bitpacker::minmax;
 
@@ -57,6 +58,24 @@ pub struct VecColumn<'a, T = u64> {
     values: &'a [T],
     min_value: T,
     max_value: T,
+}
+
+impl<'a, C: Column<T>, T: Copy + PartialOrd> Column<T> for &'a C {
+    fn get_val(&self, idx: u64) -> T {
+        (*self).get_val(idx)
+    }
+
+    fn min_value(&self) -> T {
+        (*self).min_value()
+    }
+
+    fn max_value(&self) -> T {
+        (*self).max_value()
+    }
+
+    fn num_vals(&self) -> u64 {
+        (*self).num_vals()
+    }
 }
 
 impl<'a, T: Copy + PartialOrd> Column<T> for VecColumn<'a, T> {
@@ -142,6 +161,87 @@ where
     }
 }
 
+pub struct RemappedColumn<T, M, C> {
+    column: C,
+    new_to_old_id_mapping: M,
+    min_max_cache: Mutex<Option<(T, T)>>,
+}
+
+impl<T, M, C> RemappedColumn<T, M, C>
+where
+    C: Column<T>,
+    M: Column<u32>,
+    T: Copy + Ord + Default,
+{
+    fn min_max(&self) -> (T, T) {
+        if let Some((min, max)) = self.min_max_cache.lock().unwrap().clone() {
+            return (min, max);
+        }
+        let (min, max) =
+            tantivy_bitpacker::minmax(self.iter()).unwrap_or((T::default(), T::default()));
+        *self.min_max_cache.lock().unwrap() = Some((min, max));
+        (min, max)
+    }
+}
+
+pub struct IterColumn<T>(T);
+
+impl<T> From<T> for IterColumn<T>
+where T: Iterator + Clone + ExactSizeIterator
+{
+    fn from(iter: T) -> Self {
+        IterColumn(iter)
+    }
+}
+
+impl<T> Column<T::Item> for IterColumn<T>
+where T: Iterator + Clone + ExactSizeIterator
+{
+    fn get_val(&self, idx: u64) -> T::Item {
+        self.0.clone().nth(idx as usize).unwrap()
+    }
+
+    fn min_value(&self) -> T::Item {
+        self.0.clone().next().unwrap()
+    }
+
+    fn max_value(&self) -> T::Item {
+        self.0.clone().last().unwrap()
+    }
+
+    fn num_vals(&self) -> u64 {
+        self.0.len() as u64
+    }
+
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = T::Item> + 'a> {
+        Box::new(self.0.clone())
+    }
+}
+
+impl<T, M, C> Column<T> for RemappedColumn<T, M, C>
+where
+    C: Column<T>,
+    M: Column<u32>,
+    T: Copy + Ord + Default,
+{
+    fn get_val(&self, idx: u64) -> T {
+        let old_id = self.new_to_old_id_mapping.get_val(idx);
+        self.column.get_val(old_id as u64)
+    }
+
+    fn min_value(&self) -> T {
+        self.min_max().0
+    }
+
+    fn max_value(&self) -> T {
+        self.min_max().1
+    }
+
+    fn num_vals(&self) -> u64 {
+        self.new_to_old_id_mapping.num_vals() as u64
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -157,5 +257,12 @@ mod tests {
         assert_eq!(mapped.num_vals(), 2);
         assert_eq!(mapped.get_val(0), 5);
         assert_eq!(mapped.get_val(1), 7);
+    }
+
+    #[test]
+    fn test_range_as_col() {
+        let col = IterColumn::from(10..100);
+        assert_eq!(col.num_vals(), 90);
+        assert_eq!(col.max_value(), 99);
     }
 }

--- a/fastfield_codecs/src/gcd.rs
+++ b/fastfield_codecs/src/gcd.rs
@@ -1,35 +1,6 @@
-use std::io::{self, Write};
 use std::num::NonZeroU64;
 
-use common::BinarySerializable;
 use fastdivide::DividerU64;
-
-#[derive(Debug, Clone, Copy)]
-pub struct GCDParams {
-    pub gcd: u64,
-    pub min_value: u64,
-    pub num_vals: u64,
-}
-
-impl BinarySerializable for GCDParams {
-    fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
-        self.gcd.serialize(writer)?;
-        self.min_value.serialize(writer)?;
-        self.num_vals.serialize(writer)?;
-        Ok(())
-    }
-
-    fn deserialize<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        let gcd: u64 = u64::deserialize(reader)?;
-        let min_value: u64 = u64::deserialize(reader)?;
-        let num_vals: u64 = u64::deserialize(reader)?;
-        Ok(Self {
-            gcd,
-            min_value,
-            num_vals,
-        })
-    }
-}
 
 /// Compute the gcd of two non null numbers.
 ///
@@ -85,11 +56,7 @@ mod tests {
     ) -> io::Result<()> {
         let mut vals: Vec<i64> = (-4..=(num_vals as i64) - 5).map(|val| val * 1000).collect();
         let mut buffer: Vec<u8> = Vec::new();
-        crate::serialize(
-            VecColumn::from(&vals),
-            &mut buffer,
-            &[codec_type, FastFieldCodecType::Gcd],
-        )?;
+        crate::serialize(VecColumn::from(&vals), &mut buffer, &[codec_type])?;
         let buffer = OwnedBytes::new(buffer);
         let column = crate::open::<i64>(buffer.clone())?;
         assert_eq!(column.get_val(0), -4000i64);
@@ -131,11 +98,7 @@ mod tests {
     ) -> io::Result<()> {
         let mut vals: Vec<u64> = (1..=num_vals).map(|i| i as u64 * 1000u64).collect();
         let mut buffer: Vec<u8> = Vec::new();
-        crate::serialize(
-            VecColumn::from(&vals),
-            &mut buffer,
-            &[codec_type, FastFieldCodecType::Gcd],
-        )?;
+        crate::serialize(VecColumn::from(&vals), &mut buffer, &[codec_type])?;
         let buffer = OwnedBytes::new(buffer);
         let column = crate::open::<u64>(buffer.clone())?;
         assert_eq!(column.get_val(0), 1000u64);

--- a/fastfield_codecs/src/lib.rs
+++ b/fastfield_codecs/src/lib.rs
@@ -13,17 +13,17 @@ use std::io::Write;
 use common::BinarySerializable;
 use ownedbytes::OwnedBytes;
 
-pub mod bitpacked;
-pub mod blockwise_linear;
+mod bitpacked;
+mod blockwise_linear;
 pub(crate) mod line;
-pub mod linear;
+mod linear;
 
 mod column;
 mod gcd;
 mod serialize;
 
 pub use self::column::{monotonic_map_column, Column, VecColumn};
-pub use self::serialize::{open, serialize, serialize_and_load, NormalizedHeader};
+pub use self::serialize::{estimate, open, serialize, serialize_and_load, NormalizedHeader};
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
 #[repr(u8)]
@@ -124,7 +124,7 @@ impl MonotonicallyMappableToU64 for f64 {
 
 /// The FastFieldSerializerEstimate trait is required on all variants
 /// of fast field compressions, to decide which one to choose.
-pub trait FastFieldCodec: 'static {
+trait FastFieldCodec: 'static {
     /// A codex needs to provide a unique name and id, which is
     /// used for debugging and de/serialization.
     const CODEC_TYPE: FastFieldCodecType;

--- a/fastfield_codecs/src/main.rs
+++ b/fastfield_codecs/src/main.rs
@@ -1,34 +1,7 @@
 #[macro_use]
 extern crate prettytable;
-use fastfield_codecs::bitpacked::BitpackedCodec;
-use fastfield_codecs::blockwise_linear::BlockwiseLinearCodec;
-use fastfield_codecs::linear::LinearCodec;
-use fastfield_codecs::{Column, FastFieldCodec, FastFieldCodecType, FastFieldStats};
+use fastfield_codecs::{Column, FastFieldCodecType, FastFieldStats, VecColumn};
 use prettytable::{Cell, Row, Table};
-
-struct Data<'a>(&'a [u64]);
-
-impl<'a> Column for Data<'a> {
-    fn get_val(&self, position: u64) -> u64 {
-        self.0[position as usize]
-    }
-
-    fn iter<'b>(&'b self) -> Box<dyn Iterator<Item = u64> + 'b> {
-        Box::new(self.0.iter().cloned())
-    }
-
-    fn min_value(&self) -> u64 {
-        *self.0.iter().min().unwrap_or(&0)
-    }
-
-    fn max_value(&self) -> u64 {
-        *self.0.iter().max().unwrap_or(&0)
-    }
-
-    fn num_vals(&self) -> u64 {
-        self.0.len() as u64
-    }
-}
 
 fn main() {
     let mut table = Table::new();
@@ -38,10 +11,9 @@ fn main() {
 
     for (data, data_set_name) in get_codec_test_data_sets() {
         let results: Vec<(f32, f32, FastFieldCodecType)> = [
-            serialize_with_codec::<LinearCodec>(&data),
-            serialize_with_codec::<BlockwiseLinearCodec>(&data),
-            serialize_with_codec::<BlockwiseLinearCodec>(&data),
-            serialize_with_codec::<BitpackedCodec>(&data),
+            serialize_with_codec(&data, FastFieldCodecType::Bitpacked),
+            serialize_with_codec(&data, FastFieldCodecType::Linear),
+            serialize_with_codec(&data, FastFieldCodecType::BlockwiseLinear),
         ]
         .into_iter()
         .flatten()
@@ -107,15 +79,16 @@ pub fn get_codec_test_data_sets() -> Vec<(Vec<u64>, &'static str)> {
     data_and_names
 }
 
-pub fn serialize_with_codec<C: FastFieldCodec>(
+pub fn serialize_with_codec(
     data: &[u64],
+    codec_type: FastFieldCodecType,
 ) -> Option<(f32, f32, FastFieldCodecType)> {
-    let data = Data(data);
-    let estimation = C::estimate(&data)?;
+    let col = VecColumn::from(data);
+    let estimation = fastfield_codecs::estimate(&col, codec_type)?;
     let mut out = Vec::new();
-    C::serialize(&data, &mut out).unwrap();
-    let actual_compression = out.len() as f32 / (data.num_vals() * 8) as f32;
-    Some((estimation, actual_compression, C::CODEC_TYPE))
+    fastfield_codecs::serialize(&col, &mut out, &[codec_type]).ok()?;
+    let actual_compression = out.len() as f32 / (col.num_vals() * 8) as f32;
+    Some((estimation, actual_compression, codec_type))
 }
 
 pub fn stats_from_vec(data: &[u64]) -> FastFieldStats {

--- a/fastfield_codecs/src/main.rs
+++ b/fastfield_codecs/src/main.rs
@@ -113,7 +113,7 @@ pub fn serialize_with_codec<C: FastFieldCodec>(
     let data = Data(data);
     let estimation = C::estimate(&data)?;
     let mut out = Vec::new();
-    C::serialize(&mut out, &data).unwrap();
+    C::serialize(&data, &mut out).unwrap();
     let actual_compression = out.len() as f32 / (data.num_vals() * 8) as f32;
     Some((estimation, actual_compression, C::CODEC_TYPE))
 }

--- a/fastfield_codecs/src/serialize.rs
+++ b/fastfield_codecs/src/serialize.rs
@@ -21,14 +21,13 @@ use std::io;
 use std::num::NonZeroU64;
 use std::sync::Arc;
 
-use common::BinarySerializable;
+use common::{BinarySerializable, VInt};
 use fastdivide::DividerU64;
 use log::warn;
 use ownedbytes::OwnedBytes;
 
 use crate::bitpacked::BitpackedCodec;
 use crate::blockwise_linear::BlockwiseLinearCodec;
-use crate::gcd::{find_gcd, GCDParams};
 use crate::linear::LinearCodec;
 use crate::{
     monotonic_map_column, Column, FastFieldCodec, FastFieldCodecType, MonotonicallyMappableToU64,
@@ -46,82 +45,118 @@ fn codec_estimation<C: FastFieldCodec, D: Column>(
     }
 }
 
-fn write_header<W: io::Write>(codec_type: FastFieldCodecType, output: &mut W) -> io::Result<()> {
-    codec_type.to_code().serialize(output)?;
-    Ok(())
+#[derive(Debug, Copy, Clone)]
+pub struct NormalizedHeader {
+    pub num_vals: u64,
+    pub max_value: u64,
 }
 
-fn gcd_params(column: &impl Column<u64>) -> Option<GCDParams> {
-    let min_value = column.min_value();
-    let gcd = find_gcd(column.iter().map(|val| val - min_value)).map(NonZeroU64::get)?;
-    if gcd == 1 {
-        return None;
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct Header {
+    num_vals: u64,
+    min_value: u64,
+    max_value: u64,
+    gcd: Option<NonZeroU64>,
+    codec_type: FastFieldCodecType,
+}
+
+impl Header {
+    pub fn normalized(self) -> NormalizedHeader {
+        let max_value =
+            (self.max_value - self.min_value) / self.gcd.map(|gcd| gcd.get()).unwrap_or(1);
+        NormalizedHeader {
+            num_vals: self.num_vals,
+            max_value,
+        }
     }
-    Some(GCDParams {
-        gcd,
-        min_value,
-        num_vals: column.num_vals(),
-    })
+
+    pub fn normalize_column<C: Column>(&self, from_column: C) -> impl Column {
+        let min_value = self.min_value;
+        let gcd = self.gcd.map(|gcd| gcd.get()).unwrap_or(1);
+        let divider = DividerU64::divide_by(gcd);
+        monotonic_map_column(from_column, move |val| divider.divide(val - min_value))
+    }
+
+    pub fn compute_header(
+        column: impl Column<u64>,
+        codecs: &[FastFieldCodecType],
+    ) -> Option<Header> {
+        let num_vals = column.num_vals();
+        let min_value = column.min_value();
+        let max_value = column.max_value();
+        let gcd = crate::gcd::find_gcd(column.iter().map(|val| val - min_value))
+            .filter(|gcd| gcd.get() > 1u64);
+        let divider = DividerU64::divide_by(gcd.map(|gcd| gcd.get()).unwrap_or(1u64));
+        let shifted_column = monotonic_map_column(&column, |val| divider.divide(val - min_value));
+        let codec_type = detect_codec(shifted_column, codecs)?;
+        Some(Header {
+            num_vals,
+            min_value,
+            max_value,
+            gcd,
+            codec_type,
+        })
+    }
+}
+
+impl BinarySerializable for Header {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        VInt(self.num_vals).serialize(writer)?;
+        VInt(self.min_value).serialize(writer)?;
+        VInt(self.max_value - self.min_value).serialize(writer)?;
+        if let Some(gcd) = self.gcd {
+            VInt(gcd.get()).serialize(writer)?;
+        } else {
+            VInt(0u64).serialize(writer)?;
+        }
+        self.codec_type.serialize(writer)?;
+        Ok(())
+    }
+
+    fn deserialize<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let num_vals = VInt::deserialize(reader)?.0;
+        let min_value = VInt::deserialize(reader)?.0;
+        let amplitude = VInt::deserialize(reader)?.0;
+        let max_value = min_value + amplitude;
+        let gcd_u64 = VInt::deserialize(reader)?.0;
+        let codec_type = FastFieldCodecType::deserialize(reader)?;
+        Ok(Header {
+            num_vals,
+            min_value,
+            max_value,
+            gcd: NonZeroU64::new(gcd_u64),
+            codec_type,
+        })
+    }
 }
 
 /// Returns correct the reader wrapped in the `DynamicFastFieldReader` enum for the data.
 pub fn open<T: MonotonicallyMappableToU64>(
     mut bytes: OwnedBytes,
 ) -> io::Result<Arc<dyn Column<T>>> {
-    let codec_type = FastFieldCodecType::deserialize(&mut bytes)?;
-    open_from_id(bytes, codec_type)
-}
-
-fn open_codec_from_bytes<C: FastFieldCodec, Item: MonotonicallyMappableToU64>(
-    bytes: OwnedBytes,
-) -> io::Result<Arc<dyn Column<Item>>> {
-    let reader = C::open_from_bytes(bytes)?;
-    Ok(Arc::new(monotonic_map_column(reader, Item::from_u64)))
-}
-
-pub fn open_gcd_from_bytes<WrappedCodec: FastFieldCodec>(
-    bytes: OwnedBytes,
-) -> io::Result<impl Column> {
-    let footer_offset = bytes.len() - 24;
-    let (body, mut footer) = bytes.split(footer_offset);
-    let gcd_params = GCDParams::deserialize(&mut footer)?;
-    let gcd_remap = move |val: u64| gcd_params.min_value + gcd_params.gcd * val;
-    let reader: WrappedCodec::Reader = WrappedCodec::open_from_bytes(body)?;
-    Ok(monotonic_map_column(reader, gcd_remap))
-}
-
-fn open_codec_with_gcd<C: FastFieldCodec, Item: MonotonicallyMappableToU64>(
-    bytes: OwnedBytes,
-) -> io::Result<Arc<dyn Column<Item>>> {
-    let reader = open_gcd_from_bytes::<C>(bytes)?;
-    Ok(Arc::new(monotonic_map_column(reader, Item::from_u64)))
-}
-
-/// Returns correct the reader wrapped in the `DynamicFastFieldReader` enum for the data.
-fn open_from_id<T: MonotonicallyMappableToU64>(
-    mut bytes: OwnedBytes,
-    codec_type: FastFieldCodecType,
-) -> io::Result<Arc<dyn Column<T>>> {
-    match codec_type {
-        FastFieldCodecType::Bitpacked => open_codec_from_bytes::<BitpackedCodec, _>(bytes),
-        FastFieldCodecType::Linear => open_codec_from_bytes::<LinearCodec, _>(bytes),
+    let header = Header::deserialize(&mut bytes)?;
+    match header.codec_type {
+        FastFieldCodecType::Bitpacked => open_specific_codec::<BitpackedCodec, _>(bytes, &header),
+        FastFieldCodecType::Linear => open_specific_codec::<LinearCodec, _>(bytes, &header),
         FastFieldCodecType::BlockwiseLinear => {
-            open_codec_from_bytes::<BlockwiseLinearCodec, _>(bytes)
+            open_specific_codec::<BlockwiseLinearCodec, _>(bytes, &header)
         }
-        FastFieldCodecType::Gcd => {
-            let codec_type = FastFieldCodecType::deserialize(&mut bytes)?;
-            match codec_type {
-                FastFieldCodecType::Bitpacked => open_codec_with_gcd::<BitpackedCodec, _>(bytes),
-                FastFieldCodecType::Linear => open_codec_with_gcd::<LinearCodec, _>(bytes),
-                FastFieldCodecType::BlockwiseLinear => {
-                    open_codec_with_gcd::<BlockwiseLinearCodec, _>(bytes)
-                }
-                FastFieldCodecType::Gcd => Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "Gcd codec wrapped into another gcd codec. This combination is not allowed.",
-                )),
-            }
-        }
+    }
+}
+
+fn open_specific_codec<C: FastFieldCodec, Item: MonotonicallyMappableToU64>(
+    bytes: OwnedBytes,
+    header: &Header,
+) -> io::Result<Arc<dyn Column<Item>>> {
+    let normalized_header = header.normalized();
+    let reader = C::open_from_bytes(bytes, normalized_header)?;
+    let min_value = header.min_value;
+    if let Some(gcd) = header.gcd {
+        let monotonic_mapping = move |val: u64| Item::from_u64(min_value + val * gcd.get());
+        Ok(Arc::new(monotonic_map_column(reader, monotonic_mapping)))
+    } else {
+        let monotonic_mapping = move |val: u64| Item::from_u64(min_value + val);
+        Ok(Arc::new(monotonic_map_column(reader, monotonic_mapping)))
     }
 }
 
@@ -131,40 +166,28 @@ pub fn serialize<T: MonotonicallyMappableToU64>(
     codecs: &[FastFieldCodecType],
 ) -> io::Result<()> {
     let column = monotonic_map_column(typed_column, T::to_u64);
-    let gcd_params_opt = if codecs.contains(&FastFieldCodecType::Gcd) {
-        gcd_params(&column)
-    } else {
-        None
-    };
-
-    let gcd_params = if let Some(gcd_params) = gcd_params_opt {
-        gcd_params
-    } else {
-        return serialize_without_gcd(column, output, codecs);
-    };
-
-    write_header(FastFieldCodecType::Gcd, output)?;
-    let base_value = column.min_value();
-    let gcd_divider = DividerU64::divide_by(gcd_params.gcd);
-    let divided_fastfield_accessor =
-        monotonic_map_column(column, |val: u64| gcd_divider.divide(val - base_value));
-
-    serialize_without_gcd(divided_fastfield_accessor, output, codecs)?;
-
-    gcd_params.serialize(output)?;
+    let header = Header::compute_header(&column, codecs).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "Data cannot be serialized with this list of codec. {:?}",
+                codecs
+            ),
+        )
+    })?;
+    header.serialize(output)?;
+    let normalized_column = header.normalize_column(column);
+    assert_eq!(normalized_column.min_value(), 0u64);
+    serialize_given_codec(normalized_column, header.codec_type, output)?;
     Ok(())
 }
 
-fn serialize_without_gcd(
+fn detect_codec(
     column: impl Column<u64>,
-    output: &mut impl io::Write,
     codecs: &[FastFieldCodecType],
-) -> io::Result<()> {
+) -> Option<FastFieldCodecType> {
     let mut estimations = Vec::new();
     for &codec in codecs {
-        if codec == FastFieldCodecType::Gcd {
-            continue;
-        }
         match codec {
             FastFieldCodecType::Bitpacked => {
                 codec_estimation::<BitpackedCodec, _>(&column, &mut estimations);
@@ -175,7 +198,6 @@ fn serialize_without_gcd(
             FastFieldCodecType::BlockwiseLinear => {
                 codec_estimation::<BlockwiseLinearCodec, _>(&column, &mut estimations);
             }
-            FastFieldCodecType::Gcd => {}
         }
     }
     if let Some(broken_estimation) = estimations.iter().find(|estimation| estimation.0.is_nan()) {
@@ -187,25 +209,25 @@ fn serialize_without_gcd(
     // removing nan values for codecs with broken calculations, and max values which disables
     // codecs
     estimations.retain(|estimation| !estimation.0.is_nan() && estimation.0 != f32::MAX);
-    estimations.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-    let (_ratio, codec_type) = estimations[0];
+    estimations
+        .sort_by(|(score_left, _), (score_right, _)| score_left.partial_cmp(&score_right).unwrap());
+    Some(estimations.first()?.1)
+}
 
-    write_header(codec_type, output)?;
+fn serialize_given_codec(
+    column: impl Column<u64>,
+    codec_type: FastFieldCodecType,
+    output: &mut impl io::Write,
+) -> io::Result<()> {
     match codec_type {
         FastFieldCodecType::Bitpacked => {
-            BitpackedCodec::serialize(output, &column)?;
+            BitpackedCodec::serialize(&column, output)?;
         }
         FastFieldCodecType::Linear => {
-            LinearCodec::serialize(output, &column)?;
+            LinearCodec::serialize(&column, output)?;
         }
         FastFieldCodecType::BlockwiseLinear => {
-            BlockwiseLinearCodec::serialize(output, &column)?;
-        }
-        FastFieldCodecType::Gcd => {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "GCD codec not supported.",
-            ));
+            BlockwiseLinearCodec::serialize(&column, output)?;
         }
     }
     output.flush()?;
@@ -229,5 +251,33 @@ mod tests {
         let original = [1u64, 5u64, 10u64];
         let restored: Vec<u64> = serialize_and_load(&original[..]).iter().collect();
         assert_eq!(&restored, &original[..]);
+    }
+
+    #[test]
+    fn test_fastfield_bool_size_bitwidth_1() {
+        let mut buffer = Vec::new();
+        let col = VecColumn::from(&[false, true][..]);
+        serialize(col, &mut buffer, &ALL_CODEC_TYPES).unwrap();
+        // 5 bytes of header, 1 byte of value, 7 bytes of padding.
+        assert_eq!(buffer.len(), 5 + 8);
+    }
+
+    #[test]
+    fn test_fastfield_bool_bit_size_bitwidth_0() {
+        let mut buffer = Vec::new();
+        let col = VecColumn::from(&[true][..]);
+        serialize(col, &mut buffer, &ALL_CODEC_TYPES).unwrap();
+        // 5 bytes of header, 0 bytes of value, 7 bytes of padding.
+        assert_eq!(buffer.len(), 5 + 7);
+    }
+
+    #[test]
+    fn test_fastfield_gcd() {
+        let mut buffer = Vec::new();
+        let vals: Vec<u64> = (0..80).map(|val| (val % 7) * 1_000u64).collect();
+        let col = VecColumn::from(&vals[..]);
+        serialize(col, &mut buffer, &[FastFieldCodecType::Bitpacked]).unwrap();
+        // Values are stored over 3 bits.
+        assert_eq!(buffer.len(), 7 + (3 * 80 / 8) + 7);
     }
 }

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -3,6 +3,7 @@ mod writer;
 
 pub use self::reader::MultiValuedFastFieldReader;
 pub use self::writer::MultiValuedFastFieldWriter;
+pub(crate) use self::writer::MultivalueStartIndex;
 
 #[cfg(test)]
 mod tests {

--- a/src/fastfield/multivalued/writer.rs
+++ b/src/fastfield/multivalued/writer.rs
@@ -332,13 +332,11 @@ mod tests {
 
     #[test]
     fn test_multivalue_get_vals() {
-        let doc_id_mapping = DocIdMapping::from_new_id_to_old_id(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        let doc_id_mapping =
+            DocIdMapping::from_new_id_to_old_id(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
         assert_eq!(doc_id_mapping.num_old_doc_ids(), 10);
-        let col = VecColumn::from(&[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55,][..]);
-        let multivalue_start_index = MultivalueStartIndex::new(
-            &col,
-            &doc_id_mapping,
-        );
+        let col = VecColumn::from(&[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55][..]);
+        let multivalue_start_index = MultivalueStartIndex::new(&col, &doc_id_mapping);
         assert_eq!(
             multivalue_start_index.iter().collect::<Vec<u64>>(),
             vec![0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
@@ -351,5 +349,4 @@ mod tests {
         assert_eq!(multivalue_start_index.get_val(0), 0);
         assert_eq!(multivalue_start_index.get_val(10), 55);
     }
-
 }

--- a/src/fastfield/multivalued/writer.rs
+++ b/src/fastfield/multivalued/writer.rs
@@ -1,10 +1,9 @@
 use std::io;
+use std::sync::Mutex;
 
-use fastfield_codecs::MonotonicallyMappableToU64;
+use fastfield_codecs::{Column, MonotonicallyMappableToU64, VecColumn};
 use fnv::FnvHashMap;
-use tantivy_bitpacker::minmax;
 
-use crate::fastfield::serializer::BitpackedSerializerLegacy;
 use crate::fastfield::{value_to_u64, CompositeFastFieldSerializer, FastFieldType};
 use crate::indexer::doc_id_mapping::DocIdMapping;
 use crate::postings::UnorderedTermId;
@@ -102,16 +101,6 @@ impl MultiValuedFastFieldWriter {
         }
     }
 
-    /// Register all of the values associated to a document.
-    ///
-    /// The method returns the `DocId` of the document that was
-    /// just written.
-    pub fn add_document_vals(&mut self, vals: &[UnorderedTermId]) -> DocId {
-        let doc = self.doc_index.len() as DocId;
-        self.next_doc();
-        self.vals.extend_from_slice(vals);
-        doc
-    }
     /// Returns an iterator over values per doc_id in ascending doc_id order.
     ///
     /// Normally the order is simply iterating self.doc_id_index.
@@ -151,39 +140,34 @@ impl MultiValuedFastFieldWriter {
     /// `tantivy` builds a mapping to convert this `UnorderedTermId` into
     /// term ordinals.
     pub fn serialize(
-        &self,
+        mut self,
         serializer: &mut CompositeFastFieldSerializer,
         mapping_opt: Option<&FnvHashMap<UnorderedTermId, TermOrdinal>>,
         doc_id_map: Option<&DocIdMapping>,
     ) -> io::Result<()> {
         {
-            // writing the offset index
-            let mut doc_index_serializer =
-                serializer.new_u64_fast_field_with_idx(self.field, 0, self.vals.len() as u64, 0)?;
-
-            let mut offset = 0;
-            for vals in self.get_ordered_values(doc_id_map) {
-                doc_index_serializer.add_val(offset)?;
-                offset += vals.len() as u64;
+            self.doc_index.push(self.vals.len() as u64);
+            let col = VecColumn::from(&self.doc_index[..]);
+            if let Some(doc_id_map) = doc_id_map {
+                let multi_value_start_index = MultivalueStartIndex::new(&col, doc_id_map);
+                serializer.create_auto_detect_u64_fast_field_with_idx(
+                    self.field,
+                    multi_value_start_index,
+                    0,
+                )?;
+            } else {
+                serializer.create_auto_detect_u64_fast_field_with_idx(self.field, col, 0)?;
             }
-            doc_index_serializer.add_val(self.vals.len() as u64)?;
-
-            doc_index_serializer.close_field()?;
         }
         {
-            // writing the values themselves.
-            let mut value_serializer: BitpackedSerializerLegacy<'_, _>;
+            // Writing the values themselves.
+            // TODO FIXME: Use less memory.
+            let mut values: Vec<u64> = Vec::new();
             if let Some(mapping) = mapping_opt {
-                value_serializer = serializer.new_u64_fast_field_with_idx(
-                    self.field,
-                    0u64,
-                    mapping.len() as u64,
-                    1,
-                )?;
-
                 if self.fast_field_type.is_facet() {
                     let mut doc_vals: Vec<u64> = Vec::with_capacity(100);
                     for vals in self.get_ordered_values(doc_id_map) {
+                        // In the case of facets, we want a vec of facet ord that is sorted.
                         doc_vals.clear();
                         let remapped_vals = vals
                             .iter()
@@ -191,7 +175,7 @@ impl MultiValuedFastFieldWriter {
                         doc_vals.extend(remapped_vals);
                         doc_vals.sort_unstable();
                         for &val in &doc_vals {
-                            value_serializer.add_val(val)?;
+                            values.push(val);
                         }
                     }
                 } else {
@@ -200,24 +184,172 @@ impl MultiValuedFastFieldWriter {
                             .iter()
                             .map(|val| *mapping.get(val).expect("Missing term ordinal"));
                         for val in remapped_vals {
-                            value_serializer.add_val(val)?;
+                            values.push(val);
                         }
                     }
                 }
             } else {
-                let val_min_max = minmax(self.vals.iter().cloned());
-                let (val_min, val_max) = val_min_max.unwrap_or((0u64, 0u64));
-                value_serializer =
-                    serializer.new_u64_fast_field_with_idx(self.field, val_min, val_max, 1)?;
                 for vals in self.get_ordered_values(doc_id_map) {
                     // sort values in case of remapped doc_ids?
                     for &val in vals {
-                        value_serializer.add_val(val)?;
+                        values.push(val);
                     }
                 }
             }
-            value_serializer.close_field()?;
+            let col = VecColumn::from(&values[..]);
+            serializer.create_auto_detect_u64_fast_field_with_idx(self.field, col, 1)?;
         }
         Ok(())
     }
+}
+
+pub(crate) struct MultivalueStartIndex<'a, C: Column> {
+    column: &'a C,
+    doc_id_map: &'a DocIdMapping,
+    min_max_opt: Mutex<Option<(u64, u64)>>,
+    random_seeker: Mutex<MultivalueStartIndexRandomSeeker<'a, C>>,
+}
+
+struct MultivalueStartIndexRandomSeeker<'a, C: Column> {
+    seek_head: MultivalueStartIndexIter<'a, C>,
+    seek_next_id: u64,
+}
+
+impl<'a, C: Column> MultivalueStartIndex<'a, C> {
+    pub fn new(column: &'a C, doc_id_map: &'a DocIdMapping) -> Self {
+        assert_eq!(column.num_vals(), doc_id_map.num_old_doc_ids() as u64 + 1);
+        MultivalueStartIndex {
+            column,
+            doc_id_map,
+            min_max_opt: Mutex::default(),
+            random_seeker: Mutex::new(MultivalueStartIndexRandomSeeker {
+                seek_head: MultivalueStartIndexIter {
+                    column,
+                    doc_id_map,
+                    new_doc_id: 0,
+                    offset: 0u64,
+                },
+                seek_next_id: 0u64,
+            }),
+        }
+    }
+
+    fn minmax(&self) -> (u64, u64) {
+        if let Some((min, max)) = self.min_max_opt.lock().unwrap().clone() {
+            return (min, max);
+        }
+        let (min, max) = tantivy_bitpacker::minmax(self.iter()).unwrap_or((0u64, 0u64));
+        *self.min_max_opt.lock().unwrap() = Some((min, max));
+        (min, max)
+    }
+}
+impl<'a, C: Column> Column for MultivalueStartIndex<'a, C> {
+    fn get_val(&self, idx: u64) -> u64 {
+        let mut random_seeker_lock = self.random_seeker.lock().unwrap();
+        if random_seeker_lock.seek_next_id > idx {
+            *random_seeker_lock = MultivalueStartIndexRandomSeeker {
+                seek_head: MultivalueStartIndexIter {
+                    column: self.column,
+                    doc_id_map: self.doc_id_map,
+                    new_doc_id: 0,
+                    offset: 0u64,
+                },
+                seek_next_id: 0u64,
+            };
+        }
+        let to_skip = idx - random_seeker_lock.seek_next_id;
+        random_seeker_lock.seek_next_id = idx + 1;
+        random_seeker_lock.seek_head.nth(to_skip as usize).unwrap()
+    }
+
+    fn min_value(&self) -> u64 {
+        self.minmax().0
+    }
+
+    fn max_value(&self) -> u64 {
+        self.minmax().1
+    }
+
+    fn num_vals(&self) -> u64 {
+        (self.doc_id_map.num_new_doc_ids() + 1) as u64
+    }
+
+    fn iter<'b>(&'b self) -> Box<dyn Iterator<Item = u64> + 'b> {
+        Box::new(MultivalueStartIndexIter {
+            column: &self.column,
+            doc_id_map: self.doc_id_map,
+            new_doc_id: 0,
+            offset: 0,
+        })
+    }
+}
+
+struct MultivalueStartIndexIter<'a, C: Column> {
+    pub column: &'a C,
+    pub doc_id_map: &'a DocIdMapping,
+    pub new_doc_id: usize,
+    pub offset: u64,
+}
+
+impl<'a, C: Column> Iterator for MultivalueStartIndexIter<'a, C> {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.new_doc_id > self.doc_id_map.num_new_doc_ids() {
+            return None;
+        }
+        let new_doc_id = self.new_doc_id;
+        self.new_doc_id += 1;
+        let start_offset = self.offset;
+        if new_doc_id < self.doc_id_map.num_new_doc_ids() {
+            let old_doc = self.doc_id_map.get_old_doc_id(new_doc_id as u32) as u64;
+            let num_vals_for_doc = self.column.get_val(old_doc + 1) - self.column.get_val(old_doc);
+            self.offset += num_vals_for_doc;
+        }
+        Some(start_offset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_multivalue_start_index() {
+        let doc_id_mapping = DocIdMapping::from_new_id_to_old_id(vec![4, 1, 2]);
+        assert_eq!(doc_id_mapping.num_old_doc_ids(), 5);
+        let col = VecColumn::from(&[0u64, 3, 5, 10, 12, 16][..]);
+        let multivalue_start_index = MultivalueStartIndex::new(
+            &col, // 3, 2, 5, 2, 4
+            &doc_id_mapping,
+        );
+        assert_eq!(multivalue_start_index.num_vals(), 4);
+        assert_eq!(
+            multivalue_start_index.iter().collect::<Vec<u64>>(),
+            vec![0, 4, 6, 11]
+        ); // 4, 2, 5
+    }
+
+    #[test]
+    fn test_multivalue_get_vals() {
+        let doc_id_mapping = DocIdMapping::from_new_id_to_old_id(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert_eq!(doc_id_mapping.num_old_doc_ids(), 10);
+        let col = VecColumn::from(&[0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55,][..]);
+        let multivalue_start_index = MultivalueStartIndex::new(
+            &col,
+            &doc_id_mapping,
+        );
+        assert_eq!(
+            multivalue_start_index.iter().collect::<Vec<u64>>(),
+            vec![0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
+        );
+        assert_eq!(multivalue_start_index.num_vals(), 11);
+        assert_eq!(multivalue_start_index.get_val(3), 2);
+        assert_eq!(multivalue_start_index.get_val(5), 5);
+        assert_eq!(multivalue_start_index.get_val(8), 21);
+        assert_eq!(multivalue_start_index.get_val(4), 3);
+        assert_eq!(multivalue_start_index.get_val(0), 0);
+        assert_eq!(multivalue_start_index.get_val(10), 55);
+    }
+
 }

--- a/src/fastfield/serializer/mod.rs
+++ b/src/fastfield/serializer/mod.rs
@@ -1,8 +1,7 @@
 use std::io::{self, Write};
 
 use common::{BinarySerializable, CountingWriter};
-pub use fastfield_codecs::bitpacked::BitpackedCodec;
-pub use fastfield_codecs::{Column, FastFieldCodec, FastFieldStats};
+pub use fastfield_codecs::{Column, FastFieldStats};
 use fastfield_codecs::{FastFieldCodecType, MonotonicallyMappableToU64, ALL_CODEC_TYPES};
 
 use crate::directory::{CompositeWrite, WritePtr};

--- a/src/fastfield/serializer/mod.rs
+++ b/src/fastfield/serializer/mod.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 
 use common::{BinarySerializable, CountingWriter};
-pub use fastfield_codecs::bitpacked::{BitpackedCodec, BitpackedSerializerLegacy};
+pub use fastfield_codecs::bitpacked::BitpackedCodec;
 pub use fastfield_codecs::{Column, FastFieldCodec, FastFieldStats};
 use fastfield_codecs::{FastFieldCodecType, MonotonicallyMappableToU64, ALL_CODEC_TYPES};
 
@@ -83,40 +83,6 @@ impl CompositeFastFieldSerializer {
         let field_write = self.composite_write.for_field_with_idx(field, idx);
         fastfield_codecs::serialize(fastfield_accessor, field_write, &self.codec_types)?;
         Ok(())
-    }
-
-    /// Start serializing a new u64 fast field
-    pub fn serialize_into(
-        &mut self,
-        field: Field,
-        min_value: u64,
-        max_value: u64,
-    ) -> io::Result<BitpackedSerializerLegacy<'_, CountingWriter<WritePtr>>> {
-        self.new_u64_fast_field_with_idx(field, min_value, max_value, 0)
-    }
-
-    /// Start serializing a new u64 fast field
-    pub fn new_u64_fast_field(
-        &mut self,
-        field: Field,
-        min_value: u64,
-        max_value: u64,
-    ) -> io::Result<BitpackedSerializerLegacy<'_, CountingWriter<WritePtr>>> {
-        self.new_u64_fast_field_with_idx(field, min_value, max_value, 0)
-    }
-
-    /// Start serializing a new u64 fast field
-    pub fn new_u64_fast_field_with_idx(
-        &mut self,
-        field: Field,
-        min_value: u64,
-        max_value: u64,
-        idx: usize,
-    ) -> io::Result<BitpackedSerializerLegacy<'_, CountingWriter<WritePtr>>> {
-        let field_write = self.composite_write.for_field_with_idx(field, idx);
-        // Prepend codec id to field data for compatibility with DynamicFastFieldReader.
-        FastFieldCodecType::Bitpacked.serialize(field_write)?;
-        BitpackedSerializerLegacy::open(field_write, min_value, max_value)
     }
 
     /// Start serializing a new [u8] fast field

--- a/src/fastfield/writer.rs
+++ b/src/fastfield/writer.rs
@@ -211,12 +211,12 @@ impl FastFieldsWriter {
     /// Serializes all of the `FastFieldWriter`s by pushing them in
     /// order to the fast field serializer.
     pub fn serialize(
-        &self,
+        self,
         serializer: &mut CompositeFastFieldSerializer,
         mapping: &HashMap<Field, FnvHashMap<UnorderedTermId, TermOrdinal>>,
         doc_id_map: Option<&DocIdMapping>,
     ) -> io::Result<()> {
-        for field_writer in &self.term_id_writers {
+        for field_writer in self.term_id_writers {
             let field = field_writer.field();
             field_writer.serialize(serializer, mapping.get(&field), doc_id_map)?;
         }
@@ -224,11 +224,11 @@ impl FastFieldsWriter {
             field_writer.serialize(serializer, doc_id_map)?;
         }
 
-        for field_writer in &self.multi_values_writers {
+        for field_writer in self.multi_values_writers {
             let field = field_writer.field();
             field_writer.serialize(serializer, mapping.get(&field), doc_id_map)?;
         }
-        for field_writer in &self.bytes_value_writers {
+        for field_writer in self.bytes_value_writers {
             field_writer.serialize(serializer, doc_id_map)?;
         }
         Ok(())

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -91,6 +91,12 @@ impl DocIdMapping {
             .map(|old_doc| els[*old_doc as usize])
             .collect()
     }
+    pub fn num_new_doc_ids(&self) -> usize {
+        self.new_doc_id_to_old.len()
+    }
+    pub fn num_old_doc_ids(&self) -> usize {
+        self.old_doc_id_to_new.len()
+    }
 }
 
 pub(crate) fn expect_field_id_for_sort_field(

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -612,25 +612,23 @@ impl IndexMerger {
             .collect::<Vec<_>>();
         // We can now write the actual fast field values.
         // In the case of hierarchical facets, they are actually term ordinals.
-        let max_term_ord = term_ordinal_mappings.max_term_ord();
         {
-            let mut serialize_vals =
-                fast_field_serializer.new_u64_fast_field_with_idx(field, 0u64, max_term_ord, 1)?;
-            let mut vals: Vec<u64> = Vec::with_capacity(100);
-
+            let mut vals = Vec::new();
+            let mut buffer = Vec::new();
             for old_doc_addr in doc_id_mapping.iter_old_doc_addrs() {
                 let term_ordinal_mapping: &[TermOrdinal] =
                     term_ordinal_mappings.get_segment(old_doc_addr.segment_ord as usize);
 
                 let ff_reader = &fast_field_reader[old_doc_addr.segment_ord as usize];
-                ff_reader.get_vals(old_doc_addr.doc_id, &mut vals);
-                for &prev_term_ord in &vals {
+                ff_reader.get_vals(old_doc_addr.doc_id, &mut buffer);
+                for &prev_term_ord in &buffer {
                     let new_term_ord = term_ordinal_mapping[prev_term_ord as usize];
-                    serialize_vals.add_val(new_term_ord)?;
+                    vals.push(new_term_ord);
                 }
             }
 
-            serialize_vals.close_field()?;
+            let col = VecColumn::from(&vals[..]);
+            fast_field_serializer.create_auto_detect_u64_fast_field_with_idx(field, col, 1)?;
         }
         Ok(())
     }

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -138,7 +138,7 @@ impl SegmentWriter {
         remap_and_write(
             &self.per_field_postings_writers,
             self.ctx,
-            &self.fast_field_writers,
+            self.fast_field_writers,
             &self.fieldnorms_writer,
             &self.schema,
             self.segment_serializer,
@@ -345,7 +345,7 @@ impl SegmentWriter {
 fn remap_and_write(
     per_field_postings_writers: &PerFieldPostingsWriter,
     ctx: IndexingContext,
-    fast_field_writers: &FastFieldsWriter,
+    fast_field_writers: FastFieldsWriter,
     fieldnorms_writer: &FieldNormsWriter,
     schema: &Schema,
     mut serializer: SegmentSerializer,


### PR DESCRIPTION
Since there is an estimation part when initially creating multi value fastfields I added a bench to track the regression

```
now
test fastfield::multivalued::bench::bench_multi_value_ff_creation                                                        ... bench:  89,557,762 ns/iter (+/- 14,987,022)
test fastfield::multivalued::bench::bench_multi_value_ff_creation_with_sorting                                           ... bench: 107,875,930 ns/iter (+/- 4,337,126)
test fastfield::multivalued::bench::bench_multi_value_fflookup                                                           ... bench:   1,096,212 ns/iter (+/- 15,691)


before
running 3 tests
test fastfield::multivalued::bench::bench_multi_value_ff_creation                                                        ... bench:  61,929,371 ns/iter (+/- 4,473,032)
test fastfield::multivalued::bench::bench_multi_value_ff_creation_with_sorting                                           ... bench:  60,657,527 ns/iter (+/- 3,043,559)
test fastfield::multivalued::bench::bench_multi_value_fflookup                                                           ... bench:   1,239,103 ns/iter (+/- 22,236)

```

