### PR TITLE
doc: Improve directory::Lock docs.

### DIFF
--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -187,7 +187,7 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// effectively stored durably.
     fn sync_directory(&self) -> io::Result<()>;
 
-    /// Acquire a lock in the given directory.
+    /// Acquire a lock in the directory given in the [`Lock`].
     ///
     /// The method is blocking or not depending on the [`Lock`] object.
     fn acquire_lock(&self, lock: &Lock) -> Result<DirectoryLock, LockError> {

--- a/src/directory/directory_lock.rs
+++ b/src/directory/directory_lock.rs
@@ -4,8 +4,10 @@ use once_cell::sync::Lazy;
 
 /// A directory lock.
 ///
-/// A lock is associated to a specific path and some
-/// [`LockParams`](./enum.LockParams.html).
+/// A lock is associated with a specific path.
+///
+/// The lock will be passed to [`Directory::acquire_lock`](crate::Directory::acquire_lock).
+///
 /// Tantivy itself uses only two locks but client application
 /// can use the directory facility to define their own locks.
 /// - [`INDEX_WRITER_LOCK`]
@@ -18,12 +20,13 @@ pub struct Lock {
     /// Depending on the platform, the lock might rely on the creation
     /// and deletion of this filepath.
     pub filepath: PathBuf,
-    /// `lock_params` describes whether acquiring the lock is meant
+    /// `is_blocking` describes whether acquiring the lock is meant
     /// to be a blocking operation or a non-blocking.
     ///
     /// Acquiring a blocking lock blocks until the lock is
     /// available.
-    /// Acquiring a blocking lock returns rapidly, either successfully
+    ///
+    /// Acquiring a non-blocking lock returns rapidly, either successfully
     /// or with an error signifying that someone is already holding
     /// the lock.
     pub is_blocking: bool,

--- a/src/directory/error.rs
+++ b/src/directory/error.rs
@@ -4,7 +4,9 @@ use std::{fmt, io};
 
 use crate::Version;
 
-/// Error while trying to acquire a directory lock.
+/// Error while trying to acquire a directory [lock](crate::directory::Lock).
+///
+/// This is returned from [`Directory::acquire_lock`](crate::Directory::acquire_lock).
 #[derive(Debug, Clone, Error)]
 pub enum LockError {
     /// Failed to acquired a lock as it is already held by another


### PR DESCRIPTION
Update the docs to reflect the lack of LockParams, correct an error, and improve cross-linking.