### PR TITLE
add benchmark for multivalue fast field

### DIFF
--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -428,7 +428,7 @@ mod bench {
             let write: WritePtr = directory.open_write(Path::new("test")).unwrap();
             let mut serializer = CompositeFastFieldSerializer::from_write(write).unwrap();
             let mut fast_field_writers = FastFieldsWriter::from_schema(&schema);
-            for block in &multi_values(num_docs, 1) {
+            for block in &multi_values(num_docs, 3) {
                 let mut doc = Document::new();
                 for val in block {
                     doc.add_u64(field, *val);
@@ -468,5 +468,35 @@ mod bench {
                 sum
             });
         }
+    }
+
+    #[bench]
+    fn bench_multi_value_ff_creation(b: &mut Bencher) {
+        // 3 million ff entries
+        let num_docs = 1_000_000;
+        let multi_values = multi_values(num_docs, 3);
+
+        b.iter(|| {
+            let directory: RamDirectory = RamDirectory::create();
+            let options = NumericOptions::default().set_fast(Cardinality::MultiValues);
+            let mut schema_builder = Schema::builder();
+            let field = schema_builder.add_u64_field("field", options);
+            let schema = schema_builder.build();
+
+            let write: WritePtr = directory.open_write(Path::new("test")).unwrap();
+            let mut serializer = CompositeFastFieldSerializer::from_write(write).unwrap();
+            let mut fast_field_writers = FastFieldsWriter::from_schema(&schema);
+            for block in &multi_values {
+                let mut doc = Document::new();
+                for val in block {
+                    doc.add_u64(field, *val);
+                }
+                fast_field_writers.add_document(&doc);
+            }
+            fast_field_writers
+                .serialize(&mut serializer, &HashMap::new(), None)
+                .unwrap();
+            serializer.close().unwrap();
+        });
     }
 }

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -460,8 +460,8 @@ mod bench {
             let fast_field_reader = MultiValuedFastFieldReader::open(idx_reader, vals_reader);
             b.iter(|| {
                 let mut sum = 0u64;
+                let mut data = Vec::with_capacity(10);
                 for i in 0u32..num_docs as u32 {
-                    let mut data = vec![];
                     fast_field_reader.get_vals(i, &mut data);
                     sum += data.iter().sum::<u64>();
                 }


### PR DESCRIPTION
Update: fixed bench

```
Now
running 3 tests
test fastfield::multivalued::bench::bench_multi_value_ff_creation                                                        ... bench:  59,124,102 ns/iter (+/- 569,159)
test fastfield::multivalued::bench::bench_multi_value_ff_creation_with_sorting                                           ... bench:  61,051,322 ns/iter (+/- 5,031,588)
test fastfield::multivalued::bench::bench_multi_value_fflookup                                                           ... bench:   1,243,811 ns/iter (+/- 20,847)


Previous
running 1 test
test fastfield::bench::bench_multi_value_fflookup                        ... bench:     758,148 ns/iter (+/- 13,857)

Previous iter version (from PR)
running 1 test
test fastfield::bench::bench_multi_value_fflookup                        ... bench:   1,105,754 ns/iter (+/- 31,509

```
