### PR TITLE
POLLING_INTERVAL needn't be pub.

### DIFF
--- a/src/directory/file_watcher.rs
+++ b/src/directory/file_watcher.rs
@@ -9,7 +9,7 @@ use crc32fast::Hasher;
 
 use crate::directory::{WatchCallback, WatchCallbackList, WatchHandle};
 
-pub const POLLING_INTERVAL: Duration = Duration::from_millis(if cfg!(test) { 1 } else { 500 });
+const POLLING_INTERVAL: Duration = Duration::from_millis(if cfg!(test) { 1 } else { 500 });
 
 // Watches a file and executes registered callbacks when the file is modified.
 pub struct FileWatcher {


### PR DESCRIPTION
This is only used within the file watcher and is const, so it can't be configured.