### PR TITLE
Remove references to `/cpp` directory.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-cpp/* linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ target/release
 Cargo.lock
 benchmark
 .DS_Store
-cpp/simdcomp/bitpackingbenchmark
 *.bk
 .idea
 trace.dat


### PR DESCRIPTION
This was removed in 2018, so these should be fine to remove now.