### PR TITLE
add support for TermSetQuery in query parser

### DIFF
--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -5,7 +5,8 @@ use combine::parser::range::{take_while, take_while1};
 use combine::parser::repeat::escaped;
 use combine::parser::Parser;
 use combine::{
-    attempt, choice, eof, many, many1, one_of, optional, parser, satisfy, skip_many1, value,
+    attempt, between, choice, eof, many, many1, one_of, optional, parser, satisfy, sep_by,
+    skip_many1, value,
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -264,6 +265,21 @@ fn range<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
     })
 }
 
+/// Function that parses a set out of a Stream
+/// Supports ranges like: `field: IN [val1, val2, val3]`
+fn set<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
+    let comma_list = sep_by(term_val(), spaces());
+
+    let set_content = (
+        (string("IN"), spaces()),
+        between(char('['), char(']'), comma_list),
+    )
+        .map(|(_, elements)| elements);
+
+    (field_name().skip(spaces()), set_content)
+        .map(|(field, elements)| UserInputLeaf::Set { field, elements })
+}
+
 fn negate(expr: UserInputAst) -> UserInputAst {
     expr.unary(Occur::MustNot)
 }
@@ -278,6 +294,7 @@ fn leaf<'a>() -> impl Parser<&'a str, Output = UserInputAst> {
                 string("NOT").skip(spaces1()).with(leaf()).map(negate),
             ))
             .or(attempt(range().map(UserInputAst::from)))
+            .or(attempt(set().map(UserInputAst::from)))
             .or(literal().map(UserInputAst::from))
             .parse_stream(input)
             .into_result()
@@ -745,6 +762,13 @@ mod test {
     #[test]
     fn test_parse_test_query_plus_a_b_plus_d() {
         test_parse_query_to_ast_helper("+(a b) +d", "(+(*\"a\" *\"b\") +\"d\")");
+    }
+
+    #[test]
+    fn test_parse_test_query_set() {
+        test_parse_query_to_ast_helper("abc: IN [a b c]", r#""abc": IN ["a", "b", "c"]"#);
+        test_parse_query_to_ast_helper("abc: IN [1]", r#""abc": IN ["1"]"#);
+        test_parse_query_to_ast_helper("abc: IN []", r#""abc": IN []"#);
     }
 
     #[test]

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -268,9 +268,9 @@ fn range<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
 /// Function that parses a set out of a Stream
 /// Supports ranges like: `IN [val1 val2 val3]`
 fn set<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
-    let list = between(char('['), char(']'), sep_by(term_val(), spaces()));
+    let term_list = between(char('['), char(']'), sep_by(term_val(), spaces()));
 
-    let set_content = ((string("IN"), spaces()), list).map(|(_, elements)| elements);
+    let set_content = ((string("IN"), spaces()), term_list).map(|(_, elements)| elements);
 
     (optional(attempt(field_name().skip(spaces()))), set_content)
         .map(|(field, elements)| UserInputLeaf::Set { field, elements })

--- a/query-grammar/src/user_input_ast.rs
+++ b/query-grammar/src/user_input_ast.rs
@@ -12,6 +12,10 @@ pub enum UserInputLeaf {
         lower: UserInputBound,
         upper: UserInputBound,
     },
+    Set {
+        field: String,
+        elements: Vec<String>,
+    },
 }
 
 impl Debug for UserInputLeaf {
@@ -30,6 +34,17 @@ impl Debug for UserInputLeaf {
                 write!(formatter, " TO ")?;
                 upper.display_upper(formatter)?;
                 Ok(())
+            }
+            UserInputLeaf::Set { field, elements } => {
+                write!(formatter, "\"{}\": IN [", field)?;
+                for (i, element) in elements.iter().enumerate() {
+                    if i == 0 {
+                        write!(formatter, "\"{}\"", element)?;
+                    } else {
+                        write!(formatter, ", \"{}\"", element)?;
+                    }
+                }
+                write!(formatter, "]")
             }
             UserInputLeaf::All => write!(formatter, "*"),
         }

--- a/query-grammar/src/user_input_ast.rs
+++ b/query-grammar/src/user_input_ast.rs
@@ -13,7 +13,7 @@ pub enum UserInputLeaf {
         upper: UserInputBound,
     },
     Set {
-        field: String,
+        field: Option<String>,
         elements: Vec<String>,
     },
 }
@@ -36,12 +36,16 @@ impl Debug for UserInputLeaf {
                 Ok(())
             }
             UserInputLeaf::Set { field, elements } => {
-                write!(formatter, "\"{}\": IN [", field)?;
+                if let Some(ref field) = field {
+                    write!(formatter, "\"{}\": IN [", field)?;
+                } else {
+                    write!(formatter, "IN [")?;
+                }
                 for (i, element) in elements.iter().enumerate() {
                     if i == 0 {
                         write!(formatter, "\"{}\"", element)?;
                     } else {
-                        write!(formatter, ", \"{}\"", element)?;
+                        write!(formatter, " \"{}\"", element)?;
                     }
                 }
                 write!(formatter, "]")

--- a/query-grammar/src/user_input_ast.rs
+++ b/query-grammar/src/user_input_ast.rs
@@ -37,16 +37,14 @@ impl Debug for UserInputLeaf {
             }
             UserInputLeaf::Set { field, elements } => {
                 if let Some(ref field) = field {
-                    write!(formatter, "\"{}\": IN [", field)?;
-                } else {
-                    write!(formatter, "IN [")?;
+                    write!(formatter, "\"{}\": ", field)?;
                 }
+                write!(formatter, "IN [")?;
                 for (i, element) in elements.iter().enumerate() {
-                    if i == 0 {
-                        write!(formatter, "\"{}\"", element)?;
-                    } else {
-                        write!(formatter, " \"{}\"", element)?;
+                    if i != 0 {
+                        write!(formatter, " ")?;
                     }
+                    write!(formatter, "\"{}\"", element)?;
                 }
                 write!(formatter, "]")
             }

--- a/src/query/query_parser/logical_ast.rs
+++ b/src/query/query_parser/logical_ast.rs
@@ -15,6 +15,11 @@ pub enum LogicalLiteral {
         lower: Bound<Term>,
         upper: Bound<Term>,
     },
+    Set {
+        field: Field,
+        value_type: Type,
+        elements: Vec<Term>,
+    },
     All,
 }
 
@@ -87,6 +92,27 @@ impl fmt::Debug for LogicalLiteral {
                 ref upper,
                 ..
             } => write!(formatter, "({:?} TO {:?})", lower, upper),
+            LogicalLiteral::Set { ref elements, .. } => {
+                const MAX_DISPLAYED: usize = 10;
+
+                write!(formatter, "IN [")?;
+                for (i, element) in elements.iter().enumerate() {
+                    if i == 0 {
+                        write!(formatter, "{:?}", element)?;
+                    } else if i == MAX_DISPLAYED - 1 {
+                        write!(
+                            formatter,
+                            ", {:?}, ... ({} more)",
+                            element,
+                            elements.len() - i - 1
+                        )?;
+                        break;
+                    } else {
+                        write!(formatter, ", {:?}", element)?;
+                    }
+                }
+                write!(formatter, "]")
+            }
             LogicalLiteral::All => write!(formatter, "*"),
         }
     }

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -686,9 +686,14 @@ impl QueryParser {
                 Ok(logical_ast)
             }
             UserInputLeaf::Set {
-                field: full_path,
+                field: full_field_opt,
                 elements,
             } => {
+                let full_path = full_field_opt.ok_or_else(|| {
+                    QueryParserError::UnsupportedQuery(
+                        "Set query need to target a specific field.".to_string(),
+                    )
+                })?;
                 let (field, json_path) = self
                     .split_full_path(&full_path)
                     .ok_or_else(|| QueryParserError::FieldDoesNotExist(full_path.clone()))?;

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -13,7 +13,7 @@ use crate::indexer::{
 };
 use crate::query::{
     AllQuery, BooleanQuery, BoostQuery, EmptyQuery, Occur, PhraseQuery, Query, RangeQuery,
-    TermQuery,
+    TermQuery, TermSetQuery,
 };
 use crate::schema::{
     Facet, FacetParseError, Field, FieldType, IndexRecordOption, IntoIpv6Addr, Schema, Term, Type,
@@ -685,6 +685,26 @@ impl QueryParser {
                 }));
                 Ok(logical_ast)
             }
