### PR TITLE
Move `split_full_path` to `Schema`

### DIFF
--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -216,7 +216,7 @@ impl QueryParser {
     // Splits a full_path as written in a query, into a field name and a
     // json path.
     pub(crate) fn split_full_path<'a>(&self, full_path: &'a str) -> Option<(Field, &'a str)> {
-        self.schema.split_full_path(full_path)
+        self.schema.find_field(full_path)
     }
 
     /// Creates a `QueryParser`, given

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -252,6 +252,31 @@ impl Eq for InnerSchema {}
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Schema(Arc<InnerSchema>);
 
+// Returns the position (in byte offsets) of the unescaped '.' in the `field_path`.
+//
+// This function operates directly on bytes (as opposed to codepoint), relying
+// on a encoding property of utf-8 for its correctness.
+fn locate_splitting_dots(field_path: &str) -> Vec<usize> {
+    let mut splitting_dots_pos = Vec::new();
+    let mut escape_state = false;
+    for (pos, b) in field_path.bytes().enumerate() {
+        if escape_state {
+            escape_state = false;
+            continue;
+        }
+        match b {
+            b'\\' => {
+                escape_state = true;
+            }
+            b'.' => {
+                splitting_dots_pos.push(pos);
+            }
+            _ => {}
+        }
+    }
+    splitting_dots_pos
+}
+
 impl Schema {
     /// Return the `FieldEntry` associated with a `Field`.
     pub fn get_field_entry(&self, field: Field) -> &FieldEntry {
@@ -358,6 +383,21 @@ impl Schema {
         }
         Ok(doc)
     }
+
+    /// Splits a full_path, into a field name and a json path.
+    pub fn split_full_path<'a>(&self, full_path: &'a str) -> Option<(Field, &'a str)> {
+        if let Some(field) = self.0.fields_map.get(full_path) {
+            return Some((*field, ""));
+        }
+        let mut splitting_period_pos: Vec<usize> = locate_splitting_dots(full_path);
+        while let Some(pos) = splitting_period_pos.pop() {
+            let (prefix, suffix) = full_path.split_at(pos);
+            if let Some(field) = self.0.fields_map.get(prefix) {
+                return Some((*field, &suffix[1..]));
+            }
+        }
+        None
+    }
 }
 
 impl Serialize for Schema {
@@ -435,6 +475,13 @@ mod tests {
     use crate::schema::numeric_options::Cardinality::SingleValue;
     use crate::schema::schema::DocParsingError::InvalidJson;
     use crate::schema::*;
+
+    #[test]
+    fn test_locate_splitting_dots() {
+        assert_eq!(&super::locate_splitting_dots("a.b.c"), &[1, 3]);
+        assert_eq!(&super::locate_splitting_dots(r#"a\.b.c"#), &[4]);
+        assert_eq!(&super::locate_splitting_dots(r#"a\..b.c"#), &[3, 5]);
+    }
 
     #[test]
     pub fn is_indexed_test() {

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -409,9 +409,7 @@ impl Schema {
 
 impl Serialize for Schema {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
+    where S: Serializer {
         let mut seq = serializer.serialize_seq(Some(self.0.fields.len()))?;
         for e in &self.0.fields {
             seq.serialize_element(e)?;
@@ -422,9 +420,7 @@ impl Serialize for Schema {
 
 impl<'de> Deserialize<'de> for Schema {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
+    where D: Deserializer<'de> {
         struct SchemaVisitor;
 
         impl<'de> Visitor<'de> for SchemaVisitor {
@@ -435,9 +431,7 @@ impl<'de> Deserialize<'de> for Schema {
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
+            where A: SeqAccess<'de> {
                 let mut schema = SchemaBuilder {
                     fields: Vec::with_capacity(seq.size_hint().unwrap_or(0)),
                     fields_map: HashMap::with_capacity(seq.size_hint().unwrap_or(0)),

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -384,8 +384,8 @@ impl Schema {
         Ok(doc)
     }
 
-    /// Splits a full_path, into a field name and a json path.
-    pub fn split_full_path<'a>(&self, full_path: &'a str) -> Option<(Field, &'a str)> {
+    /// Searches for a full_path, returning the field name and a json path.
+    pub fn find_field<'a>(&self, full_path: &'a str) -> Option<(Field, &'a str)> {
         if let Some(field) = self.0.fields_map.get(full_path) {
             return Some((*field, ""));
         }


### PR DESCRIPTION
Having this method on the `Schema` level will help simplify the code on Quickwit for the issue https://github.com/quickwit-oss/quickwit/pull/2260.

Also, this comes with a bonus of removing the `field_names` hashmap from `QueryParser`.