### PR TITLE
 new sstable format

### DIFF
--- a/columnar/src/tests.rs
+++ b/columnar/src/tests.rs
@@ -17,7 +17,7 @@ fn test_dataframe_writer_str() {
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("my_string").unwrap();
     assert_eq!(cols.len(), 1);
-    assert_eq!(cols[0].num_bytes(), 158);
+    assert_eq!(cols[0].num_bytes(), 88);
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn test_dataframe_writer_bytes() {
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("my_string").unwrap();
     assert_eq!(cols.len(), 1);
-    assert_eq!(cols[0].num_bytes(), 158);
+    assert_eq!(cols[0].num_bytes(), 88);
 }
 
 #[test]

--- a/common/src/dictionary_footer.rs
+++ b/common/src/dictionary_footer.rs
@@ -1,0 +1,63 @@
+use std::io::{self, Read, Write};
+
+use crate::BinarySerializable;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum DictionaryKind {
+    Fst = 1,
+    SSTable = 2,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DictionaryFooter {
+    pub kind: DictionaryKind,
+    pub version: u32,
+}
+
+impl DictionaryFooter {
+    pub fn verify_equal(&self, other: &DictionaryFooter) -> io::Result<()> {
+        if self.kind != other.kind {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "Invalid dictionary type, expected {:?}, found {:?}",
+                    self.kind, other.kind
+                ),
+            ));
+        }
+        if self.version != other.version {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "Unsuported dictionary version, expected {}, found {}",
+                    self.version, other.version
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl BinarySerializable for DictionaryFooter {
+    fn serialize<W: Write + ?Sized>(&self, writer: &mut W) -> io::Result<()> {
+        self.version.serialize(writer)?;
+        (self.kind as u32).serialize(writer)
+    }
+    fn deserialize<R: Read>(reader: &mut R) -> io::Result<Self> {
+        let version = u32::deserialize(reader)?;
+        let kind = u32::deserialize(reader)?;
+        let kind = match kind {
+            1 => DictionaryKind::Fst,
+            2 => DictionaryKind::SSTable,
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("invalid dictionary kind: {kind}"),
+                ))
+            }
+        };
+
+        Ok(DictionaryFooter { kind, version })
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -6,6 +6,7 @@ pub use byteorder::LittleEndian as Endianness;
 
 mod bitset;
 mod datetime;
+mod dictionary_footer;
 pub mod file_slice;
 mod group_by;
 mod serialize;
@@ -13,6 +14,7 @@ mod vint;
 mod writer;
 pub use bitset::*;
 pub use datetime::{DatePrecision, DateTime};
+pub use dictionary_footer::*;
 pub use group_by::GroupByIteratorExtended;
 pub use ownedbytes::{OwnedBytes, StableDeref};
 pub use serialize::{BinarySerializable, DeserializeFrom, FixedSize};

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -130,7 +130,7 @@ mod tests {
         }
         let file = directory.open_read(path).unwrap();
 
-        assert_eq!(file.len(), 161);
+        assert_eq!(file.len(), 94);
         let fast_field_readers = FastFieldReaders::open(file, SCHEMA.clone()).unwrap();
         let column = fast_field_readers
             .u64("field")
@@ -180,7 +180,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 189);
+        assert_eq!(file.len(), 122);
         let fast_field_readers = FastFieldReaders::open(file, SCHEMA.clone()).unwrap();
         let col = fast_field_readers
             .u64("field")
@@ -213,7 +213,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 162);
+        assert_eq!(file.len(), 95);
         let fast_field_readers = FastFieldReaders::open(file, SCHEMA.clone()).unwrap();
         let fast_field_reader = fast_field_readers
             .u64("field")
@@ -245,7 +245,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 4557);
+        assert_eq!(file.len(), 4490);
         {
             let fast_field_readers = FastFieldReaders::open(file, SCHEMA.clone()).unwrap();
             let col = fast_field_readers
@@ -278,7 +278,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 333_usize);
+        assert_eq!(file.len(), 266);
 
         {
             let fast_field_readers = FastFieldReaders::open(file, schema).unwrap();
@@ -772,7 +772,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 175);
+        assert_eq!(file.len(), 103);
         let fast_field_readers = FastFieldReaders::open(file, schema).unwrap();
         let bool_col = fast_field_readers.bool("field_bool").unwrap();
         assert_eq!(bool_col.first(0), Some(true));
