### PR TITLE
work in batches of docs

### DIFF
--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -72,7 +72,7 @@ pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync {
         let cutoff = indexes.len() - indexes.len() % step_size;
 
         for idx in cutoff..indexes.len() {
-            output[idx] = self.get_val(indexes[idx] as u32);
+            output[idx] = self.get_val(indexes[idx]);
         }
     }
 

--- a/src/aggregation/buf_collector.rs
+++ b/src/aggregation/buf_collector.rs
@@ -64,9 +64,8 @@ impl SegmentAggregationCollector for BufAggregationCollector {
         docs: &[crate::DocId],
         agg_with_accessor: &AggregationsWithAccessor,
     ) -> crate::Result<()> {
-        for doc in docs {
-            self.collect(*doc, agg_with_accessor)?;
-        }
+        self.collector.collect_block(docs, agg_with_accessor)?;
+
         Ok(())
     }
 

--- a/src/aggregation/collector.rs
+++ b/src/aggregation/collector.rs
@@ -8,7 +8,7 @@ use super::intermediate_agg_result::IntermediateAggregationResults;
 use super::segment_agg_result::{build_segment_agg_collector, SegmentAggregationCollector};
 use crate::aggregation::agg_req_with_accessor::get_aggs_with_accessor_and_validate;
 use crate::collector::{Collector, SegmentCollector};
-use crate::{SegmentReader, TantivyError};
+use crate::{DocId, SegmentReader, TantivyError};
 
 /// The default max bucket count, before the aggregation fails.
 pub const MAX_BUCKET_COUNT: u32 = 65000;