+            UserInputLeaf::Set {
+                field: full_path,
+                elements,
+            } => {
+                let (field, json_path) = self
+                    .split_full_path(&full_path)
+                    .ok_or_else(|| QueryParserError::FieldDoesNotExist(full_path.clone()))?;
+                let field_entry = self.schema.get_field_entry(field);
+                let value_type = field_entry.field_type().value_type();
+                let logical_ast = LogicalAst::Leaf(Box::new(LogicalLiteral::Set {
+                    elements: elements
+                        .into_iter()
+                        .map(|element| self.compute_boundary_term(field, json_path, &element))
+                        .collect::<Result<Vec<_>, _>>()?,
+
+                    field,
+                    value_type,
+                }));
+                Ok(logical_ast)
+            }
         }
     }
 }
@@ -703,6 +723,7 @@ fn convert_literal_to_query(logical_literal: LogicalLiteral) -> Box<dyn Query> {
         } => Box::new(RangeQuery::new_term_bounds(
             field, value_type, &lower, &upper,
         )),
+        LogicalLiteral::Set { elements, .. } => Box::new(TermSetQuery::new(elements)),
         LogicalLiteral::All => Box::new(AllQuery),
     }
 }
@@ -1538,6 +1559,31 @@ mod test {
         test_parse_query_to_logical_ast_helper(
             "title:\"a b~4\"~2",
             r#""[(0, Term(type=Str, field=0, "a")), (1, Term(type=Str, field=0, "b")), (2, Term(type=Str, field=0, "4"))]"~2"#,
+            false,
+        );
+    }
+
+    #[test]
+    pub fn test_term_set_query() {
+        test_parse_query_to_logical_ast_helper(
+            "title: IN [a b cd]",
+            r#"IN [Term(type=Str, field=0, "a"), Term(type=Str, field=0, "b"), Term(type=Str, field=0, "cd")]"#,
+            false,
+        );
+        test_parse_query_to_logical_ast_helper(
+            "bytes: IN [AA== ABA= ABCD]",
+            r#"IN [Term(type=Bytes, field=12, [0]), Term(type=Bytes, field=12, [0, 16]), Term(type=Bytes, field=12, [0, 16, 131])]"#,
+            false,
+        );
+        test_parse_query_to_logical_ast_helper(
+            "signed: IN [1 2 -3]",
+            r#"IN [Term(type=I64, field=2, 1), Term(type=I64, field=2, 2), Term(type=I64, field=2, -3)]"#,
+            false,
+        );
+
+        test_parse_query_to_logical_ast_helper(
+            "float: IN [1.1 2.2 -3.3]",
+            r#"IN [Term(type=F64, field=10, 1.1), Term(type=F64, field=10, 2.2), Term(type=F64, field=10, -3.3)]"#,
             false,
         );
     }


### PR DESCRIPTION
Add support for creating a `TermSetQuery` from the query parser with `field: IN [val1 val2 val3]`