### PR TITLE
Tidy up clippy config.

### DIFF
--- a/src/core/inverted_index_reader.rs
+++ b/src/core/inverted_index_reader.rs
@@ -30,7 +30,7 @@ pub struct InvertedIndexReader {
 }
 
 impl InvertedIndexReader {
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_pass_by_value))] // for symmetry
+    #[allow(clippy::needless_pass_by_value)] // for symmetry
     pub(crate) fn new(
         termdict: TermDictionary,
         postings_file_slice: FileSlice,

--- a/src/indexer/delete_queue.rs
+++ b/src/indexer/delete_queue.rs
@@ -188,7 +188,7 @@ impl DeleteCursor {
         }
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))]
+    #[allow(clippy::wrong_self_convention)]
     fn is_behind_opstamp(&mut self, target_opstamp: Opstamp) -> bool {
         self.get()
             .map(|operation| operation.opstamp < target_opstamp)

--- a/src/postings/mod.rs
+++ b/src/postings/mod.rs
@@ -31,7 +31,7 @@ pub use self::term_info::TermInfo;
 
 pub(crate) type UnorderedTermId = u64;
 
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::enum_variant_names))]
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
 pub(crate) enum FreqReadingOption {
     NoFreq,

--- a/src/termdict/fst_termdict/streamer.rs
+++ b/src/termdict/fst_termdict/streamer.rs
@@ -136,7 +136,7 @@ where A: Automaton
     }
 
     /// Return the next `(key, value)` pair.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::should_implement_trait))]
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<(&[u8], &TermInfo)> {
         if self.advance() {
             Some((self.key(), self.value()))

--- a/src/termdict/sstable_termdict/streamer.rs
+++ b/src/termdict/sstable_termdict/streamer.rs
@@ -179,7 +179,7 @@ where
     }
 
     /// Return the next `(key, value)` pair.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::should_implement_trait))]
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<(&[u8], &TermInfo)> {
         if self.advance() {
             Some((self.key(), self.value()))

--- a/src/termdict/sstable_termdict/termdict.rs
+++ b/src/termdict/sstable_termdict/termdict.rs
@@ -52,7 +52,7 @@ impl<W: io::Write> TermDictionaryBuilder<W> {
     /// to insert_key and insert_value.
     ///
     /// Prefer using `.insert(key, value)`
-    #[allow(clippy::clippy::clippy::unnecessary_wraps)]
+    #[allow(clippy::unnecessary_wraps)]
     pub(crate) fn insert_key(&mut self, key: &[u8]) -> io::Result<()> {
         self.sstable_writer.write_key(key);
         Ok(())


### PR DESCRIPTION
* Checking cfg_attr is no longer necessary.
* Don't need multiple `clippy::` prefixes on a name.