### PR TITLE
add agg benchmark for optional and multi value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ test-log = "0.2.10"
 env_logger = "0.10.0"
 pprof = { version = "0.11.0", features = ["flamegraph", "criterion"] }
 futures = "0.3.21"
+paste = "1.0.11"
 
 [dev-dependencies.fail]
 version = "0.5.0"

--- a/src/indexer/merger_sorted_index_test.rs
+++ b/src/indexer/merger_sorted_index_test.rs
@@ -475,8 +475,6 @@ mod tests {
 #[cfg(all(test, feature = "unstable"))]
 mod bench_sorted_index_merge {
 
-    use std::sync::Arc;
-
     use test::{self, Bencher};
 
     use crate::core::Index;


### PR DESCRIPTION
closes #1870
```
test aggregation::agg_tests::bench::bench_aggregation_average_f64                                                        ... bench:   7,870,605 ns/iter (+/- 26,592)
test aggregation::agg_tests::bench::bench_aggregation_average_f64_multi                                                  ... bench:  14,278,611 ns/iter (+/- 561,535)
test aggregation::agg_tests::bench::bench_aggregation_average_f64_opt                                                    ... bench:  12,225,374 ns/iter (+/- 681,566)
test aggregation::agg_tests::bench::bench_aggregation_average_u64                                                        ... bench:   7,852,960 ns/iter (+/- 662,773)
test aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64                                                ... bench:  12,009,021 ns/iter (+/- 683,122)
test aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64_multi                                          ... bench:  24,672,227 ns/iter (+/- 384,337)
test aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64_opt                                            ... bench:  20,895,884 ns/iter (+/- 666,042)
test aggregation::agg_tests::bench::bench_aggregation_average_u64_multi                                                  ... bench:  14,302,079 ns/iter (+/- 742,301)
test aggregation::agg_tests::bench::bench_aggregation_average_u64_opt                                                    ... bench:  12,510,001 ns/iter (+/- 713,201)
test aggregation::agg_tests::bench::bench_aggregation_avg_and_range_with_avg                                             ... bench:  23,659,615 ns/iter (+/- 420,231)
test aggregation::agg_tests::bench::bench_aggregation_avg_and_range_with_avg_multi                                       ... bench:  38,954,585 ns/iter (+/- 1,437,249)
test aggregation::agg_tests::bench::bench_aggregation_avg_and_range_with_avg_opt                                         ... bench:  36,028,610 ns/iter (+/- 1,092,240)
test aggregation::agg_tests::bench::bench_aggregation_histogram_only                                                     ... bench:  21,986,925 ns/iter (+/- 1,112,171)
test aggregation::agg_tests::bench::bench_aggregation_histogram_only_hard_bounds                                         ... bench:  16,814,391 ns/iter (+/- 415,878)
test aggregation::agg_tests::bench::bench_aggregation_histogram_only_hard_bounds_multi                                   ... bench:  20,802,688 ns/iter (+/- 734,261)
test aggregation::agg_tests::bench::bench_aggregation_histogram_only_hard_bounds_opt                                     ... bench:  18,962,809 ns/iter (+/- 386,514)
test aggregation::agg_tests::bench::bench_aggregation_histogram_only_multi                                               ... bench:  29,287,084 ns/iter (+/- 603,787)
test aggregation::agg_tests::bench::bench_aggregation_histogram_only_opt                                                 ... bench:  24,537,437 ns/iter (+/- 768,724)
test aggregation::agg_tests::bench::bench_aggregation_histogram_with_avg                                                 ... bench:  46,026,955 ns/iter (+/- 2,620,359)
test aggregation::agg_tests::bench::bench_aggregation_histogram_with_avg_multi                                           ... bench:  69,248,333 ns/iter (+/- 6,908,116)
test aggregation::agg_tests::bench::bench_aggregation_histogram_with_avg_opt                                             ... bench:  60,616,753 ns/iter (+/- 5,920,151)
test aggregation::agg_tests::bench::bench_aggregation_range_only                                                         ... bench:  11,415,179 ns/iter (+/- 71,024)
test aggregation::agg_tests::bench::bench_aggregation_range_only_multi                                                   ... bench:  15,868,661 ns/iter (+/- 3,024,740)
test aggregation::agg_tests::bench::bench_aggregation_range_only_opt                                                     ... bench:  13,853,202 ns/iter (+/- 801,934)
test aggregation::agg_tests::bench::bench_aggregation_range_with_avg                                                     ... bench:  19,427,526 ns/iter (+/- 1,130,700)
test aggregation::agg_tests::bench::bench_aggregation_range_with_avg_multi                                               ... bench:  28,505,356 ns/iter (+/- 441,136)
test aggregation::agg_tests::bench::bench_aggregation_range_with_avg_opt                                                 ... bench:  24,877,203 ns/iter (+/- 822,687)
test aggregation::agg_tests::bench::bench_aggregation_stats_f64                                                          ... bench:   7,885,531 ns/iter (+/- 1,983,799)
test aggregation::agg_tests::bench::bench_aggregation_stats_f64_multi                                                    ... bench:  14,088,240 ns/iter (+/- 92,505)
test aggregation::agg_tests::bench::bench_aggregation_stats_f64_opt                                                      ... bench:  12,188,895 ns/iter (+/- 804,500)
test aggregation::agg_tests::bench::bench_aggregation_terms_few                                                          ... bench:   9,409,013 ns/iter (+/- 388,593)
test aggregation::agg_tests::bench::bench_aggregation_terms_few_multi                                                    ... bench:  17,869,058 ns/iter (+/- 410,469)
test aggregation::agg_tests::bench::bench_aggregation_terms_few_opt                                                      ... bench:  13,462,613 ns/iter (+/- 536,467)
test aggregation::agg_tests::bench::bench_aggregation_terms_many2                                                        ... bench:  29,873,532 ns/iter (+/- 3,498,411)
test aggregation::agg_tests::bench::bench_aggregation_terms_many2_multi                                                  ... bench:  43,887,523 ns/iter (+/- 6,261,082)
test aggregation::agg_tests::bench::bench_aggregation_terms_many2_opt                                                    ... bench:  57,780,708 ns/iter (+/- 35,908,506)
test aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term                                           ... bench:  34,577,974 ns/iter (+/- 18,784,093)
test aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term_multi                                     ... bench:  50,002,298 ns/iter (+/- 23,607,483)
test aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term_opt                                       ... bench:  42,791,748 ns/iter (+/- 17,590,704)
test aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg                                            ... bench: 112,070,509 ns/iter (+/- 61,019,957)
test aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg_multi                                      ... bench: 179,995,920 ns/iter (+/- 93,936,453)
test aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg_opt                                        ... bench: 177,585,487 ns/iter (+/- 93,074,422)
```