@@ -804,7 +804,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 187);
+        assert_eq!(file.len(), 115);
         let readers = FastFieldReaders::open(file, schema).unwrap();
         let bool_col = readers.bool("field_bool").unwrap();
         for i in 0..25 {
@@ -829,7 +829,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 177);
+        assert_eq!(file.len(), 105);
         let fastfield_readers = FastFieldReaders::open(file, schema).unwrap();
         let col = fastfield_readers.bool("field_bool").unwrap();
         assert_eq!(col.first(0), None);

--- a/sstable/Cargo.toml
+++ b/sstable/Cargo.toml
@@ -6,8 +6,6 @@ license = "MIT"
 
 [dependencies]
 common = {path="../common", package="tantivy-common"}
-ciborium = "0.2"
-serde = "1"
 tantivy-fst = "0.4"
 
 [dev-dependencies]

--- a/sstable/README.md
+++ b/sstable/README.md
@@ -87,9 +87,10 @@ Note: there is no ambiguity between both representation as Add is always guarant
 
 ### SSTFooter
 ```
-+-------+-------------+---------+---------+------+
-| Block | IndexOffset | NumTerm | Version | Type |
-+-------+-------------+---------+---------+------+
++-------+-------+-----+-------------+---------+---------+------+
+| Block | Block | ... | IndexOffset | NumTerm | Version | Type |
++-------+-------+-----+-------------+---------+---------+------+
+|----( # of blocks)---|
 ```
 - Block(SSTBlock): uses IndexValue for its Values format
 - IndexOffset(u64): Offset to the start of the SSTFooter

