### PR TITLE
refactor aggregations

### DIFF
--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -244,7 +244,7 @@ impl TermBuckets {
     fn force_flush(&mut self, agg_with_accessor: &AggregationsWithAccessor) -> crate::Result<()> {
         for entry in &mut self.entries.values_mut() {
             if let Some(sub_aggregations) = entry.sub_aggregations.as_mut() {
-                sub_aggregations.flush_staged_docs(agg_with_accessor, false)?;
+                sub_aggregations.flush(agg_with_accessor)?;
             }
         }
         Ok(())
@@ -393,7 +393,6 @@ impl SegmentTermCollector {
         &mut self,
         docs: &[DocId],
         bucket_with_accessor: &BucketAggregationWithAccessor,
-        force_flush: bool,
     ) -> crate::Result<()> {
         let accessor = &bucket_with_accessor.accessor;
 
@@ -411,10 +410,15 @@ impl SegmentTermCollector {
             }
         }
 
-        if force_flush {
-            self.term_buckets
-                .force_flush(&bucket_with_accessor.sub_aggregation)?;
-        }
+        Ok(())
+    }
+
+    pub(crate) fn flush(
+        &mut self,
+        bucket_with_accessor: &BucketAggregationWithAccessor,
+    ) -> crate::Result<()> {
+        self.term_buckets
+            .force_flush(&bucket_with_accessor.sub_aggregation)?;
         Ok(())
     }
 }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -289,7 +289,7 @@ impl SegmentTermCollector {
 
         let has_sub_aggregations = !sub_aggregations.is_empty();
         let blueprint = if has_sub_aggregations {
-            let sub_aggregation = build_segment_agg_collector(sub_aggregations)?;
+            let sub_aggregation = build_segment_agg_collector(sub_aggregations, false)?;
             Some(sub_aggregation)
         } else {
             None

--- a/src/aggregation/buf_collector.rs
+++ b/src/aggregation/buf_collector.rs
@@ -1,0 +1,81 @@
+use super::agg_req_with_accessor::AggregationsWithAccessor;
+use super::intermediate_agg_result::IntermediateAggregationResults;
+use super::segment_agg_result::SegmentAggregationCollector;
+use crate::DocId;
+
+pub(crate) const DOC_BLOCK_SIZE: usize = 64;
+pub(crate) type DocBlock = [DocId; DOC_BLOCK_SIZE];
+
+/// BufAggregationCollector buffers documents before calling collect_block().
+#[derive(Clone)]
+pub(crate) struct BufAggregationCollector<T> {
+    pub(crate) collector: T,
+    staged_docs: DocBlock,
+    num_staged_docs: usize,
+}
+
+impl<T> std::fmt::Debug for BufAggregationCollector<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SegmentAggregationResultsCollector")
+            .field("staged_docs", &&self.staged_docs[..self.num_staged_docs])
+            .field("num_staged_docs", &self.num_staged_docs)
+            .finish()
+    }
+}
+
+impl<T: SegmentAggregationCollector> BufAggregationCollector<T> {
+    pub fn new(collector: T) -> Self {
+        Self {
+            collector,
+            num_staged_docs: 0,
+            staged_docs: [0; DOC_BLOCK_SIZE],
+        }
+    }
+}
+
+impl<T: SegmentAggregationCollector + Clone + 'static> SegmentAggregationCollector
+    for BufAggregationCollector<T>
+{
+    fn into_intermediate_aggregations_result(
+        self: Box<Self>,
+        agg_with_accessor: &AggregationsWithAccessor,
+    ) -> crate::Result<IntermediateAggregationResults> {
+        Box::new(self.collector).into_intermediate_aggregations_result(agg_with_accessor)
+    }
+
+    fn collect(
+        &mut self,
+        doc: crate::DocId,
+        agg_with_accessor: &AggregationsWithAccessor,
+    ) -> crate::Result<()> {
+        self.staged_docs[self.num_staged_docs] = doc;
+        self.num_staged_docs += 1;
+        if self.num_staged_docs == self.staged_docs.len() {
+            self.collector
+                .collect_block(&self.staged_docs[..self.num_staged_docs], agg_with_accessor)?;
+            self.num_staged_docs = 0;
+        }
+        Ok(())
+    }
+
+    fn collect_block(
+        &mut self,
+        docs: &[crate::DocId],
+        agg_with_accessor: &AggregationsWithAccessor,
+    ) -> crate::Result<()> {
+        for doc in docs {
+            self.collect(*doc, agg_with_accessor)?;
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self, agg_with_accessor: &AggregationsWithAccessor) -> crate::Result<()> {
+        self.collector
+            .collect_block(&self.staged_docs[..self.num_staged_docs], agg_with_accessor)?;
+        self.num_staged_docs = 0;
+
+        self.collector.flush(agg_with_accessor)?;
+
+        Ok(())
+    }
+}

--- a/src/aggregation/collector.rs
+++ b/src/aggregation/collector.rs
@@ -151,7 +151,7 @@ impl AggregationSegmentCollector {
     ) -> crate::Result<Self> {
         let aggs_with_accessor =
             get_aggs_with_accessor_and_validate(agg, reader, Rc::default(), max_bucket_count)?;
-        let result = build_segment_agg_collector(&aggs_with_accessor)?;
+        let result = build_segment_agg_collector(&aggs_with_accessor, true)?;
         Ok(AggregationSegmentCollector {
             aggs_with_accessor,
             result,

--- a/src/aggregation/collector.rs
+++ b/src/aggregation/collector.rs
@@ -177,8 +177,7 @@ impl SegmentCollector for AggregationSegmentCollector {
         if let Some(err) = self.error {
             return Err(err);
         }
-        self.result
-            .flush_staged_docs(&self.aggs_with_accessor, true)?;
+        self.result.flush(&self.aggs_with_accessor)?;
         self.result
             .into_intermediate_aggregations_result(&self.aggs_with_accessor)
     }

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -242,10 +242,10 @@ impl SegmentAggregationCollector for SegmentStatsCollector {
         Ok(())
     }
 
-    fn flush_staged_docs(
+    fn collect_block(
         &mut self,
+        _docs: &[crate::DocId],
         _agg_with_accessor: &AggregationsWithAccessor,
-        _force_flush: bool,
     ) -> crate::Result<()> {
         Ok(())
     }

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -160,6 +160,7 @@ pub mod agg_req;
 mod agg_req_with_accessor;
 pub mod agg_result;
 pub mod bucket;
+mod buf_collector;
 mod collector;
 mod date;
 pub mod intermediate_agg_result;
@@ -332,8 +333,8 @@ mod tests {
     };
     use crate::aggregation::agg_result::AggregationResults;
     use crate::aggregation::bucket::TermsAggregation;
+    use crate::aggregation::buf_collector::DOC_BLOCK_SIZE;
     use crate::aggregation::intermediate_agg_result::IntermediateAggregationResults;
-    use crate::aggregation::segment_agg_result::DOC_BLOCK_SIZE;
     use crate::aggregation::DistributedAggregationCollector;
     use crate::indexer::NoMergePolicy;
     use crate::query::{AllQuery, TermQuery};
@@ -1590,7 +1591,7 @@ mod tests {
         }
 
         #[bench]
-        fn bench_aggregation_sub_tree(b: &mut Bencher) {
+        fn bench_aggregation_avg_and_range_with_avg(b: &mut Bencher) {
             let index = get_test_index_bench(false).unwrap();
             let reader = index.reader().unwrap();
             let text_field = reader.searcher().schema().get_field("text").unwrap();


### PR DESCRIPTION
- add specialized version for full cardinality
- refactor aggregation collection
    - split collection and flushing
- add staging collector

```
 aggregation::tests::bench::bench_aggregation_average_f64                 10,506,069       9,218,078           -1,287,991  -12.26%   x 1.14 
 aggregation::tests::bench::bench_aggregation_average_u64                 9,062,582        9,367,880              305,298    3.37%   x 0.97 
 aggregation::tests::bench::bench_aggregation_average_u64_and_f64         13,326,599       13,442,273             115,674    0.87%   x 0.99 
 aggregation::tests::bench::bench_aggregation_histogram_only              17,879,982       16,766,669          -1,113,313   -6.23%   x 1.07 
 aggregation::tests::bench::bench_aggregation_histogram_only_hard_bounds  16,116,178       15,454,050            -662,128   -4.11%   x 1.04 
 aggregation::tests::bench::bench_aggregation_histogram_with_avg          37,076,780       35,573,842          -1,502,938   -4.05%   x 1.04 
 aggregation::tests::bench::bench_aggregation_range_only                  12,534,568       13,489,130             954,562    7.62%   x 0.93 
 aggregation::tests::bench::bench_aggregation_stats_f64                   9,463,641        9,657,604              193,963    2.05%   x 0.98 
 aggregation::tests::bench::bench_aggregation_terms_few                   14,573,134       13,908,208            -664,926   -4.56%   x 1.05 
 aggregation::tests::bench::bench_aggregation_terms_many2                 35,757,387       30,942,369          -4,815,018  -13.47%   x 1.16 
 aggregation::tests::bench::bench_aggregation_terms_many_order_by_term    39,661,657       32,838,242          -6,823,415  -17.20%   x 1.21 
 aggregation::tests::bench::bench_aggregation_terms_many_with_sub_agg     102,926,064      100,122,452         -2,803,612   -2.72%   x 1.03 
```