### PR TITLE
Bump prettytables

### DIFF
--- a/fastfield_codecs/Cargo.toml
+++ b/fastfield_codecs/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/quickwit-oss/tantivy"
 [dependencies]
 common = { version = "0.5", path = "../common/", package = "tantivy-common" }
 tantivy-bitpacker = { version= "0.3", path = "../bitpacker/" }
-prettytable-rs = {version="0.9.0", optional= true}
+prettytable-rs = {version="0.10.0", optional= true}
 rand = {version="0.8.3", optional= true}
 fastdivide = "0.4"
 log = "0.4"


### PR DESCRIPTION
Fixes an issue with some latest nightly builds (stable as usual worked) and there was unsafe API that got removed.