--- a/sstable/README.md
+++ b/sstable/README.md
@@ -38,7 +38,7 @@ Overview of the SSTable format. Unless noted otherwise, numbers are little-endia
 +-------+-------+-----+--------+
 |----( # of blocks)---|
 ```
-- Block(`SSTBlock`): list of independant block, terminated by a single empty block.
+- Block(`SSTBlock`): list of independent block, terminated by a single empty block.
 - Footer(`SSTFooter`)
 
 ### SSTBlock
@@ -48,8 +48,8 @@ Overview of the SSTable format. Unless noted otherwise, numbers are little-endia
 +----------+--------+-------+-------+-----+
                     |----( # of deltas)---|
 ```
-- BlockLen(u32): lenght of the block
-- Values: an application defined format storing a sequence of value, capable of determining it own lenght
+- BlockLen(u32): length of the block
+- Values: an application defined format storing a sequence of value, capable of determining it own length
 - Delta
 
 ### Delta
@@ -115,5 +115,5 @@ Note: there is no ambiguity between both representation as Add is always guarant
 | BlockLen | FirstOrdinal |
 +----------+--------------+
 ```
-- BlockLen(VInt): lenght of the block
+- BlockLen(VInt): length of the block
 - FirstOrdinal(VInt): ordinal of the first element in the given block

--- a/sstable/README.md
+++ b/sstable/README.md
@@ -87,15 +87,15 @@ Note: there is no ambiguity between both representation as Add is always guarant
 
 ### SSTFooter
 ```
-+-------+---------+---------+------+-------------+
-| Block | NumTerm | Version | Type | IndexOffset |
-+-------+---------+---------+------+-------------+
++-------+-------------+---------+---------+------+
+| Block | IndexOffset | NumTerm | Version | Type |
++-------+-------------+---------+---------+------+
 ```
 - Block(SSTBlock): uses IndexValue for its Values format
+- IndexOffset(u64): Offset to the start of the SSTFooter
 - NumTerm(u64): number of terms in the sstable
 - Version(u32): Currently defined to 0x00\_00\_00\_01
 - Type(u32): Defined to 0x00\_00\_00\_02
-- IndexOffset(u64): Offset to the start of the SSTFooter
 
 ### IndexValue
 ```

--- a/sstable/README.md
+++ b/sstable/README.md
@@ -26,3 +26,95 @@ possible.
 - it allows incremental encoding of the keys
 - the front compression is leveraged to optimize
 the intersection with an automaton
+
+# On disk format
+
+The on disk format is made to allow for partial loading from a sparse FileSlice. A single SSTable is composed of a sequence of independant blocks followed by an index.
+
+This definition uses a rust like syntax. Numbers are encoded in little endian unless noted otherwise.
+```rust
+struct SSTable {
+    /// terminated by an empty last block
+    blocks: [Block],
+    index: Index,
+}
+
+struct Block {
+    /// byte_len(values) + byte_len(deltas)
+    block_len: u32,
+    /// user defined format, represent a sequence of values, in the same order as the sequence of key encoded in deltas.
+    /// this format must be able to extract its own lenght.
+    values: [u8],
+    deltas: [Delta]
+}
+
+struct Delta {
+    keep_add: KeepAdd,
+    /// keep_add.add
+    suffix: [u8],
+}
+
+union KeepAdd {
+    /// when both `keep < 16` and `add < 16`
+    Small {
+        add: u4,
+        keep: u4,
+    },
+    /// otherwise
+    Large {
+        /// 0x01
+        _vint_mode_marker: u8,
+        keep: VInt,
+        add: VInt,
+    }
+}
+
+union VInt {
+    LastByte {
+        /// 0b0
+        _continue_bit: u1,
+        value: u7
+    },
+    WithContinuation {
+        // 0b1
+        _continue_bit: u1,
+        value: u7,
+        continuation: VInt,
+    }
+}
+
+impl VInt {
+    fn get_u64(self) -> u64 {
+        if self._continue_bit == 0 {
+            self.value
+        } else {
+            self.value + self.continuation.get_u64() << 7
+        }
+    }
+}
+
+// TODO this isn't actually implemented. Current format is cbor encoding of the struct
+struct Index {
+    // this block is a bit unusual as it has no target size like others usually do
+    index: Block,
+    num_term: u64,
+    // TODO insert a version field somewhere along here
+    // TODO encode dictionary type
+    index_start_offset: u64,
+}
+
+/// The format for Block::values for a block inside the Index
+struct IndexSSTableValue {
+    entry_count: VInt,
+    entries: [IndexEntry],
+}
+
+struct IndexEntry {
+    // last_key_or_greater is encoded inside the key part
+    byte_range_start: VInt,
+    byte_range_len: VInt,
+    first_ordinal: VInt,
+}
+
+```
+All numbers are little endian.

--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -110,7 +110,7 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
     /// only block for up to `limit` matching terms.
     ///
     /// It works by identifying
-    /// - `first_block`: the block containing the start boudary key
+    /// - `first_block`: the block containing the start boundary key
     /// - `last_block`: the block containing the end boundary key.
     ///
     /// And then returning the range that spans over all blocks between.
@@ -247,7 +247,7 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
             let suffix = sstable_delta_reader.suffix();
 
             match prefix_len.cmp(&ok_bytes) {
-                Ordering::Less => return Ok(None), // poped bytes already matched => too far
+                Ordering::Less => return Ok(None), // popped bytes already matched => too far
                 Ordering::Equal => (),
                 Ordering::Greater => {
                     // the ok prefix is less than current entry prefix => continue to next elem

--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -186,10 +186,16 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
         let version = u32::deserialize(&mut footer_len_bytes)?;
         let type_ = u32::deserialize(&mut footer_len_bytes)?;
         if type_ != 2 {
-            todo!("not an sstable")
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Invalid dictionary type, expected 2 (sstable), found {type_}"),
+            ));
         }
         if version != 1 {
-            todo!("unsupported version")
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("Unsupported version, expected 1, found {version}"),
+            ));
         }
 
         let (sstable_slice, index_slice) = main_slice.split(index_offset as usize);

--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -178,10 +178,20 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
 
     /// Opens a `TermDictionary`.
     pub fn open(term_dictionary_file: FileSlice) -> io::Result<Self> {
-        let (main_slice, footer_len_slice) = term_dictionary_file.split_from_end(16);
+        let (main_slice, footer_len_slice) = term_dictionary_file.split_from_end(24);
         let mut footer_len_bytes: OwnedBytes = footer_len_slice.read_bytes()?;
+
         let index_offset = u64::deserialize(&mut footer_len_bytes)?;
         let num_terms = u64::deserialize(&mut footer_len_bytes)?;
+        let version = u32::deserialize(&mut footer_len_bytes)?;
+        let type_ = u32::deserialize(&mut footer_len_bytes)?;
+        if type_ != 2 {
+            todo!("not an sstable")
+        }
+        if version != 1 {
+            todo!("unsupported version")
+        }
+
         let (sstable_slice, index_slice) = main_slice.split(index_offset as usize);
         let sstable_index_bytes = index_slice.read_bytes()?;
         let sstable_index = SSTableIndex::load(sstable_index_bytes.as_slice())

--- a/sstable/src/lib.rs
+++ b/sstable/src/lib.rs
@@ -519,8 +519,8 @@ mod test {
         fn test_proptest_sstable_ranges(words in prop::collection::btree_set("[a-c]{0,6}", 1..100),
             (lower_bound, upper_bound) in bounds_strategy(),
         ) {
-            // TODO tweak block size.
             let mut builder = Dictionary::<VoidSSTable>::builder(Vec::new()).unwrap();
+            builder.set_block_len(16);
             for word in &words {
                 builder.insert(word.as_bytes(), &()).unwrap();
             }

--- a/sstable/src/lib.rs
+++ b/sstable/src/lib.rs
@@ -288,6 +288,7 @@ where
             self.first_ordinal_of_the_block = self.num_terms;
         }
         let mut wrt = self.delta_writer.finish();
+        // add a final empty block as an end marker
         wrt.write_all(&0u32.to_le_bytes())?;
 
         let offset = wrt.written_bytes();

--- a/sstable/src/lib.rs
+++ b/sstable/src/lib.rs
@@ -201,6 +201,14 @@ where
         }
     }
 
