### PR TITLE
More cosmetic fixes for upcoming Clippy lints.

### DIFF
--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -1208,7 +1208,7 @@ mod tests {
                         text_field_many_terms => many_terms_data.choose(&mut rng).unwrap().to_string(),
                         text_field_few_terms => few_terms_data.choose(&mut rng).unwrap().to_string(),
                         score_field => val as u64,
-                        score_field_f64 => val as f64,
+                        score_field_f64 => val,
                         score_field_i64 => val as i64,
                     ))?;
                 }
@@ -1250,10 +1250,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req_1, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&term_query, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&term_query, &collector).unwrap()
             });
         }
 
@@ -1281,10 +1278,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req_1, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&term_query, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&term_query, &collector).unwrap()
             });
         }
 
@@ -1312,10 +1306,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req_1, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&term_query, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&term_query, &collector).unwrap()
             });
         }
 
@@ -1351,10 +1342,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req_1, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&term_query, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&term_query, &collector).unwrap()
             });
         }
 
@@ -1380,10 +1368,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&AllQuery, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&AllQuery, &collector).unwrap()
             });
         }
 
@@ -1409,10 +1394,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&AllQuery, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&AllQuery, &collector).unwrap()
             });
         }
 
@@ -1446,10 +1428,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req_1, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&AllQuery, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&AllQuery, &collector).unwrap()
             });
         }
 
@@ -1481,10 +1460,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req_1, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&AllQuery, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&AllQuery, &collector).unwrap()
             });
         }
 
@@ -1520,10 +1496,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req_1, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&AllQuery, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&AllQuery, &collector).unwrap()
             });
         }
 
@@ -1550,10 +1523,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req_1, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&AllQuery, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&AllQuery, &collector).unwrap()
             });
         }
 
@@ -1597,7 +1567,7 @@ mod tests {
                                 ],
                                 ..Default::default()
                             }),
-                            sub_aggregation: sub_agg_req_1.clone(),
+                            sub_aggregation: sub_agg_req_1,
                         }),
                     ),
                 ]
@@ -1607,10 +1577,7 @@ mod tests {
                 let collector = AggregationCollector::from_aggs(agg_req_1, None, index.schema());
 
                 let searcher = reader.searcher();
-                let agg_res: AggregationResults =
-                    searcher.search(&term_query, &collector).unwrap().into();
-
-                agg_res
+                searcher.search(&term_query, &collector).unwrap()
             });
         }
     }

--- a/src/fastfield/alive_bitset.rs
+++ b/src/fastfield/alive_bitset.rs
@@ -175,7 +175,7 @@ mod bench {
 
     fn get_alive() -> Vec<u32> {
         let mut data = (0..1_000_000_u32).collect::<Vec<u32>>();
-        for _ in 0..(1_000_000) * 1 / 8 {
+        for _ in 0..1_000_000 / 8 {
             remove_rand(&mut data);
         }
         data

--- a/src/fastfield/multivalued/mod.rs
+++ b/src/fastfield/multivalued/mod.rs
@@ -525,7 +525,7 @@ mod bench {
             serializer.close().unwrap();
             field
         };
-        let file = directory.open_read(&path).unwrap();
+        let file = directory.open_read(path).unwrap();
         {
             let fast_fields_composite = CompositeFile::open(&file).unwrap();
             let data_idx = fast_fields_composite

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,14 @@
 #![doc(html_logo_url = "http://fulmicoton.com/tantivy-logo/tantivy-logo.png")]
 #![cfg_attr(all(feature = "unstable", test), feature(test))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(
-        clippy::module_inception,
-        clippy::needless_range_loop,
-        clippy::bool_assert_comparison
-    )
-)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![warn(missing_docs)]
-#![allow(clippy::len_without_is_empty)]
-#![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(
+    clippy::len_without_is_empty,
+    clippy::derive_partial_eq_without_eq,
+    clippy::module_inception,
+    clippy::needless_range_loop,
+    clippy::bool_assert_comparison
+)]
 
 //! # `tantivy`
 //!

