### PR TITLE
Make `Column: Send + Sync`

### DIFF
--- a/fastfield_codecs/src/monotonic_mapping.rs
+++ b/fastfield_codecs/src/monotonic_mapping.rs
@@ -1,4 +1,4 @@
-pub trait MonotonicallyMappableToU64: 'static + PartialOrd + Copy {
+pub trait MonotonicallyMappableToU64: 'static + PartialOrd + Copy + Send + Sync {
     /// Converts a value to u64.
     ///
     /// Internally all fast field values are encoded as u64.


### PR DESCRIPTION
`Arc<dyn Column<V>>` will only implement `Send` if `Column` is both.