### PR TITLE
Perf fix on the MonotonicMapping column

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ maplit = "1.0.2"
 matches = "0.1.9"
 pretty_assertions = "1.2.1"
 proptest = "1.0.0"
-criterion = "0.4.0"
+criterion = "0.3.5"
 test-log = "0.2.10"
 env_logger = "0.9.0"
 pprof = { version = "0.10.0", features = ["flamegraph", "criterion"] }


### PR DESCRIPTION
The Monotonic mapping was using the default implementation for `get_range` and `.iter`.

As a result, some of the column used in merge (e.g. multivalued fast fields) were exhibiting a very strong performance regression.