### PR TITLE
Add MIT license to tokenizer-api crate

### DIFF
--- a/tokenizer-api/Cargo.toml
+++ b/tokenizer-api/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "tantivy-tokenizer-api"
 version = "0.1.0"
+license = "MIT"
 edition = "2021"
 description = "Tokenizer API of tantivy"
 


### PR DESCRIPTION
Quickwit CI job complains about missing license.