### PR TITLE
docs: Remove mentions of stream_field method.

### DIFF
--- a/src/termdict/fst_termdict/termdict.rs
+++ b/src/termdict/fst_termdict/termdict.rs
@@ -192,7 +192,7 @@ impl TermDictionary {
         TermStreamerBuilder::new(self, self.fst_index.range())
     }
 
-    /// A stream of all the sorted terms. [See also `.stream_field()`](#method.stream_field)
+    /// A stream of all the sorted terms.
     pub fn stream(&self) -> io::Result<TermStreamer<'_>> {
         self.range().into_stream()
     }

--- a/src/termdict/sstable_termdict/termdict.rs
+++ b/src/termdict/sstable_termdict/termdict.rs
@@ -235,7 +235,7 @@ impl TermDictionary {
         TermStreamerBuilder::new(self, AlwaysMatch)
     }
 
-    // A stream of all the sorted terms. [See also `.stream_field()`](#method.stream_field)
+    // A stream of all the sorted terms.
     pub fn stream(&self) -> io::Result<TermStreamer<'_>> {
         self.range().into_stream()
     }


### PR DESCRIPTION
This method doesn't exist, so no need to mention it.