### PR TITLE
fix: Fix power of two computation on 32bit architectures

### DIFF
--- a/src/postings/stacker/term_hashmap.rs
+++ b/src/postings/stacker/term_hashmap.rs
@@ -98,7 +98,7 @@ impl<'a> Iterator for Iter<'a> {
 /// # Panics if n == 0
 fn compute_previous_power_of_two(n: usize) -> usize {
     assert!(n > 0);
-    let msb = (63u32 - n.leading_zeros()) as u8;
+    let msb = (63u32 - (n as u64).leading_zeros()) as u8;
     1 << msb
 }
 


### PR DESCRIPTION
The current `compute_previous_power_of_two()` implementation used for TermHashmap takes and returns `usize` , but actually only works correclty on 64 bit architectures (aka usize == u64)

On other architectures the leading_zeros computation is run on the wrong type (must be u64), and leads to overflows.

Fixed simply computing the leading_zeros based on a u64 value.