### PR TITLE
Introduced a select cursor.

### DIFF
--- a/columnar/src/column_index/optional_index/set.rs
+++ b/columnar/src/column_index/optional_index/set.rs
@@ -13,7 +13,19 @@ pub trait SetCodec {
     fn open<'a>(data: &'a [u8]) -> Self::Reader<'a>;
 }
 
+
+/// Stateful object that makes it possible to compute several select in a row,
+/// provided the rank passed as argument are increasing.
+pub trait SelectCursor<T> {
+    // May panic if rank is greater than the number of elements in the Set,
+    // or if rank is < than value provided in the previous call.
+    fn select(&mut self, rank: T) -> T;
+}
+
 pub trait Set<T> {
+    type SelectCursor<'b>: SelectCursor<T> where Self: 'b;
+
+
     /// Returns true if the elements is contained in the Set
     fn contains(&self, el: T) -> bool;
 
@@ -28,11 +40,6 @@ pub trait Set<T> {
     /// May panic if rank is greater than the number of elements in the Set.
     fn select(&self, rank: T) -> T;
 
-    /// Batch version of select.
-    /// `ranks` is assumed to be sorted.
-    ///
-    /// # Panics
-    ///
-    /// May panic if rank is greater than the number of elements in the Set.
-    fn select_batch(&self, ranks: &[T], outputs: &mut [T]);
+    /// Creates a brand new select cursor.
+    fn select_cursor<'b>(&'b self,) -> Self::SelectCursor<'b>;
 }


### PR DESCRIPTION
The goal of the PR is more to allow in-place select to unify code in the range query.
There seems to be a small perf improvment as a bonus.

Before
```
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_10percent_filled_0comma005percent_hit ... bench:       1,219 ns/iter (+/- 25)
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_1percent_filled_0comma005percent_hit  ... bench:          18 ns/iter (+/- 0)
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_1percent_filled_10percent_hit         ... bench:       4,004 ns/iter (+/- 81)
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_1percent_filled_full_scan             ... bench:      38,154 ns/iter (+/- 782)
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_90percent_filled_0comma005percent_hit ... bench:       7,296 ns/iter (+/- 134)
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_90percent_filled_full_scan            ... bench:  17,812,681 ns/iter (+/- 57,394)
```

After
```
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_10percent_filled_0comma005percent_hit ... bench:       1,140 ns/iter (+/- 19)
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_1percent_filled_0comma005percent_hit  ... bench:           2 ns/iter (+/- 0)
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_1percent_filled_10percent_hit         ... bench:       2,373 ns/iter (+/- 38)
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_1percent_filled_full_scan             ... bench:      22,787 ns/iter (+/- 225)
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_90percent_filled_0comma005percent_hit ... bench:       7,120 ns/iter (+/- 96)
test column_index::optional_index::tests::bench::bench_translate_codec_to_orig_90percent_filled_full_scan            ... bench:  17,150,903 ns/iter (+/- 36,651)

```