--- a/src/postings/mod.rs
+++ b/src/postings/mod.rs
@@ -631,7 +631,7 @@ mod bench {
             let mut segment_postings = segment_reader
                 .inverted_index(TERM_A.field())
                 .unwrap()
-                .read_postings(&*TERM_A, IndexRecordOption::Basic)
+                .read_postings(&TERM_A, IndexRecordOption::Basic)
                 .unwrap()
                 .unwrap();
             while segment_postings.advance() != TERMINATED {}
@@ -647,25 +647,25 @@ mod bench {
             let segment_postings_a = segment_reader
                 .inverted_index(TERM_A.field())
                 .unwrap()
-                .read_postings(&*TERM_A, IndexRecordOption::Basic)
+                .read_postings(&TERM_A, IndexRecordOption::Basic)
                 .unwrap()
                 .unwrap();
             let segment_postings_b = segment_reader
                 .inverted_index(TERM_B.field())
                 .unwrap()
-                .read_postings(&*TERM_B, IndexRecordOption::Basic)
+                .read_postings(&TERM_B, IndexRecordOption::Basic)
                 .unwrap()
                 .unwrap();
             let segment_postings_c = segment_reader
                 .inverted_index(TERM_C.field())
                 .unwrap()
-                .read_postings(&*TERM_C, IndexRecordOption::Basic)
+                .read_postings(&TERM_C, IndexRecordOption::Basic)
                 .unwrap()
                 .unwrap();
             let segment_postings_d = segment_reader
                 .inverted_index(TERM_D.field())
                 .unwrap()
-                .read_postings(&*TERM_D, IndexRecordOption::Basic)
+                .read_postings(&TERM_D, IndexRecordOption::Basic)
                 .unwrap()
                 .unwrap();
             let mut intersection = Intersection::new(vec![
@@ -687,7 +687,7 @@ mod bench {
         let mut segment_postings = segment_reader
             .inverted_index(TERM_A.field())
             .unwrap()
-            .read_postings(&*TERM_A, IndexRecordOption::Basic)
+            .read_postings(&TERM_A, IndexRecordOption::Basic)
             .unwrap()
             .unwrap();
 
@@ -705,7 +705,7 @@ mod bench {
             let mut segment_postings = segment_reader
                 .inverted_index(TERM_A.field())
                 .unwrap()
-                .read_postings(&*TERM_A, IndexRecordOption::Basic)
+                .read_postings(&TERM_A, IndexRecordOption::Basic)
                 .unwrap()
                 .unwrap();
             for doc in &existing_docs {
@@ -746,7 +746,7 @@ mod bench {
             let mut segment_postings = segment_reader
                 .inverted_index(TERM_A.field())
                 .unwrap()
-                .read_postings(&*TERM_A, IndexRecordOption::Basic)
+                .read_postings(&TERM_A, IndexRecordOption::Basic)
                 .unwrap()
                 .unwrap();
             let mut s = 0u32;

--- a/src/query/range_query/range_query_ip_fastfield.rs
+++ b/src/query/range_query/range_query_ip_fastfield.rs
@@ -313,8 +313,7 @@ mod bench {
             })
             .collect();
 
-        let index = create_index_from_docs(&docs);
-        index
+        create_index_from_docs(&docs)
     }
 
     fn get_90_percent() -> RangeInclusive<Ipv6Addr> {
@@ -353,7 +352,7 @@ mod bench {
 
         let query = gen_query_inclusive(ip_range.start(), ip_range.end());
         let query_from_text = |text: &str| {
-            QueryParser::for_index(&index, vec![])
+            QueryParser::for_index(index, vec![])
                 .parse_query(text)
                 .unwrap()
         };

--- a/src/query/range_query/range_query_u64_fastfield.rs
+++ b/src/query/range_query/range_query_u64_fastfield.rs
@@ -358,8 +358,7 @@ mod bench {
             })
             .collect();
 
-        let index = create_index_from_docs(&docs);
-        index
+        create_index_from_docs(&docs)
     }
 
     fn get_90_percent() -> RangeInclusive<u64> {
@@ -392,7 +391,7 @@ mod bench {
 
         let query = gen_query_inclusive(id_range.start(), id_range.end());
         let query_from_text = |text: &str| {
-            QueryParser::for_index(&index, vec![])
+            QueryParser::for_index(index, vec![])
                 .parse_query(text)
                 .unwrap()
         };


### PR DESCRIPTION
There are still some missing docs in the `fastfield_codecs` crate and Clippy will go nuts about `uninlined-format-args` if that ever reaches a stable version, but this should already make for a smaller diff before the next Clippy release.