### PR TITLE
improve docs

### DIFF
--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -42,8 +42,8 @@ use crate::{DocId, TantivyError};
 /// AggregationCollector.
 ///
 /// Result type is
-/// [crate::aggregation::intermediate_agg_result::IntermediateBucketResult] with
-/// [crate::aggregation::intermediate_agg_result::IntermediateHistogramBucketEntry] on the
+/// [IntermediateBucketResult](crate::aggregation::intermediate_agg_result::IntermediateBucketResult) with
+/// [IntermediateHistogramBucketEntry](crate::aggregation::intermediate_agg_result::IntermediateHistogramBucketEntry) on the
 /// DistributedAggregationCollector.
 ///
 /// # Limitations/Compatibility

--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -27,8 +27,8 @@ use crate::{DocId, TantivyError};
 /// AggregationCollector.
 ///
 /// Result type is
-/// [crate::aggregation::intermediate_agg_result::IntermediateBucketResult] with
-/// [crate::aggregation::intermediate_agg_result::IntermediateRangeBucketEntry] on the
+/// [IntermediateBucketResult](crate::aggregation::intermediate_agg_result::IntermediateBucketResult) with
+/// [IntermediateRangeBucketEntry](crate::aggregation::intermediate_agg_result::IntermediateRangeBucketEntry) on the
 /// DistributedAggregationCollector.
 ///
 /// # Limitations/Compatibility

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -47,8 +47,8 @@ use crate::{DocId, TantivyError};
 /// AggregationCollector.
 ///
 /// Result type is
-/// [crate::aggregation::intermediate_agg_result::IntermediateBucketResult] with
-/// [crate::aggregation::intermediate_agg_result::IntermediateTermBucketEntry] on the
+/// [IntermediateBucketResult](crate::aggregation::intermediate_agg_result::IntermediateBucketResult) with
+/// [IntermediateTermBucketEntry](crate::aggregation::intermediate_agg_result::IntermediateTermBucketEntry) on the
 /// DistributedAggregationCollector.
 ///
 /// # Limitations/Compatibility

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -150,8 +150,8 @@
 //! IntermediateAggregationResults provides the
 //! [merge_fruits](intermediate_agg_result::IntermediateAggregationResults::merge_fruits) method to
 //! merge multiple results. The merged result can then be converted into
-//! [agg_result::AggregationResults] via the
-//! [agg_result::AggregationResults::from_intermediate_and_req] method.
+//! [AggregationResults](agg_result::AggregationResults) via the
+//! [into_final_bucket_result](intermediate_agg_result::IntermediateAggregationResults::into_final_bucket_result) method.
 
 pub mod agg_req;
 mod agg_req_with_accessor;

--- a/src/fastfield/multivalued/writer.rs
+++ b/src/fastfield/multivalued/writer.rs
@@ -27,7 +27,7 @@ use crate::{DatePrecision, DocId};
 /// get_multivalue_writer_mut).
 ///
 /// Once acquired, writing is done by calling
-/// [`.add_document_vals(&[u64])`](MultiValuedFastFieldWriter::add_document_vals) once per document.
+/// [`.add_document(&Document)`](MultiValuedFastFieldWriter::add_document) once per value.
 ///
 /// The serializer makes it possible to remap all of the values
 /// that were pushed to the writer using a mapping.


### PR DESCRIPTION
fix link alias after https://github.com/rust-lang/rustfmt/pull/5262 has been merged and released.
fix dead links
