### PR TITLE
disable linear codec for multivalue values

### DIFF
--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -26,10 +26,8 @@ pub use self::alive_bitset::{intersect_alive_bitsets, write_alive_bitset, AliveB
 pub use self::bytes::{BytesFastFieldReader, BytesFastFieldWriter};
 pub use self::error::{FastFieldNotAvailableError, Result};
 pub use self::facet_reader::FacetReader;
-pub(crate) use self::multivalued::MultivalueStartIndex;
-pub use self::multivalued::{
-    get_fastfield_codecs_for_multivalue, MultiValuedFastFieldReader, MultiValuedFastFieldWriter,
-};
+pub(crate) use self::multivalued::{get_fastfield_codecs_for_multivalue, MultivalueStartIndex};
+pub use self::multivalued::{MultiValuedFastFieldReader, MultiValuedFastFieldWriter};
 pub use self::readers::FastFieldReaders;
 pub(crate) use self::readers::{type_and_cardinality, FastType};
 pub use self::serializer::{Column, CompositeFastFieldSerializer};

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -27,7 +27,9 @@ pub use self::bytes::{BytesFastFieldReader, BytesFastFieldWriter};
 pub use self::error::{FastFieldNotAvailableError, Result};
 pub use self::facet_reader::FacetReader;
 pub(crate) use self::multivalued::MultivalueStartIndex;
-pub use self::multivalued::{MultiValuedFastFieldReader, MultiValuedFastFieldWriter};
+pub use self::multivalued::{
+    get_fastfield_codecs_for_multivalue, MultiValuedFastFieldReader, MultiValuedFastFieldWriter,
+};
 pub use self::readers::FastFieldReaders;
 pub(crate) use self::readers::{type_and_cardinality, FastType};
 pub use self::serializer::{Column, CompositeFastFieldSerializer};

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -1,9 +1,21 @@
 mod reader;
 mod writer;
 
+use fastfield_codecs::FastFieldCodecType;
+
 pub use self::reader::MultiValuedFastFieldReader;
 pub use self::writer::MultiValuedFastFieldWriter;
 pub(crate) use self::writer::MultivalueStartIndex;
+
+/// The valid codecs for multivalue values excludes the linear interpolation codec.
+///
+/// This limitation is only valid for the values, not the offset index of the multivalue index.
+pub fn get_fastfield_codecs_for_multivalue() -> [FastFieldCodecType; 2] {
+    [
+        FastFieldCodecType::Bitpacked,
+        FastFieldCodecType::BlockwiseLinear,
+    ]
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use self::writer::MultivalueStartIndex;
 /// The valid codecs for multivalue values excludes the linear interpolation codec.
 ///
 /// This limitation is only valid for the values, not the offset index of the multivalue index.
-pub fn get_fastfield_codecs_for_multivalue() -> [FastFieldCodecType; 2] {
+pub(crate) fn get_fastfield_codecs_for_multivalue() -> [FastFieldCodecType; 2] {
     [
         FastFieldCodecType::Bitpacked,
         FastFieldCodecType::BlockwiseLinear,

--- a/src/fastfield/serializer/mod.rs
+++ b/src/fastfield/serializer/mod.rs
@@ -70,6 +70,20 @@ impl CompositeFastFieldSerializer {
         Ok(())
     }
 
+    /// Serialize data into a new u64 fast field. The best compression codec of the the provided
+    /// will be chosen.
+    pub fn create_auto_detect_u64_fast_field_with_idx_and_codecs<T: MonotonicallyMappableToU64>(
+        &mut self,
+        field: Field,
+        fastfield_accessor: impl Column<T>,
+        idx: usize,
+        codec_types: &[FastFieldCodecType],
+    ) -> io::Result<()> {
+        let field_write = self.composite_write.for_field_with_idx(field, idx);
+        fastfield_codecs::serialize(fastfield_accessor, field_write, codec_types)?;
+        Ok(())
+    }
+
     /// Start serializing a new [u8] fast field. Use the returned writer to write data into the
     /// bytes field. To associate the bytes with documents a seperate index must be created on
     /// index 0. See bytes/writer.rs::serialize for an example.

--- a/src/indexer/sorted_doc_id_multivalue_column.rs
+++ b/src/indexer/sorted_doc_id_multivalue_column.rs
@@ -104,7 +104,7 @@ pub(crate) struct RemappedDocIdMultiValueIndexColumn<'a, T: MultiValueLength> {
 
 impl<'a, T: MultiValueLength> RemappedDocIdMultiValueIndexColumn<'a, T> {
     pub(crate) fn new(
-        segment_and_multi_value_length_readers: &'a [(&'a SegmentReader, T)],
+        segment_and_ff_readers: &'a [(&'a SegmentReader, T)],
         doc_id_mapping: &'a SegmentDocIdMapping,
     ) -> Self {
         // We go through a complete first pass to compute the minimum and the
@@ -112,11 +112,10 @@ impl<'a, T: MultiValueLength> RemappedDocIdMultiValueIndexColumn<'a, T> {
         let mut num_vals = 0;
         let min_value = 0;
         let mut max_value = 0;
-        let mut multi_value_length_readers =
-            Vec::with_capacity(segment_and_multi_value_length_readers.len());
-        for reader_and_multi_value_length_reader in segment_and_multi_value_length_readers {
-            let segment_reader = reader_and_multi_value_length_reader.0;
-            let multi_value_length_reader = &reader_and_multi_value_length_reader.1;
+        let mut multi_value_length_readers = Vec::with_capacity(segment_and_ff_readers.len());
+        for segment_and_ff_reader in segment_and_ff_readers {
+            let segment_reader = segment_and_ff_reader.0;
+            let multi_value_length_reader = &segment_and_ff_reader.1;
             if !segment_reader.has_deletes() {
                 max_value += multi_value_length_reader.get_total_len();
             } else {


### PR DESCRIPTION
disable linear codec for multivalue values
don't materialize index column on merge
use simpler chain() variant