+    /// Set the target block lenght.
+    ///
+    /// The delta part of a block will generaly be slighly larger than the requested `block_len`,
+    /// however this does not account for the length of the Value part of the table.
+    pub fn set_block_len(&mut self, block_len: usize) {
+        self.delta_writer.set_block_len(block_len)
+    }
+
     /// Returns the last inserted key.
     /// If no key has been inserted yet, or the block was just
     /// flushed, this function returns "".

--- a/sstable/src/lib.rs
+++ b/sstable/src/lib.rs
@@ -201,9 +201,9 @@ where
         }
     }
 
-    /// Set the target block lenght.
+    /// Set the target block length.
     ///
-    /// The delta part of a block will generaly be slighly larger than the requested `block_len`,
+    /// The delta part of a block will generally be slightly larger than the requested `block_len`,
     /// however this does not account for the length of the Value part of the table.
     pub fn set_block_len(&mut self, block_len: usize) {
         self.delta_writer.set_block_len(block_len)

--- a/sstable/src/sstable_index.rs
+++ b/sstable/src/sstable_index.rs
@@ -140,8 +140,11 @@ impl SSTableIndexBuilder {
     pub fn serialize<W: std::io::Write>(&self, wrt: W) -> io::Result<()> {
         // we can't use a plain writer as it would generate an index
         let mut sstable_writer = IndexSSTable::delta_writer(wrt);
-        // create only a single block
-        sstable_writer.set_block_len(usize::MAX);
+
+        // in tests, set a smaller block size to stress-test
+        #[cfg(test)]
+        sstable_writer.set_block_len(16);
+
         let mut previous_key = Vec::with_capacity(crate::DEFAULT_KEY_CAPACITY);
         for block in self.index.blocks.iter() {
             let keep_len = common_prefix_len(&previous_key, &block.last_key_or_greater);

--- a/sstable/src/sstable_index.rs
+++ b/sstable/src/sstable_index.rs
@@ -31,7 +31,7 @@ impl SSTableIndex {
             .map(|block_meta| block_meta.block_addr.clone())
     }
 
-    /// Get the block id of the block that woudl contain `key`.
+    /// Get the block id of the block that would contain `key`.
     ///
     /// Returns None if `key` is lexicographically after the last key recorded.
     pub(crate) fn locate_with_key(&self, key: &[u8]) -> Option<usize> {
@@ -164,8 +164,8 @@ impl SSTableIndexBuilder {
 /// SSTable representing an index
 ///
 /// `last_key_or_greater` is used as the key, the value contains the
-/// lenght and first ordinal of each block. The start offset is implicitly
-/// obtained from lenghts.
+/// length and first ordinal of each block. The start offset is implicitly
+/// obtained from lengths.
 struct IndexSSTable;
 
 impl SSTable for IndexSSTable {

--- a/sstable/src/sstable_index.rs
+++ b/sstable/src/sstable_index.rs
@@ -1,11 +1,9 @@
-use std::io;
+use std::io::{self, Write};
 use std::ops::Range;
 
-use serde::{Deserialize, Serialize};
+use crate::{common_prefix_len, SSTable, SSTableDataCorruption, TermOrdinal};
 
-use crate::{common_prefix_len, SSTableDataCorruption, TermOrdinal};
-
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone)]
 pub struct SSTableIndex {
     blocks: Vec<BlockMeta>,
 }
@@ -13,7 +11,17 @@ pub struct SSTableIndex {
 impl SSTableIndex {
     /// Load an index from its binary representation
     pub fn load(data: &[u8]) -> Result<SSTableIndex, SSTableDataCorruption> {
-        ciborium::de::from_reader(data).map_err(|_| SSTableDataCorruption)
+        let mut reader = IndexSSTable::reader(data);
+        let mut blocks = Vec::new();
+
+        while reader.advance().map_err(|_| SSTableDataCorruption)? {
+            blocks.push(BlockMeta {
+                last_key_or_greater: reader.key().to_vec(),
+                block_addr: reader.value().clone(),
+            });
+        }
+
+        Ok(SSTableIndex { blocks })
     }
 
     /// Get the [`BlockAddr`] of the requested block.
@@ -69,13 +77,13 @@ impl SSTableIndex {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct BlockAddr {
     pub byte_range: Range<usize>,
     pub first_ordinal: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub(crate) struct BlockMeta {
     /// Any byte string that is lexicographically greater or equal to
     /// the last key in the block,
@@ -130,9 +138,39 @@ impl SSTableIndexBuilder {
     }
 
     pub fn serialize<W: std::io::Write>(&self, wrt: W) -> io::Result<()> {
-        ciborium::ser::into_writer(&self.index, wrt)
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+        // we can't use a plain writer as it would generate an index
+        let mut sstable_writer = IndexSSTable::delta_writer(wrt);
+        // create only a single block
+        sstable_writer.set_block_len(usize::MAX);
+        let mut previous_key = Vec::with_capacity(crate::DEFAULT_KEY_CAPACITY);
+        for block in self.index.blocks.iter() {
+            let keep_len = common_prefix_len(&previous_key, &block.last_key_or_greater);
+
+            sstable_writer.write_suffix(keep_len, &block.last_key_or_greater[keep_len..]);
+            sstable_writer.write_value(&block.block_addr);
+
+            previous_key.clear();
+            previous_key.extend_from_slice(&block.last_key_or_greater);
+        }
+        sstable_writer.flush_block()?;
+        sstable_writer.finish().write_all(&0u32.to_le_bytes())?;
+        Ok(())
     }
+}
+
+/// SSTable representing an index
+///
+/// `last_key_or_greater` is used as the key, the value contains the
+/// lenght and first ordinal of each block. The start offset is implicitly
+/// obtained from lenghts.
+struct IndexSSTable;
+
+impl SSTable for IndexSSTable {
+    type Value = BlockAddr;
+
+    type ValueReader = crate::value::index::IndexValueReader;
+
+    type ValueWriter = crate::value::index::IndexValueWriter;
 }
 
 #[cfg(test)]
@@ -143,7 +181,7 @@ mod tests {
     #[test]
     fn test_sstable_index() {
         let mut sstable_builder = SSTableIndexBuilder::default();
-        sstable_builder.add_block(b"aaa", 10..20, 0u64);
+        sstable_builder.add_block(b"aaa", 0..20, 0u64);
         sstable_builder.add_block(b"bbbbbbb", 20..30, 5u64);
         sstable_builder.add_block(b"ccc", 30..40, 10u64);
         sstable_builder.add_block(b"dddd", 40..50, 15u64);

--- a/sstable/src/value/index.rs
+++ b/sstable/src/value/index.rs
@@ -1,0 +1,118 @@
+use std::io;
+
+use crate::value::{deserialize_vint_u64, ValueReader, ValueWriter};
+use crate::{vint, BlockAddr};
+
+#[derive(Default)]
+pub(crate) struct IndexValueReader {
+    vals: Vec<BlockAddr>,
+}
+
+impl ValueReader for IndexValueReader {
+    type Value = BlockAddr;
+
+    #[inline(always)]
+    fn value(&self, idx: usize) -> &Self::Value {
+        &self.vals[idx]
+    }
+
+    fn load(&mut self, mut data: &[u8]) -> io::Result<usize> {
+        let original_num_bytes = data.len();
+        let num_vals = deserialize_vint_u64(&mut data) as usize;
+        self.vals.clear();
+        let mut first_ordinal = 0u64;
+        let mut prev_start = 0usize;
+        for _ in 0..num_vals {
+            let len = deserialize_vint_u64(&mut data);
+            let delta_ordinal = deserialize_vint_u64(&mut data);
+
+            first_ordinal += delta_ordinal;
+            let end = prev_start + len as usize;
+            self.vals.push(BlockAddr {
+                byte_range: prev_start..end,
+                first_ordinal,
+            });
+            prev_start = end;
+        }
+        Ok(original_num_bytes - data.len())
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct IndexValueWriter {
+    vals: Vec<BlockAddr>,
+}
+
+impl ValueWriter for IndexValueWriter {
+    type Value = BlockAddr;
+
+    fn write(&mut self, val: &Self::Value) {
+        self.vals.push(val.clone());
+    }
+
+    fn serialize_block(&self, output: &mut Vec<u8>) {
+        let mut prev_ord = 0u64;
+        vint::serialize_into_vec(self.vals.len() as u64, output);
+        // TODO use array_windows when it gets stabilized
+        for elem in self.vals.windows(2) {
+            let [current, next] = elem else {
+                unreachable!("windows should always return exactly 2 elements");
+            };
+            let len = next.byte_range.start - current.byte_range.start;
+            vint::serialize_into_vec(len as u64, output);
+            let delta = current.first_ordinal - prev_ord;
+            vint::serialize_into_vec(delta, output);
+            prev_ord = current.first_ordinal;
+        }
+        if let Some(last) = self.vals.last() {
+            let len = last.byte_range.end - last.byte_range.start;
+            vint::serialize_into_vec(len as u64, output);
+            let delta = last.first_ordinal - prev_ord;
+            vint::serialize_into_vec(delta, output);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.vals.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_reader_writer() {
+        crate::value::tests::test_value_reader_writer::<_, IndexValueReader, IndexValueWriter>(&[]);
+        crate::value::tests::test_value_reader_writer::<_, IndexValueReader, IndexValueWriter>(&[
+            BlockAddr {
+                byte_range: 0..10,
+                first_ordinal: 0,
+            },
+        ]);
+        crate::value::tests::test_value_reader_writer::<_, IndexValueReader, IndexValueWriter>(&[
+            BlockAddr {
+                byte_range: 0..10,
+                first_ordinal: 0,
+            },
+            BlockAddr {
+                byte_range: 10..20,
+                first_ordinal: 5,
+            },
+        ]);
+        crate::value::tests::test_value_reader_writer::<_, IndexValueReader, IndexValueWriter>(&[
+            BlockAddr {
+                byte_range: 0..10,
+                first_ordinal: 0,
+            },
+            BlockAddr {
+                byte_range: 10..20,
+                first_ordinal: 5,
+            },
+            BlockAddr {
+                byte_range: 20..30,
+                first_ordinal: 10,
+            },
+        ]);
+    }
+}

--- a/sstable/src/value/mod.rs
+++ b/sstable/src/value/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod index;
 mod range;
 mod u64_monotonic;
 mod void;


### PR DESCRIPTION
this implements and document a new format for sstables. Most of the format is the same as before, except the index is now a small sstable too instead of a cbor blob.

fix #1851
- [x] remove the dependency.
- [x] have a well-spec'ed format.
- [x] have proper versioning in the format
- [x]  get something more compact... Right now a tiny dictionary can often top 100 bytes.

groundwork for #1827 (encode dictionary type, but only for sstable, fst kept unchanged for now)

fix some of #1738
- [ ] inverse vint implementation (not sure what this is)
- [x] remove serde_cbor.
- [ ] add multilevel indexing (in some way this is a 2 level index I guess?)

fix #1731

fix some of #1727
- [x] add version & magic number in SSTable format. At the dictionary scale, not in each block.
- [ ] remove `sstable::Dictionary::new` and use `sstable::Dictionary::create`
- [ ] refactor the magic number/ version logic.


Size comparison with previous format:
- tests in `src/fastfield/mod.rs` and `columnar/src/tests.rs` show the difference for small indexes
- test payload in `sstable/src/lib.rs` went from 115 to 53 bytes
- on a split of exactly one day of gh-archive, the size of the "footer" went from 1075365 (1MB) to 86399 (84kB), ~92% smaller

The improvement comes from three sources:
- cbor keep the name of the fields as it aims to encode the same kind of data as json, so an index for a single block might look something like this: `$fblocks$$slast_key_or_greater$!!jblock_addr$jbyte_range$estartcend$mfirst_ordinal`, where there is more field name than actual metadata (impact both small and large indexes)
- using sstable allows to merge key prefixes when there are blocks ending with similar enough keys (impact only large indexes)
- block range and first_ord are encoded as delta, start offset are implicit, derived from the length of previous blocks (impact both small and large indexes)

This could probably be made to support reading the old format if we want some amount of backward compatibility, at the cost of reintroducing cbor 