### PR TITLE
Export vint codec from postings::compression

### DIFF
--- a/src/postings/compression/mod.rs
+++ b/src/postings/compression/mod.rs
@@ -4,7 +4,7 @@ use common::FixedSize;
 pub const COMPRESSION_BLOCK_SIZE: usize = BitPacker4x::BLOCK_LEN;
 const COMPRESSED_BLOCK_MAX_SIZE: usize = COMPRESSION_BLOCK_SIZE * u32::SIZE_IN_BYTES;
 
-mod vint;
+pub mod vint;
 
 /// Returns the size in bytes of a compressed block, given `num_bits`.
 pub fn compressed_block_size(num_bits: u8) -> usize {

--- a/src/postings/compression/vint.rs
+++ b/src/postings/compression/vint.rs
@@ -21,7 +21,7 @@ pub fn compress_sorted<'a>(input: &[u32], output: &'a mut [u8], mut offset: u32)
 }
 
 #[inline]
-pub(crate) fn compress_unsorted<'a>(input: &[u32], output: &'a mut [u8]) -> &'a [u8] {
+pub fn compress_unsorted<'a>(input: &[u32], output: &'a mut [u8]) -> &'a [u8] {
     let mut byte_written = 0;
     for &v in input {
         let mut to_encode: u32 = v;
@@ -62,7 +62,7 @@ pub fn uncompress_sorted(compressed_data: &[u8], output: &mut [u32], offset: u32
 }
 
 #[inline]
-pub(crate) fn uncompress_unsorted(compressed_data: &[u8], output_arr: &mut [u32]) -> usize {
+pub fn uncompress_unsorted(compressed_data: &[u8], output_arr: &mut [u32]) -> usize {
     let mut num_read_bytes = 0;
     for output_mut in output_arr.iter_mut() {
         let mut result = 0u32;
@@ -82,7 +82,7 @@ pub(crate) fn uncompress_unsorted(compressed_data: &[u8], output_arr: &mut [u32]
 }
 
 #[inline]
-pub(crate) fn uncompress_unsorted_until_end(
+pub fn uncompress_unsorted_until_end(
     compressed_data: &[u8],
     output_arr: &mut [u32],
 ) -> usize {

--- a/src/postings/mod.rs
+++ b/src/postings/mod.rs
@@ -19,6 +19,7 @@ mod term_info;
 
 pub(crate) use stacker::compute_table_size;
 
+pub use self::compression::vint;
 pub use self::block_segment_postings::BlockSegmentPostings;
 pub(crate) use self::indexing_context::IndexingContext;
 pub(crate) use self::per_field_postings_writer::PerFieldPostingsWriter;


### PR DESCRIPTION
I'd like to use Tantivy's `vint` compression in one of my projects, and this PR is a first pass at making it public. I haven't added docstrings to the newly public exports since I'm not sure this is the right approach.

Would it be better to extract these functions into a new `tantivy-vint` crate underneath the repo root? 