### PR TITLE
remove Column from MultiValuedU128FastFieldReader

### DIFF
--- a/fastfield_codecs/src/column.rs
+++ b/fastfield_codecs/src/column.rs
@@ -70,11 +70,6 @@ pub trait Column<T: PartialOrd = u64>: Send + Sync {
     /// The number of values in the column.
     fn num_vals(&self) -> u32;
 
-    /// The number of docs in the column. For single value columns this equals num_vals.
-    fn num_docs(&self) -> u32 {
-        self.num_vals()
-    }
-
     /// Returns a iterator over the data
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = T> + 'a> {
         Box::new((0..self.num_vals()).map(|idx| self.get_val(idx)))

--- a/src/fastfield/multivalued/reader.rs
+++ b/src/fastfield/multivalued/reader.rs
@@ -177,33 +177,10 @@ impl<T: MonotonicallyMappableToU128> MultiValuedU128FastFieldReader<T> {
         );
         self.idx_reader.total_num_vals()
     }
-}
 
-// TODO having something that looks like MultiColumn trait.
-// See discussion in #1679
-impl<T: MonotonicallyMappableToU128> Column<T> for MultiValuedU128FastFieldReader<T> {
-    fn get_val(&self, _idx: u32) -> T {
-        panic!("calling get_val on a multivalue field indicates a bug")
-    }
-
-    fn min_value(&self) -> T {
-        (self as &MultiValuedU128FastFieldReader<T>).min_value()
-    }
-
-    fn max_value(&self) -> T {
-        (self as &MultiValuedU128FastFieldReader<T>).max_value()
-    }
-
-    fn num_vals(&self) -> u32 {
-        self.total_num_vals() as u32
-    }
-
-    fn num_docs(&self) -> u32 {
-        self.get_index_reader().num_docs()
-    }
-
+    /// Returns the docids matching given doc_id_range and value_range.
     #[inline]
-    fn get_docids_for_value_range(
+    pub fn get_docids_for_value_range(
         &self,
         value_range: RangeInclusive<T>,
         doc_id_range: Range<u32>,

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -800,7 +800,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::net::Ipv6Addr;
 
-    use fastfield_codecs::{Column, MonotonicallyMappableToU128};
+    use fastfield_codecs::MonotonicallyMappableToU128;
     use proptest::prelude::*;
     use proptest::prop_oneof;
     use proptest::strategy::Strategy;
@@ -1851,7 +1851,7 @@ mod tests {
                 .iter()
                 .map(|segment_reader| {
                     let ff_reader = segment_reader.fast_fields().ip_addrs(ips_field).unwrap();
-                    ff_reader.num_docs() as usize
+                    ff_reader.get_index_reader().num_docs() as usize
                 })
                 .sum();
             assert_eq!(num_docs, num_docs_expected);


### PR DESCRIPTION
I opted for the enum version, since it's more readable compared to the trait version