### PR TITLE
Allow range queries via fast fields on non-indexed fields

### DIFF
--- a/src/query/range_query/mod.rs
+++ b/src/query/range_query/mod.rs
@@ -3,4 +3,6 @@ mod range_query;
 mod range_query_ip_fastfield;
 mod range_query_u64_fastfield;
 
+pub(crate) use range_query::is_type_valid_for_fastfield_range_query;
+
 pub use self::range_query::RangeQuery;

--- a/src/query/range_query/range_query.rs
+++ b/src/query/range_query/range_query.rs
@@ -287,7 +287,7 @@ impl RangeQuery {
     }
 }
 
-fn is_type_valid_for_fastfield_range_query(typ: Type) -> bool {
+pub(crate) fn is_type_valid_for_fastfield_range_query(typ: Type) -> bool {
     match typ {
         Type::U64 | Type::I64 | Type::F64 | Type::Bool | Type::Date => true,
         Type::IpAddr => true,


### PR DESCRIPTION
Generalize the existing IP address field's logic to the datetime and u64 fields.