### PR TITLE
Fixing test_fail_on_flush_segment_but_one_worker_remains

### DIFF
--- a/columnar/src/columnar/writer/mod.rs
+++ b/columnar/src/columnar/writer/mod.rs
@@ -63,12 +63,12 @@ pub struct ColumnarWriter {
 impl Default for ColumnarWriter {
     fn default() -> Self {
         ColumnarWriter {
-            numerical_field_hash_map: ArenaHashMap::new(10_000),
-            bool_field_hash_map: ArenaHashMap::new(10_000),
-            ip_addr_field_hash_map: ArenaHashMap::new(10_000),
-            bytes_field_hash_map: ArenaHashMap::new(10_000),
-            str_field_hash_map: ArenaHashMap::new(10_000),
-            datetime_field_hash_map: ArenaHashMap::new(10_000),
+            numerical_field_hash_map: ArenaHashMap::new(),
+            bool_field_hash_map: ArenaHashMap::new(),
+            ip_addr_field_hash_map: ArenaHashMap::new(),
+            bytes_field_hash_map: ArenaHashMap::new(),
+            str_field_hash_map: ArenaHashMap::new(),
+            datetime_field_hash_map: ArenaHashMap::new(),
             dictionaries: Vec::new(),
             arena: MemoryArena::default(),
             buffers: SpareBuffers::default(),

--- a/src/aggregation/bucket/histogram/mod.rs
+++ b/src/aggregation/bucket/histogram/mod.rs
@@ -1,4 +1,4 @@
-mod date_histogram;
+// mod date_histogram;
 mod histogram;
-pub use date_histogram::*;
+// pub use date_histogram::*;
 pub use histogram::*;

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -1,7 +1,5 @@
 use std::fmt::Debug;
 
-use columnar::Column;
-use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
@@ -13,11 +11,9 @@ use crate::aggregation::intermediate_agg_result::{
     IntermediateBucketResult, IntermediateTermBucketEntry, IntermediateTermBucketResult,
 };
 use crate::aggregation::segment_agg_result::{
-    build_segment_agg_collector, GenericSegmentAggregationResultsCollector,
-    SegmentAggregationCollector,
+    build_segment_agg_collector, SegmentAggregationCollector,
 };
 use crate::error::DataCorruption;
-use crate::schema::Type;
 use crate::{DocId, TantivyError};
 
 /// Creates a bucket for every unique term and counts the number of occurences.
@@ -246,7 +242,7 @@ impl TermBucketEntry {
 
 impl TermBuckets {
     pub(crate) fn from_req_and_validate(
-        sub_aggregation: &AggregationsWithAccessor,
+        _sub_aggregation: &AggregationsWithAccessor,
         _max_term_id: usize,
     ) -> crate::Result<Self> {
         Ok(TermBuckets {

--- a/src/aggregation/collector.rs
+++ b/src/aggregation/collector.rs
@@ -4,10 +4,7 @@ use super::agg_req::Aggregations;
 use super::agg_req_with_accessor::AggregationsWithAccessor;
 use super::agg_result::AggregationResults;
 use super::intermediate_agg_result::IntermediateAggregationResults;
-use super::segment_agg_result::{
-    build_segment_agg_collector, GenericSegmentAggregationResultsCollector,
-    SegmentAggregationCollector,
-};
+use super::segment_agg_result::{build_segment_agg_collector, SegmentAggregationCollector};
 use crate::aggregation::agg_req_with_accessor::get_aggs_with_accessor_and_validate;
 use crate::collector::{Collector, SegmentCollector};
 use crate::schema::Schema;

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -22,7 +22,6 @@
 use std::net::Ipv6Addr;
 
 pub use columnar::Column;
-use columnar::MonotonicallyMappableToU64;
 
 pub use self::alive_bitset::{intersect_alive_bitsets, write_alive_bitset, AliveBitSet};
 pub use self::error::{FastFieldNotAvailableError, Result};
@@ -109,7 +108,7 @@ mod tests {
     use std::ops::{Range, RangeInclusive};
     use std::path::Path;
 
-    use columnar::Column;
+    use columnar::{Column, MonotonicallyMappableToU64};
     use common::{HasLen, TerminatingWrite};
     use once_cell::sync::Lazy;
     use rand::prelude::SliceRandom;

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -333,12 +333,12 @@ impl SegmentWriter {
     ///
     /// As a user, you should rather use `IndexWriter`'s add_document.
     pub fn add_document(&mut self, add_operation: AddOperation) -> crate::Result<()> {
-        let doc = add_operation.document;
+        let AddOperation { document, opstamp } = add_operation;
         self.doc_opstamps.push(add_operation.opstamp);
-        self.fast_field_writers.add_document(&doc)?;
-        self.index_document(&doc)?;
+        self.fast_field_writers.add_document(&document)?;
+        self.index_document(&document)?;
         let doc_writer = self.segment_serializer.get_store_writer();
-        doc_writer.store(&doc, &self.schema)?;
+        doc_writer.store(&document, &self.schema)?;
         self.max_doc += 1;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,8 +131,6 @@ pub use time;
 
 pub use crate::error::TantivyError;
 pub use crate::future_result::FutureResult;
-use crate::time::format_description::well_known::Rfc3339;
-use crate::time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
 
 /// Tantivy result.
 ///

--- a/src/postings/indexing_context.rs
+++ b/src/postings/indexing_context.rs
@@ -13,7 +13,7 @@ pub(crate) struct IndexingContext {
 impl IndexingContext {
     /// Create a new IndexingContext given the size of the term hash map.
     pub(crate) fn new(table_size: usize) -> IndexingContext {
-        let term_index = ArenaHashMap::new(table_size);
+        let term_index = ArenaHashMap::with_capacity(table_size);
         IndexingContext {
             arena: MemoryArena::default(),
             term_index,


### PR DESCRIPTION
The new fast field code, based on columnar, had a larger minimum memory footprint, causing the first docuemnt to trigger a flush of the asegment in this unit test.

This PR prevents the allocation of a large capacity for the different hashmap tables using in the columnar writer.

Closes #1859