### PR TITLE
Draft: Switch fs2 to fs4 as it is now unmaintained and does not support illumos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ log = "0.4.16"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 num_cpus = "1.13.1"
-fs2 = { version = "0.4.3", optional = true }
+fs4 = { version = "0.6.3", optional = true }
 levenshtein_automata = "0.2.1"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 crossbeam-channel = "0.5.4"
@@ -94,7 +94,7 @@ overflow-checks = true
 
 [features]
 default = ["mmap", "stopwords", "lz4-compression"]
-mmap = ["fs2", "tempfile", "memmap2"]
+mmap = ["fs4", "tempfile", "memmap2"]
 stopwords = []
 
 brotli-compression = ["brotli"]

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, RwLock, Weak};
 use std::{fmt, result};
 
 use common::StableDeref;
-use fs2::FileExt;
+use fs4::FileExt;
 use memmap2::Mmap;
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;


### PR DESCRIPTION
Cargo test passes tests and API is compatible.