### PR TITLE
Read only index.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,9 @@ pub enum TantivyError {
     /// Index already exists in this directory.
     #[error("Index already exists")]
     IndexAlreadyExists,
+    /// Index is read-only.
+    #[error("Index is read-only")]
+    IndexReadOnly,
     /// Failed to acquire file lock.
     #[error("Failed to acquire Lockfile: {0:?}. {1:?}")]
     LockFailure(LockError, Option<String>),


### PR DESCRIPTION
An index can be opened in read-only mode, which will prevent an IndexWriter from being created, as well as mark any IndexReaders as read-only as well (through a new reload policy) so that the lock file need not be created.

This is useful for when you have index data stored on read-only storage.

Fixes #557.