### PR TITLE
move buffer in front of dynamic dispatch

### DIFF
--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -51,6 +51,20 @@ pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync {
     /// May panic if `idx` is greater than the column length.
     fn get_val(&self, idx: u32) -> T;
 
+    /// Allows to push down multiple fetch calls, to avoid dynamic dispatch overhead.
+    ///
+    /// idx and output should have the same length
+    ///
+    /// # Panics
+    ///
+    /// May panic if `idx` is greater than the column length.
+    fn get_vals(&self, idx: &[u32], output: &mut [T]) {
+        assert!(idx.len() == output.len());
+        for (out, idx) in output.iter_mut().zip(idx.iter()) {
+            *out = self.get_val(*idx as u32);
+        }
+    }
+
     /// Fills an output buffer with the fast field values
     /// associated with the `DocId` going from
     /// `start` to `start + output.len()`.

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -322,7 +322,7 @@ impl SegmentHistogramCollector {
         let sub_aggregation_blueprint = if sub_aggregation.is_empty() {
             None
         } else {
-            let sub_aggregation = build_segment_agg_collector(sub_aggregation, false)?;
+            let sub_aggregation = build_segment_agg_collector(sub_aggregation)?;
             Some(sub_aggregation)
         };
 

--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -286,7 +286,7 @@ impl SegmentRangeCollector {
                 let sub_aggregation = if sub_aggregation.is_empty() {
                     None
                 } else {
-                    Some(build_segment_agg_collector(sub_aggregation, false)?)
+                    Some(build_segment_agg_collector(sub_aggregation)?)
                 };
 
                 Ok(SegmentRangeAndBucketEntry {

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -374,7 +374,7 @@ impl SegmentTermCollector {
 
         let has_sub_aggregations = !sub_aggregations.is_empty();
         let blueprint = if has_sub_aggregations {
-            let sub_aggregation = build_segment_agg_collector(sub_aggregations, false)?;
+            let sub_aggregation = build_segment_agg_collector(sub_aggregations)?;
             Some(sub_aggregation)
         } else {
             None

--- a/src/aggregation/buf_collector.rs
+++ b/src/aggregation/buf_collector.rs
@@ -8,13 +8,13 @@ pub(crate) type DocBlock = [DocId; DOC_BLOCK_SIZE];
 
 /// BufAggregationCollector buffers documents before calling collect_block().
 #[derive(Clone)]
-pub(crate) struct BufAggregationCollector<T> {
-    pub(crate) collector: T,
+pub(crate) struct BufAggregationCollector {
+    pub(crate) collector: Box<dyn SegmentAggregationCollector>,
     staged_docs: DocBlock,
     num_staged_docs: usize,
 }
 
-impl<T> std::fmt::Debug for BufAggregationCollector<T> {
+impl std::fmt::Debug for BufAggregationCollector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SegmentAggregationResultsCollector")
             .field("staged_docs", &&self.staged_docs[..self.num_staged_docs])
@@ -23,8 +23,8 @@ impl<T> std::fmt::Debug for BufAggregationCollector<T> {
     }
 }
 
-impl<T: SegmentAggregationCollector> BufAggregationCollector<T> {
-    pub fn new(collector: T) -> Self {
+impl BufAggregationCollector {
+    pub fn new(collector: Box<dyn SegmentAggregationCollector>) -> Self {
         Self {
             collector,
             num_staged_docs: 0,
@@ -33,9 +33,7 @@ impl<T: SegmentAggregationCollector> BufAggregationCollector<T> {
     }
 }
 
-impl<T: SegmentAggregationCollector + Clone + 'static> SegmentAggregationCollector
-    for BufAggregationCollector<T>
-{
+impl SegmentAggregationCollector for BufAggregationCollector {
     fn into_intermediate_aggregations_result(
         self: Box<Self>,
         agg_with_accessor: &AggregationsWithAccessor,


### PR DESCRIPTION
dynamic dispatch seems to be quite expensive for aggregations. This PR moves the buffer in front of the dynamic dispatch, to reduce the number of calls into the dynamic dispatched collector.

```
 aggregation::agg_tests::bench::bench_aggregation_average_f64                                                         10,160,201       7,842,652           -2,317,549  -22.81%   x 1.30 
 aggregation::agg_tests::bench::bench_aggregation_average_u64                                                         10,161,699       8,382,533           -1,779,166  -17.51%   x 1.21 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64                                                 15,091,252       12,522,860          -2,568,392  -17.02%   x 1.21 
 aggregation::agg_tests::bench::bench_aggregation_avg_and_range_with_avg                                              25,335,268       24,035,044          -1,300,224   -5.13%   x 1.05 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only                                                      24,206,546       23,176,082          -1,030,464   -4.26%   x 1.04 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_hard_bounds                                          18,503,005       16,422,698          -2,080,307  -11.24%   x 1.13 
 aggregation::agg_tests::bench::bench_aggregation_histogram_with_avg                                                  48,343,627       46,958,711          -1,384,916   -2.86%   x 1.03 
 aggregation::agg_tests::bench::bench_aggregation_range_only                                                          13,509,929       12,258,016          -1,251,913   -9.27%   x 1.10 
 aggregation::agg_tests::bench::bench_aggregation_range_with_avg                                                      22,096,478       20,961,746          -1,134,732   -5.14%   x 1.05 
 aggregation::agg_tests::bench::bench_aggregation_stats_f64                                                           9,941,708        7,900,089           -2,041,619  -20.54%   x 1.26 
 aggregation::agg_tests::bench::bench_aggregation_terms_few                                                           11,866,509       10,010,856          -1,855,653  -15.64%   x 1.19 
 aggregation::agg_tests::bench::bench_aggregation_terms_many2                                                         36,950,598       29,730,911          -7,219,687  -19.54%   x 1.24 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term                                            33,679,091       31,005,312          -2,673,779   -7.94%   x 1.09 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg                                             102,701,768      98,926,120          -3,775,648   -3.68%   x 1.04 
```