@@ -135,7 +135,7 @@ fn merge_fruits(
 /// `AggregationSegmentCollector` does the aggregation collection on a segment.
 pub struct AggregationSegmentCollector {
     aggs_with_accessor: AggregationsWithAccessor,
-    result: BufAggregationCollector,
+    agg_collector: BufAggregationCollector,
     error: Option<TantivyError>,
 }
 
@@ -153,7 +153,7 @@ impl AggregationSegmentCollector {
             BufAggregationCollector::new(build_segment_agg_collector(&aggs_with_accessor)?);
         Ok(AggregationSegmentCollector {
             aggs_with_accessor,
-            result,
+            agg_collector: result,
             error: None,
         })
     }
@@ -163,11 +163,26 @@ impl SegmentCollector for AggregationSegmentCollector {
     type Fruit = crate::Result<IntermediateAggregationResults>;
 
     #[inline]
-    fn collect(&mut self, doc: crate::DocId, _score: crate::Score) {
+    fn collect(&mut self, doc: DocId, _score: crate::Score) {
         if self.error.is_some() {
             return;
         }
-        if let Err(err) = self.result.collect(doc, &self.aggs_with_accessor) {
+        if let Err(err) = self.agg_collector.collect(doc, &self.aggs_with_accessor) {
+            self.error = Some(err);
+        }
+    }
+
+    /// The query pushes the documents to the collector via this method.
+    ///
+    /// Only valid for Collectors that ignore docs
+    fn collect_block(&mut self, docs: &[DocId]) {
+        if self.error.is_some() {
+            return;
+        }
+        if let Err(err) = self
+            .agg_collector
+            .collect_block(docs, &self.aggs_with_accessor)
+        {
             self.error = Some(err);
         }
     }
@@ -176,7 +191,7 @@ impl SegmentCollector for AggregationSegmentCollector {
         if let Some(err) = self.error {
             return Err(err);
         }
-        self.result.flush(&self.aggs_with_accessor)?;
-        Box::new(self.result).into_intermediate_aggregations_result(&self.aggs_with_accessor)
+        self.agg_collector.flush(&self.aggs_with_accessor)?;
+        Box::new(self.agg_collector).into_intermediate_aggregations_result(&self.aggs_with_accessor)
     }
 }

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -94,10 +94,12 @@ fn compute_deleted_bitset(
         // document that were inserted before it.
         delete_op
             .target
-            .for_each_no_score(segment_reader, &mut |doc_matching_delete_query| {
-                if doc_opstamps.is_deleted(doc_matching_delete_query, delete_op.opstamp) {
-                    alive_bitset.remove(doc_matching_delete_query);
-                    might_have_changed = true;
+            .for_each_no_score(segment_reader, &mut |docs_matching_delete_query| {
+                for doc_matching_delete_query in docs_matching_delete_query.iter().cloned() {
+                    if doc_opstamps.is_deleted(doc_matching_delete_query, delete_op.opstamp) {
+                        alive_bitset.remove(doc_matching_delete_query);
+                        might_have_changed = true;
+                    }
                 }
             })?;
         delete_cursor.advance();

--- a/src/query/all_query.rs
+++ b/src/query/all_query.rs
@@ -96,8 +96,8 @@ impl Scorer for AllScorer {
 #[cfg(test)]
 mod tests {
     use super::AllQuery;
-    use crate::docset::TERMINATED;
-    use crate::query::{EnableScoring, Query};
+    use crate::docset::{DocSet, BUFFER_LEN, TERMINATED};
+    use crate::query::{AllScorer, EnableScoring, Query};
     use crate::schema::{Schema, TEXT};
     use crate::Index;
 
@@ -156,5 +156,23 @@ mod tests {
             assert_eq!(scorer.score(), 1.5);
         }
         Ok(())
+    }
+
+    #[test]
+    pub fn test_fill_buffer() {
+        let mut postings = AllScorer {
+            doc: 0u32,
+            max_doc: BUFFER_LEN as u32 * 2 + 9,
+        };
+        let mut buffer = [0u32; BUFFER_LEN];
+        assert_eq!(postings.fill_buffer(&mut buffer), BUFFER_LEN);
+        for i in 0u32..BUFFER_LEN as u32 {
+            assert_eq!(buffer[i as usize], i);
+        }
+        assert_eq!(postings.fill_buffer(&mut buffer), BUFFER_LEN);
+        for i in 0u32..BUFFER_LEN as u32 {
+            assert_eq!(buffer[i as usize], i + BUFFER_LEN as u32);
+        }
+        assert_eq!(postings.fill_buffer(&mut buffer), 9);
     }
 }

--- a/src/query/all_query.rs
+++ b/src/query/all_query.rs
@@ -1,5 +1,5 @@
 use crate::core::SegmentReader;
-use crate::docset::{DocSet, TERMINATED};
+use crate::docset::{DocSet, BUFFER_LEN, TERMINATED};
 use crate::query::boost_query::BoostScorer;
 use crate::query::explanation::does_not_match;
 use crate::query::{EnableScoring, Explanation, Query, Scorer, Weight};
@@ -44,6 +44,7 @@ pub struct AllScorer {
 }
 
 impl DocSet for AllScorer {
+    #[inline(always)]
     fn advance(&mut self) -> DocId {
         if self.doc + 1 >= self.max_doc {
             self.doc = TERMINATED;
@@ -53,6 +54,30 @@ impl DocSet for AllScorer {
         self.doc
     }
 
+    fn fill_buffer(&mut self, buffer: &mut [DocId; BUFFER_LEN]) -> usize {
+        if self.doc() == TERMINATED {
+            return 0;
+        }
+        let is_safe_distance = self.doc() + (buffer.len() as u32) < self.max_doc;
+        if is_safe_distance {
+            let num_items = buffer.len();
+            for buffer_val in buffer {
+                *buffer_val = self.doc();
+                self.doc += 1;
+            }
+            num_items
+        } else {
+            for (i, buffer_val) in buffer.iter_mut().enumerate() {
+                *buffer_val = self.doc();
+                if self.advance() == TERMINATED {
+                    return i + 1;
+                }
+            }
+            buffer.len()
+        }
+    }
+
+    #[inline(always)]
     fn doc(&self) -> DocId {
         self.doc
     }

--- a/src/query/bitset/mod.rs
+++ b/src/query/bitset/mod.rs
@@ -45,6 +45,7 @@ impl From<BitSet> for BitSetDocSet {
 }
 
 impl DocSet for BitSetDocSet {
+    #[inline]
     fn advance(&mut self) -> DocId {
         if let Some(lower) = self.cursor_tinybitset.pop_lowest() {
             self.doc = (self.cursor_bucket * 64u32) | lower;

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
 use crate::core::SegmentReader;
+use crate::docset::BUFFER_LEN;
 use crate::postings::FreqReadingOption;
 use crate::query::explanation::does_not_match;
 use crate::query::score_combiner::{DoNothingCombiner, ScoreCombiner};
 use crate::query::term_query::TermScorer;
-use crate::query::weight::{for_each_docset, for_each_pruning_scorer, for_each_scorer};
+use crate::query::weight::{for_each_docset_buffered, for_each_pruning_scorer, for_each_scorer};
 use crate::query::{
     intersect_scorers, EmptyScorer, Exclude, Explanation, Occur, RequiredOptionalScorer, Scorer,
     Union, Weight,
@@ -222,16 +223,18 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
     fn for_each_no_score(
         &self,
         reader: &SegmentReader,
-        callback: &mut dyn FnMut(DocId),
+        callback: &mut dyn FnMut(&[DocId]),
     ) -> crate::Result<()> {
         let scorer = self.complex_scorer(reader, 1.0, || DoNothingCombiner)?;
+        let mut buffer = [0u32; BUFFER_LEN];
+
         match scorer {
             SpecializedScorer::TermUnion(term_scorers) => {
                 let mut union_scorer = Union::build(term_scorers, &self.score_combiner_fn);
-                for_each_docset(&mut union_scorer, callback);
+                for_each_docset_buffered(&mut union_scorer, &mut buffer, callback);
             }
             SpecializedScorer::Other(mut scorer) => {
-                for_each_docset(scorer.as_mut(), callback);
+                for_each_docset_buffered(scorer.as_mut(), &mut buffer, callback);
             }
         }
         Ok(())

--- a/src/query/boost_query.rs
+++ b/src/query/boost_query.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::docset::BUFFER_LEN;
 use crate::fastfield::AliveBitSet;
 use crate::query::explanation::does_not_match;
 use crate::query::{EnableScoring, Explanation, Query, Scorer, Weight};
@@ -106,7 +107,7 @@ impl<S: Scorer> DocSet for BoostScorer<S> {
         self.underlying.seek(target)
     }
 
-    fn fill_buffer(&mut self, buffer: &mut [DocId]) -> usize {
+    fn fill_buffer(&mut self, buffer: &mut [DocId; BUFFER_LEN]) -> usize {
         self.underlying.fill_buffer(buffer)
     }
 

--- a/src/query/const_score_query.rs
+++ b/src/query/const_score_query.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::docset::BUFFER_LEN;
 use crate::query::{EnableScoring, Explanation, Query, Scorer, Weight};
 use crate::{DocId, DocSet, Score, SegmentReader, TantivyError, Term};
 
@@ -119,7 +120,7 @@ impl<TDocSet: DocSet> DocSet for ConstScorer<TDocSet> {
         self.docset.seek(target)
     }
 
-    fn fill_buffer(&mut self, buffer: &mut [DocId]) -> usize {
+    fn fill_buffer(&mut self, buffer: &mut [DocId; BUFFER_LEN]) -> usize {
         self.docset.fill_buffer(buffer)
     }
 

--- a/src/query/term_query/term_weight.rs
+++ b/src/query/term_query/term_weight.rs
@@ -1,11 +1,11 @@
 use super::term_scorer::TermScorer;
 use crate::core::SegmentReader;
-use crate::docset::DocSet;
+use crate::docset::{DocSet, BUFFER_LEN};
 use crate::fieldnorm::FieldNormReader;
 use crate::postings::SegmentPostings;
 use crate::query::bm25::Bm25Weight;
 use crate::query::explanation::does_not_match;
-use crate::query::weight::{for_each_docset, for_each_scorer};
+use crate::query::weight::{for_each_docset_buffered, for_each_scorer};
 use crate::query::{Explanation, Scorer, Weight};
 use crate::schema::IndexRecordOption;
 use crate::{DocId, Score, Term};
@@ -61,10 +61,11 @@ impl Weight for TermWeight {
     fn for_each_no_score(
         &self,
         reader: &SegmentReader,
-        callback: &mut dyn FnMut(DocId),
+        callback: &mut dyn FnMut(&[DocId]),
     ) -> crate::Result<()> {
         let mut scorer = self.specialized_scorer(reader, 1.0)?;
-        for_each_docset(&mut scorer, callback);
+        let mut buffer = [0u32; BUFFER_LEN];
+        for_each_docset_buffered(&mut scorer, &mut buffer, callback);
         Ok(())
     }
 

--- a/src/query/vec_docset.rs
+++ b/src/query/vec_docset.rs
@@ -53,7 +53,7 @@ impl HasLen for VecDocSet {
 pub mod tests {
 
     use super::*;
-    use crate::docset::DocSet;
+    use crate::docset::{DocSet, BUFFER_LEN};
     use crate::DocId;
 
     #[test]
@@ -70,19 +70,19 @@ pub mod tests {
         assert_eq!(postings.seek(6000u32), TERMINATED);
     }
 
-    //#[test]
-    // pub fn test_fill_buffer() {
-    // let doc_ids: Vec<DocId> = (1u32..210u32).collect();
-    // let mut postings = VecDocSet::from(doc_ids);
-    // let mut buffer = vec![1000u32; 100];
-    // assert_eq!(postings.fill_buffer(&mut buffer[..]), 100);
-    // for i in 0u32..100u32 {
-    // assert_eq!(buffer[i as usize], i + 1);
-    //}
-    // assert_eq!(postings.fill_buffer(&mut buffer[..]), 100);
-    // for i in 0u32..100u32 {
-    // assert_eq!(buffer[i as usize], i + 101);
-    //}
-    // assert_eq!(postings.fill_buffer(&mut buffer[..]), 9);
-    //}
+    #[test]
+    pub fn test_fill_buffer() {
+        let doc_ids: Vec<DocId> = (1u32..=(BUFFER_LEN as u32 * 2 + 9)).collect();
+        let mut postings = VecDocSet::from(doc_ids);
+        let mut buffer = [0u32; BUFFER_LEN];
+        assert_eq!(postings.fill_buffer(&mut buffer), BUFFER_LEN);
+        for i in 0u32..BUFFER_LEN as u32 {
+            assert_eq!(buffer[i as usize], i + 1);
+        }
+        assert_eq!(postings.fill_buffer(&mut buffer), BUFFER_LEN);
+        for i in 0u32..BUFFER_LEN as u32 {
+            assert_eq!(buffer[i as usize], i + 1 + BUFFER_LEN as u32);
+        }
+        assert_eq!(postings.fill_buffer(&mut buffer), 9);
+    }
 }

--- a/src/query/vec_docset.rs
+++ b/src/query/vec_docset.rs
@@ -70,19 +70,19 @@ pub mod tests {
         assert_eq!(postings.seek(6000u32), TERMINATED);
     }
 
-    #[test]
-    pub fn test_fill_buffer() {
-        let doc_ids: Vec<DocId> = (1u32..210u32).collect();
-        let mut postings = VecDocSet::from(doc_ids);
-        let mut buffer = vec![1000u32; 100];
-        assert_eq!(postings.fill_buffer(&mut buffer[..]), 100);
-        for i in 0u32..100u32 {
-            assert_eq!(buffer[i as usize], i + 1);
-        }
-        assert_eq!(postings.fill_buffer(&mut buffer[..]), 100);
-        for i in 0u32..100u32 {
-            assert_eq!(buffer[i as usize], i + 101);
-        }
-        assert_eq!(postings.fill_buffer(&mut buffer[..]), 9);
-    }
+    //#[test]
+    // pub fn test_fill_buffer() {
+    // let doc_ids: Vec<DocId> = (1u32..210u32).collect();
+    // let mut postings = VecDocSet::from(doc_ids);
+    // let mut buffer = vec![1000u32; 100];
+    // assert_eq!(postings.fill_buffer(&mut buffer[..]), 100);
+    // for i in 0u32..100u32 {
+    // assert_eq!(buffer[i as usize], i + 1);
+    //}
+    // assert_eq!(postings.fill_buffer(&mut buffer[..]), 100);
+    // for i in 0u32..100u32 {
+    // assert_eq!(buffer[i as usize], i + 101);
+    //}
+    // assert_eq!(postings.fill_buffer(&mut buffer[..]), 9);
+    //}
 }


### PR DESCRIPTION
Work in batches of docs when collecting results

- Adding `collect_block` to `SegmentCollector` for cases without scores.
- Add specalized `fill_buffer` for AllQuery. The check in `advance` is quite expensive
- Add missing `fill_buffer` to `Box<TDocSet>`
- Fixed size buffer for `fill_buffer` as a hint to the compiler

The batch handling could also be done for scores, e.g. `collect_block_with_score`.

Performance improvements look really good
```
 aggregation::agg_tests::bench::bench_aggregation_average_f64                       8,475,539        5,351,862           -3,123,677  -36.86%   x 1.58 
 aggregation::agg_tests::bench::bench_aggregation_average_f64_multi                 14,934,251       11,492,754          -3,441,497  -23.04%   x 1.30 
 aggregation::agg_tests::bench::bench_aggregation_average_f64_opt                   13,295,030       9,724,984           -3,570,046  -26.85%   x 1.37 
 aggregation::agg_tests::bench::bench_aggregation_average_u64                       8,107,198        5,359,265           -2,747,933  -33.89%   x 1.51 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64               12,963,225       9,566,766           -3,396,459  -26.20%   x 1.36 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64_multi         23,682,025       22,689,063            -992,962   -4.19%   x 1.04 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64_opt           20,925,034       18,479,274          -2,445,760  -11.69%   x 1.13 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_multi                 13,663,622       11,543,616          -2,120,006  -15.52%   x 1.18 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_opt                   13,323,016       9,832,037           -3,490,979  -26.20%   x 1.36 
 aggregation::agg_tests::bench::bench_aggregation_avg_and_range_with_avg            23,500,390       21,357,001          -2,143,389   -9.12%   x 1.10 
 aggregation::agg_tests::bench::bench_aggregation_avg_and_range_with_avg_multi      38,782,161       35,499,394          -3,282,767   -8.46%   x 1.09 
 aggregation::agg_tests::bench::bench_aggregation_avg_and_range_with_avg_opt        33,908,693       30,860,009          -3,048,684   -8.99%   x 1.10 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only                    22,357,460       20,540,925          -1,816,535   -8.12%   x 1.09 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_hard_bounds        16,599,594       13,048,134          -3,551,460  -21.39%   x 1.27 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_hard_bounds_multi  20,886,318       17,816,289          -3,070,029  -14.70%   x 1.17 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_hard_bounds_opt    19,210,837       15,905,418          -3,305,419  -17.21%   x 1.21 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_multi              29,869,368       27,007,167          -2,862,201   -9.58%   x 1.11 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_opt                25,172,715       22,390,367          -2,782,348  -11.05%   x 1.12 
 aggregation::agg_tests::bench::bench_aggregation_histogram_with_avg                48,240,088       45,420,994          -2,819,094   -5.84%   x 1.06 
 aggregation::agg_tests::bench::bench_aggregation_histogram_with_avg_multi          68,637,350       66,299,311          -2,338,039   -3.41%   x 1.04 
 aggregation::agg_tests::bench::bench_aggregation_histogram_with_avg_opt            63,490,770       61,551,842          -1,938,928   -3.05%   x 1.03 
 aggregation::agg_tests::bench::bench_aggregation_range_only                        11,631,475       8,509,606           -3,121,869  -26.84%   x 1.37 
 aggregation::agg_tests::bench::bench_aggregation_range_only_multi                  16,446,888       13,241,036          -3,205,852  -19.49%   x 1.24 
 aggregation::agg_tests::bench::bench_aggregation_range_only_opt                    14,737,189       10,854,391          -3,882,798  -26.35%   x 1.36 
 aggregation::agg_tests::bench::bench_aggregation_range_with_avg                    20,722,099       16,146,332          -4,575,767  -22.08%   x 1.28 
 aggregation::agg_tests::bench::bench_aggregation_range_with_avg_multi              29,723,431       26,693,781          -3,029,650  -10.19%   x 1.11 
 aggregation::agg_tests::bench::bench_aggregation_range_with_avg_opt                25,390,323       23,517,092          -1,873,231   -7.38%   x 1.08 
 aggregation::agg_tests::bench::bench_aggregation_stats_f64                         8,244,255        5,338,127           -2,906,128  -35.25%   x 1.54 
 aggregation::agg_tests::bench::bench_aggregation_stats_f64_multi                   14,475,345       12,176,140          -2,299,205  -15.88%   x 1.19 
 aggregation::agg_tests::bench::bench_aggregation_stats_f64_opt                     12,830,282       10,377,016          -2,453,266  -19.12%   x 1.24 
 aggregation::agg_tests::bench::bench_aggregation_terms_few                         6,549,730        3,577,244           -2,972,486  -45.38%   x 1.83 
 aggregation::agg_tests::bench::bench_aggregation_terms_few_multi                   19,969,163       17,757,300          -2,211,863  -11.08%   x 1.12 
 aggregation::agg_tests::bench::bench_aggregation_terms_few_opt                     15,391,557       12,275,784          -3,115,773  -20.24%   x 1.25 
 aggregation::agg_tests::bench::bench_aggregation_terms_many2                       17,329,689       15,005,286          -2,324,403  -13.41%   x 1.15 
 aggregation::agg_tests::bench::bench_aggregation_terms_many2_multi                 36,266,867       33,543,039          -2,723,828   -7.51%   x 1.08 
 aggregation::agg_tests::bench::bench_aggregation_terms_many2_opt                   33,012,959       30,288,960          -2,723,999   -8.25%   x 1.09 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term          18,708,459       15,791,601          -2,916,858  -15.59%   x 1.18 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term_multi    37,182,700       34,490,866          -2,691,834   -7.24%   x 1.08 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term_opt      32,750,782       31,254,708          -1,496,074   -4.57%   x 1.05 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg           132,758,440      131,027,529         -1,730,911   -1.30%   x 1.01 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg_multi     203,791,080      212,675,305          8,884,225    4.36%   x 0.96 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg_opt       198,716,848      188,832,143         -9,884,705   -4.97%   x 1.05 
 aggregation::bucket::range::bench::bench_range_100_buckets                         288,427          282,725                 -5,702   -1.98%   x 1.02 
 aggregation::bucket::range::bench::bench_range_10_buckets                          154,329          149,996                 -4,333   -2.81%   x 1.03 
```