### PR TITLE
add coerce option for text and numbers types

### DIFF
--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -346,7 +346,7 @@ impl FieldType {
                     }
                     FieldType::I64(opt) => {
                         if opt.should_coerce() {
-                            Ok(Value::U64(field_text.parse().map_err(|_| {
+                            Ok(Value::I64(field_text.parse().map_err(|_| {
                                 ValueParsingError::TypeError {
                                     expected: "a i64 or a i64 as string",
                                     json: JsonValue::String(field_text),
@@ -361,7 +361,7 @@ impl FieldType {
                     }
                     FieldType::F64(opt) => {
                         if opt.should_coerce() {
-                            Ok(Value::U64(field_text.parse().map_err(|_| {
+                            Ok(Value::F64(field_text.parse().map_err(|_| {
                                 ValueParsingError::TypeError {
                                     expected: "a f64 or a f64 as string",
                                     json: JsonValue::String(field_text),

--- a/src/schema/flags.rs
+++ b/src/schema/flags.rs
@@ -32,6 +32,18 @@ pub const INDEXED: SchemaFlagList<IndexedFlag, ()> = SchemaFlagList {
 };
 
 #[derive(Clone)]
+pub struct CoerceFlag;
+/// Flag to mark the field as coerced.
+///
+/// `COERCE` will try to convert values into its value type if they don't match.
+///
+/// See [fast fields](`crate::fastfield`).
+pub const COERCE: SchemaFlagList<CoerceFlag, ()> = SchemaFlagList {
+    head: CoerceFlag,
+    tail: (),
+};
+
+#[derive(Clone)]
 pub struct FastFlag;
 /// Flag to mark the field as a fast field (similar to Lucene's DocValues)
 ///

--- a/src/schema/json_object_options.rs
+++ b/src/schema/json_object_options.rs
@@ -39,6 +39,7 @@ pub struct JsonObjectOptions {
     /// `{"root": {"child": {"with": {"dot": "hello"}}}}`
     /// and it can be search using the following query:
     /// `root.child.with.dot:hello`
+    #[serde(default)]
     expand_dots_enabled: bool,
 }
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -138,7 +138,7 @@ pub use self::field::Field;
 pub use self::field_entry::FieldEntry;
 pub use self::field_type::{FieldType, Type};
 pub use self::field_value::FieldValue;
-pub use self::flags::{FAST, INDEXED, STORED};
+pub use self::flags::{COERCE, FAST, INDEXED, STORED};
 pub use self::index_record_option::IndexRecordOption;
 pub use self::ip_options::{IntoIpv6Addr, IpAddrOptions};
 pub use self::json_object_options::JsonObjectOptions;

--- a/src/schema/numeric_options.rs
+++ b/src/schema/numeric_options.rs
@@ -2,6 +2,7 @@ use std::ops::BitOr;
 
 use serde::{Deserialize, Serialize};
 
+use super::flags::CoerceFlag;
 use crate::schema::flags::{FastFlag, IndexedFlag, SchemaFlagList, StoredFlag};
 
 #[deprecated(since = "0.17.0", note = "Use NumericOptions instead.")]
@@ -135,6 +136,18 @@ impl NumericOptions {
 impl From<()> for NumericOptions {
     fn from(_: ()) -> NumericOptions {
         NumericOptions::default()
+    }
+}
+
+impl From<CoerceFlag> for NumericOptions {
+    fn from(_: CoerceFlag) -> NumericOptions {
+        NumericOptions {
+            indexed: false,
+            fieldnorms: false,
+            stored: false,
+            fast: false,
+            coerce: true,
+        }
     }
 }
 

--- a/src/schema/text_options.rs
+++ b/src/schema/text_options.rs
@@ -3,7 +3,7 @@ use std::ops::BitOr;
 
 use serde::{Deserialize, Serialize};
 
-use super::flags::FastFlag;
+use super::flags::{CoerceFlag, FastFlag};
 use crate::schema::flags::{SchemaFlagList, StoredFlag};
 use crate::schema::IndexRecordOption;
 
@@ -242,6 +242,17 @@ impl From<StoredFlag> for TextOptions {
             stored: true,
             fast: false,
             coerce: false,
+        }
+    }
+}
+
+impl From<CoerceFlag> for TextOptions {
+    fn from(_: CoerceFlag) -> TextOptions {
+        TextOptions {
+            indexing: None,
+            stored: false,
+            fast: false,
+            coerce: true,
         }
     }
 }

--- a/src/schema/text_options.rs
+++ b/src/schema/text_options.rs
@@ -17,6 +17,14 @@ pub struct TextOptions {
     stored: bool,
     #[serde(default)]
     fast: bool,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "is_false")]
+    /// coerce values if they are not of type string
+    coerce: bool,
+}
+
+fn is_false(val: &bool) -> bool {
+    !val
 }
 
 impl TextOptions {
@@ -33,6 +41,11 @@ impl TextOptions {
     /// Returns true if and only if the value is a fast field.
     pub fn is_fast(&self) -> bool {
         self.fast
+    }
+
+    /// Returns true if values should be coerced to strings (numbers, null).
+    pub fn should_coerce(&self) -> bool {
+        self.coerce
     }
 
     /// Set the field as a fast field.
@@ -56,7 +69,14 @@ impl TextOptions {
         self
     }
 
-    /// Sets the field as stored
+    /// Coerce values if they are not of type string. Defaults to false.
+    #[must_use]
+    pub fn set_coerce(mut self) -> TextOptions {
+        self.coerce = true;
+        self
+    }
+
+    /// Sets the field as stored.
     #[must_use]
     pub fn set_stored(mut self) -> TextOptions {
         self.stored = true;
@@ -180,6 +200,7 @@ pub const STRING: TextOptions = TextOptions {
     }),
     stored: false,
     fast: false,
+    coerce: false,
 };
 
 /// The field will be tokenized and indexed.
@@ -190,6 +211,7 @@ pub const TEXT: TextOptions = TextOptions {
         record: IndexRecordOption::WithFreqsAndPositions,
     }),
     stored: false,
+    coerce: false,
     fast: false,
 };
 
@@ -202,6 +224,7 @@ impl<T: Into<TextOptions>> BitOr<T> for TextOptions {
             indexing: self.indexing.or(other.indexing),
             stored: self.stored | other.stored,
             fast: self.fast | other.fast,
+            coerce: self.coerce | other.coerce,
         }
     }
 }
@@ -218,6 +241,7 @@ impl From<StoredFlag> for TextOptions {
             indexing: None,
             stored: true,
             fast: false,
+            coerce: false,
         }
     }
 }
@@ -228,6 +252,7 @@ impl From<FastFlag> for TextOptions {
             indexing: None,
             stored: false,
             fast: true,
+            coerce: false,
         }
     }
 }


### PR DESCRIPTION
allow to coerce the field type when indexing if the type does not match
