### PR TITLE
faster skipindex deserialization, larger blocksize on sort

### DIFF
--- a/src/indexer/segment_serializer.rs
+++ b/src/indexer/segment_serializer.rs
@@ -30,8 +30,10 @@ impl SegmentSerializer {
             StoreWriter::new(
                 store_write,
                 crate::store::Compressor::None,
-                0, // we want random access on the docs, so we choose a minimal block size. Every
-                // doc will get its own block.
+                // We want fast random access on the docs, so we choose a small block size.
+                // If this is zero, the skip index will contain too many checkpoints and
+                // therefore will be relatively slow.
+                16000,
                 settings.docstore_compress_dedicated_thread,
             )?
         } else {

--- a/src/store/index/block.rs
+++ b/src/store/index/block.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::ops::Range;
 
-use common::VInt;
+use common::{read_u32_vint, VInt};
 
 use crate::store::index::{Checkpoint, CHECKPOINT_PERIOD};
 use crate::DocId;
@@ -85,15 +85,15 @@ impl CheckpointBlock {
             return Err(io::Error::new(io::ErrorKind::UnexpectedEof, ""));
         }
         self.checkpoints.clear();
-        let len = VInt::deserialize_u64(data)? as usize;
+        let len = read_u32_vint(data);
         if len == 0 {
             return Ok(());
         }
-        let mut doc = VInt::deserialize_u64(data)? as DocId;
-        let mut start_offset = VInt::deserialize_u64(data)? as usize;
+        let mut doc = read_u32_vint(data);
+        let mut start_offset = read_u32_vint(data) as usize;
         for _ in 0..len {
-            let num_docs = VInt::deserialize_u64(data)? as DocId;
-            let block_num_bytes = VInt::deserialize_u64(data)? as usize;
+            let num_docs = read_u32_vint(data);
+            let block_num_bytes = read_u32_vint(data) as usize;
             self.checkpoints.push(Checkpoint {
                 doc_range: doc..doc + num_docs,
                 byte_range: start_offset..start_offset + block_num_bytes,


### PR DESCRIPTION
```
Tested on index with sorting (testset with 13 fastfields)

Before
   - 10,66% tantivy::indexer::segment_writer::SegmentWriter::finalize                                                                                                                   
      + 5,80% tantivy::fastfield::writer::FastFieldsWriter::serialize                                                                                                                   
      - 4,75% tantivy::store::reader::StoreReader::get_document_bytes                                                                                                                   
         - 2,55% tantivy::store::index::block::CheckpointBlock::deserialize                                                                                                             
              1,41% <tantivy_common::vint::VInt as tantivy_common::serialize::BinarySerializable>::deserialize                                                                          
         + 1,23% tantivy::store::reader::StoreReader::read_block                                                                                                                        

Faster Deserialization
   - 10,10% tantivy::indexer::segment_writer::SegmentWriter::finalize                                                                                                                   
      + 5,98% tantivy::fastfield::writer::FastFieldsWriter::serialize                                                                                                                   
      - 4,02% tantivy::store::reader::StoreReader::get_document_bytes                                                                                                                   
         + 1,94% tantivy::store::index::block::CheckpointBlock::deserialize                                                                                                             
         + 1,08% tantivy::store::reader::StoreReader::read_block                                                                                                               


Faster Deserialization & 16KB BLOCKS
-    9,74%     0,55%  thrd-tantivy-in  tantivy               [.] tantivy::indexer::segment_writer::SegmentWriter::finalize                                                              
   - 9,19% tantivy::indexer::segment_writer::SegmentWriter::finalize                                                                                                                    
      + 6,26% tantivy::fastfield::writer::FastFieldsWriter::serialize                                                                                                                   
      - 2,80% tantivy::store::reader::StoreReader::get_document_bytes                                                                                                                   
         + 1,22% tantivy::store::index::block::CheckpointBlock::deserialize                                                                                                             
         + 1,03% tantivy::store::reader::StoreReader::read_block     
```