### PR TITLE
modify getters for sstable metadata

### DIFF
--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -206,7 +206,7 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
         let mut term_ord = 0u64;
         let key_bytes = key.as_ref();
         let mut sstable_reader = self.sstable_reader()?;
-        while sstable_reader.advance().unwrap_or(false) {
+        while sstable_reader.advance()? {
             if sstable_reader.key() == key_bytes {
                 return Ok(Some(term_ord));
             }
@@ -233,8 +233,8 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
 
         // then search inside that block only
         let mut sstable_reader = self.sstable_reader_block(block_addr)?;
-        for _ in first_ordinal..(ord + 1) {
-            if !sstable_reader.advance().unwrap_or(false) {
+        for _ in first_ordinal..=ord {
+            if !sstable_reader.advance()? {
                 return Ok(false);
             }
         }
@@ -253,8 +253,8 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
 
         // then search inside that block only
         let mut sstable_reader = self.sstable_reader_block(block_addr)?;
-        for _ in first_ordinal..(term_ord + 1) {
-            if !sstable_reader.advance().unwrap_or(false) {
+        for _ in first_ordinal..=term_ord {
+            if !sstable_reader.advance()? {
                 return Ok(None);
             }
         }
@@ -266,7 +266,7 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
         if let Some(block_addr) = self.sstable_index.search_block(key.as_ref()) {
             let mut sstable_reader = self.sstable_reader_block(block_addr)?;
             let key_bytes = key.as_ref();
-            while sstable_reader.advance().unwrap_or(false) {
+            while sstable_reader.advance()? {
                 if sstable_reader.key() == key_bytes {
                     let value = sstable_reader.value().clone();
                     return Ok(Some(value));
@@ -281,7 +281,7 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
         if let Some(block_addr) = self.sstable_index.search_block(key.as_ref()) {
             let mut sstable_reader = self.sstable_reader_block_async(block_addr).await?;
             let key_bytes = key.as_ref();
-            while sstable_reader.advance().unwrap_or(false) {
+            while sstable_reader.advance()? {
                 if sstable_reader.key() == key_bytes {
                     let value = sstable_reader.value().clone();
                     return Ok(Some(value));

--- a/sstable/src/sstable_index.rs
+++ b/sstable/src/sstable_index.rs
@@ -144,7 +144,7 @@ mod tests {
     fn test_sstable_index() {
         let mut sstable_builder = SSTableIndexBuilder::default();
         sstable_builder.add_block(b"aaa", 10..20, 0u64);
-        sstable_builder.add_block(b"bbbbbbb", 20..30, 564);
+        sstable_builder.add_block(b"bbbbbbb", 20..30, 5u64);
         sstable_builder.add_block(b"ccc", 30..40, 10u64);
         sstable_builder.add_block(b"dddd", 40..50, 15u64);
         let mut buffer: Vec<u8> = Vec::new();
@@ -157,13 +157,25 @@ mod tests {
                 byte_range: 30..40
             })
         );
+
+        assert_eq!(sstable_index.locate_with_key(b"aa").unwrap(), 0);
+        assert_eq!(sstable_index.locate_with_key(b"aaa").unwrap(), 0);
+        assert_eq!(sstable_index.locate_with_key(b"aab").unwrap(), 1);
+        assert_eq!(sstable_index.locate_with_key(b"ccc").unwrap(), 2);
+        assert!(sstable_index.locate_with_key(b"e").is_none());
+
+        assert_eq!(sstable_index.locate_with_ord(0), 0);
+        assert_eq!(sstable_index.locate_with_ord(1), 0);
+        assert_eq!(sstable_index.locate_with_ord(4), 0);
+        assert_eq!(sstable_index.locate_with_ord(5), 1);
+        assert_eq!(sstable_index.locate_with_ord(100), 3);
     }
 
     #[test]
     fn test_sstable_with_corrupted_data() {
         let mut sstable_builder = SSTableIndexBuilder::default();
         sstable_builder.add_block(b"aaa", 10..20, 0u64);
-        sstable_builder.add_block(b"bbbbbbb", 20..30, 564);
+        sstable_builder.add_block(b"bbbbbbb", 20..30, 5u64);
         sstable_builder.add_block(b"ccc", 30..40, 10u64);
         sstable_builder.add_block(b"dddd", 40..50, 15u64);
         let mut buffer: Vec<u8> = Vec::new();

--- a/sstable/src/value/mod.rs
+++ b/sstable/src/value/mod.rs
@@ -16,7 +16,7 @@ pub trait ValueReader: Default {
 
     /// Loads a block.
     ///
-    /// Returns the number of bytes that were written.
+    /// Returns the number of bytes that were read.
     fn load(&mut self, data: &[u8]) -> io::Result<usize>;
 }
 


### PR DESCRIPTION
this adds support for limit when ranging over an sstable, and makes a few function read less blocks by leveraging sstable metadata more.

This is ready for review, however I'd like to add tests before merging to make sure no of-by-one slipped in