### PR TITLE
split term collection count and sub_agg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ benchmark
 .idea
 trace.dat
 cargo-timing*
+control
+variable

--- a/columnar/src/column_values/monotonic_column.rs
+++ b/columnar/src/column_values/monotonic_column.rs
@@ -50,7 +50,7 @@ where
     Input: PartialOrd + Send + Debug + Sync + Clone,
     Output: PartialOrd + Send + Debug + Sync + Clone,
 {
-    #[inline]
+    #[inline(always)]
     fn get_val(&self, idx: u32) -> Output {
         let from_val = self.from_column.get_val(idx);
         self.monotonic_mapping.mapping(from_val)

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -230,6 +230,7 @@ impl SegmentAggregationCollector for SegmentHistogramCollector {
         })
     }
 
+    #[inline]
     fn collect(
         &mut self,
         doc: crate::DocId,
@@ -238,6 +239,7 @@ impl SegmentAggregationCollector for SegmentHistogramCollector {
         self.collect_block(&[doc], agg_with_accessor)
     }
 
+    #[inline]
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],

--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -208,6 +208,7 @@ impl SegmentAggregationCollector for SegmentRangeCollector {
         })
     }
 
+    #[inline]
     fn collect(
         &mut self,
         doc: crate::DocId,
@@ -216,6 +217,7 @@ impl SegmentAggregationCollector for SegmentRangeCollector {
         self.collect_block(&[doc], agg_with_accessor)
     }
 
+    #[inline]
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],

--- a/src/aggregation/buf_collector.rs
+++ b/src/aggregation/buf_collector.rs
@@ -34,6 +34,7 @@ impl BufAggregationCollector {
 }
 
 impl SegmentAggregationCollector for BufAggregationCollector {
+    #[inline]
     fn into_intermediate_aggregations_result(
         self: Box<Self>,
         agg_with_accessor: &AggregationsWithAccessor,
@@ -41,6 +42,7 @@ impl SegmentAggregationCollector for BufAggregationCollector {
         Box::new(self.collector).into_intermediate_aggregations_result(agg_with_accessor)
     }
 
+    #[inline]
     fn collect(
         &mut self,
         doc: crate::DocId,
@@ -56,6 +58,7 @@ impl SegmentAggregationCollector for BufAggregationCollector {
         Ok(())
     }
 
+    #[inline]
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
@@ -67,6 +70,7 @@ impl SegmentAggregationCollector for BufAggregationCollector {
         Ok(())
     }
 
+    #[inline]
     fn flush(&mut self, agg_with_accessor: &AggregationsWithAccessor) -> crate::Result<()> {
         self.collector
             .collect_block(&self.staged_docs[..self.num_staged_docs], agg_with_accessor)?;


### PR DESCRIPTION
split term aggregations collection into count and sub_agg
use unrolled ColumnValues::get_vals

Plain term aggs are much faster (project airmail queries)
Terms with sub_agg are slower, we probably should add a specialized variant later (maybe a switch via generics).

```
 aggregation::agg_tests::bench::bench_aggregation_average_f64                       8,496,983        8,282,907             -214,076   -2.52%   x 1.03 
 aggregation::agg_tests::bench::bench_aggregation_average_f64_multi                 15,129,847       14,128,980          -1,000,867   -6.62%   x 1.07 
 aggregation::agg_tests::bench::bench_aggregation_average_f64_opt                   13,074,282       11,983,953          -1,090,329   -8.34%   x 1.09 
 aggregation::agg_tests::bench::bench_aggregation_average_u64                       8,399,143        7,994,802             -404,341   -4.81%   x 1.05 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64               13,257,169       12,038,036          -1,219,133   -9.20%   x 1.10 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64_multi         24,232,811       26,045,646           1,812,835    7.48%   x 0.93 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64_opt           20,833,926       21,939,831           1,105,905    5.31%   x 0.95 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_multi                 14,164,610       15,947,909           1,783,299   12.59%   x 0.89 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_opt                   11,825,887       12,288,002             462,115    3.91%   x 0.96 
 aggregation::agg_tests::bench::bench_aggregation_stats_f64                         7,779,247        7,929,514              150,267    1.93%   x 0.98 
 aggregation::agg_tests::bench::bench_aggregation_stats_f64_multi                   13,909,319       13,917,555               8,236    0.06%   x 1.00 
 aggregation::agg_tests::bench::bench_aggregation_stats_f64_opt                     12,120,927       11,893,682            -227,245   -1.87%   x 1.02 
 aggregation::agg_tests::bench::bench_aggregation_terms_few                         10,087,047       6,380,277           -3,706,770  -36.75%   x 1.58 
 aggregation::agg_tests::bench::bench_aggregation_terms_few_multi                   18,830,643       19,442,880             612,237    3.25%   x 0.97 
 aggregation::agg_tests::bench::bench_aggregation_terms_few_opt                     14,754,719       14,470,627            -284,092   -1.93%   x 1.02 
 aggregation::agg_tests::bench::bench_aggregation_terms_many2                       31,585,264       16,910,181         -14,675,083  -46.46%   x 1.87 
 aggregation::agg_tests::bench::bench_aggregation_terms_many2_multi                 42,720,151       36,486,115          -6,234,036  -14.59%   x 1.17 
 aggregation::agg_tests::bench::bench_aggregation_terms_many2_opt                   38,962,256       32,300,582          -6,661,674  -17.10%   x 1.21 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term          33,179,298       17,982,891         -15,196,407  -45.80%   x 1.85 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term_multi    42,940,308       37,767,674          -5,172,634  -12.05%   x 1.14 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term_opt      40,311,282       32,796,177          -7,515,105  -18.64%   x 1.23 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg           100,009,099      120,727,836         20,718,737   20.72%   x 0.83 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg_multi     156,301,906      211,335,012         55,033,106   35.21%   x 0.74 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg_opt       145,652,875      183,808,301         38,155,426   26.20%   x 0.79 
```