### PR TITLE
fetch blocks of vals in aggregation for all cardinality

### DIFF
--- a/columnar/src/block_accessor.rs
+++ b/columnar/src/block_accessor.rs
@@ -1,0 +1,36 @@
+use crate::{Column, DocId, RowId};
+
+#[derive(Debug, Default, Clone)]
+pub struct ColumnBlockAccessor<T> {
+    val_cache: Vec<T>,
+    docid_cache: Vec<DocId>,
+    row_id_cache: Vec<RowId>,
+}
+
+impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
+    ColumnBlockAccessor<T>
+{
+    #[inline]
+    pub fn fetch_block(&mut self, docs: &[u32], accessor: &Column<T>) {
+        self.docid_cache.clear();
+        self.row_id_cache.clear();
+        accessor.row_ids_for_docs(docs, &mut self.docid_cache, &mut self.row_id_cache);
+        self.val_cache.resize(self.row_id_cache.len(), T::default());
+        accessor
+            .values
+            .get_vals(&self.row_id_cache, &mut self.val_cache);
+    }
+
+    #[inline]
+    pub fn iter_vals(&self) -> impl Iterator<Item = T> + '_ {
+        self.val_cache.iter().cloned()
+    }
+
+    #[inline]
+    pub fn iter_docid_vals(&self) -> impl Iterator<Item = (DocId, T)> + '_ {
+        self.docid_cache
+            .iter()
+            .cloned()
+            .zip(self.val_cache.iter().cloned())
+    }
+}

--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -68,6 +68,14 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
         self.values_for_doc(row_id).next()
     }
 
+    /// Translates a block of docis to row_ids.
+    ///
+    /// returns the row_ids and the matching docids on the same index
+    /// e.g.
+    /// DocId In:  [0, 5, 6]
+    /// DocId Out: [0, 0, 6, 6]
+    /// RowId Out: [0, 1, 2, 3]
+    #[inline]
     pub fn row_ids_for_docs(
         &self,
         doc_ids: &[DocId],

--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -16,7 +16,7 @@ pub use serialize::{
 use crate::column_index::ColumnIndex;
 use crate::column_values::monotonic_mapping::StrictlyMonotonicMappingToInternal;
 use crate::column_values::{monotonic_map_column, ColumnValues};
-use crate::{Cardinality, MonotonicallyMappableToU64, RowId};
+use crate::{Cardinality, DocId, MonotonicallyMappableToU64, RowId};
 
 #[derive(Clone)]
 pub struct Column<T = u64> {
@@ -68,8 +68,17 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
         self.values_for_doc(row_id).next()
     }
 
-    pub fn values_for_doc(&self, row_id: RowId) -> impl Iterator<Item = T> + '_ {
-        self.value_row_ids(row_id)
+    pub fn row_ids_for_docs(
+        &self,
+        doc_ids: &[DocId],
+        doc_ids_out: &mut Vec<DocId>,
+        row_ids: &mut Vec<RowId>,
+    ) {
+        self.idx.docids_to_rowids(doc_ids, doc_ids_out, row_ids)
+    }
+
+    pub fn values_for_doc(&self, doc_id: DocId) -> impl Iterator<Item = T> + '_ {
+        self.value_row_ids(doc_id)
             .map(|value_row_id: RowId| self.values.get_val(value_row_id))
     }
 

--- a/columnar/src/column_index/mod.rs
+++ b/columnar/src/column_index/mod.rs
@@ -81,13 +81,13 @@ impl ColumnIndex {
     /// DocId In:  [0, 5, 6]
     /// DocId Out: [0, 0, 6, 6]
     /// RowId Out: [0, 1, 2, 3]
+    #[inline]
     pub fn docids_to_rowids(
         &self,
         doc_ids: &[DocId],
         doc_ids_out: &mut Vec<DocId>,
         row_ids: &mut Vec<RowId>,
     ) {
-        row_ids.clear();
         match self {
             ColumnIndex::Empty { .. } => {}
             ColumnIndex::Full => {

--- a/columnar/src/lib.rs
+++ b/columnar/src/lib.rs
@@ -9,6 +9,7 @@ extern crate test;
 
 use std::io;
 
+mod block_accessor;
 mod column;
 mod column_index;
 pub mod column_values;
@@ -19,6 +20,7 @@ mod iterable;
 pub(crate) mod utils;
 mod value;
 
+pub use block_accessor::ColumnBlockAccessor;
 pub use column::{BytesColumn, Column, StrColumn};
 pub use column_index::ColumnIndex;
 pub use column_values::{ColumnValues, MonotonicallyMappableToU128, MonotonicallyMappableToU64};

--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use columnar::{Column, ColumnType, ColumnValues, StrColumn};
+use columnar::{Column, ColumnBlockAccessor, ColumnType, ColumnValues, StrColumn};
 
 use super::agg_req::{Aggregation, Aggregations, BucketAggregationType, MetricAggregation};
 use super::bucket::{
@@ -45,6 +45,7 @@ pub struct BucketAggregationWithAccessor {
     pub(crate) bucket_agg: BucketAggregationType,
     pub(crate) sub_aggregation: AggregationsWithAccessor,
     pub(crate) limits: AggregationLimits,
+    pub(crate) column_block_accessor: ColumnBlockAccessor<u64>,
 }
 
 impl BucketAggregationWithAccessor {
@@ -85,6 +86,7 @@ impl BucketAggregationWithAccessor {
             bucket_agg: bucket.clone(),
             str_dict_column,
             limits,
+            column_block_accessor: Default::default(),
         })
     }
 }
@@ -95,6 +97,7 @@ pub struct MetricAggregationWithAccessor {
     pub metric: MetricAggregation,
     pub field_type: ColumnType,
     pub accessor: Column<u64>,
+    pub column_block_accessor: ColumnBlockAccessor<u64>,
 }
 
 impl MetricAggregationWithAccessor {
@@ -115,6 +118,7 @@ impl MetricAggregationWithAccessor {
                     accessor,
                     field_type,
                     metric: metric.clone(),
+                    column_block_accessor: Default::default(),
                 })
             }
         }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use columnar::{ColumnBlockAccessor, ColumnType};
+use columnar::ColumnType;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
@@ -210,7 +210,10 @@ struct TermBuckets {
 }
 
 impl TermBuckets {
-    fn force_flush(&mut self, agg_with_accessor: &AggregationsWithAccessor) -> crate::Result<()> {
+    fn force_flush(
+        &mut self,
+        agg_with_accessor: &mut AggregationsWithAccessor,
+    ) -> crate::Result<()> {
         for sub_aggregations in &mut self.sub_aggs.values_mut() {
             sub_aggregations.as_mut().flush(agg_with_accessor)?;
         }
@@ -228,7 +231,6 @@ pub struct SegmentTermCollector {
     blueprint: Option<Box<dyn SegmentAggregationCollector>>,
     field_type: ColumnType,
     accessor_idx: usize,
-    column_block_accessor: ColumnBlockAccessor<u64>,
 }
 
 pub(crate) fn get_agg_name_and_property(name: &str) -> (&str, &str) {
@@ -257,7 +259,7 @@ impl SegmentAggregationCollector for SegmentTermCollector {
     fn collect(
         &mut self,
         doc: crate::DocId,
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()> {
         self.collect_block(&[doc], agg_with_accessor)
     }
@@ -266,34 +268,34 @@ impl SegmentAggregationCollector for SegmentTermCollector {
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()> {
-        let accessor = &agg_with_accessor.buckets.values[self.accessor_idx].accessor;
-        let sub_aggregation_accessor =
-            &agg_with_accessor.buckets.values[self.accessor_idx].sub_aggregation;
+        let bucket_agg_accessor = &mut agg_with_accessor.buckets.values[self.accessor_idx];
 
-        self.column_block_accessor.fetch_block(docs, accessor);
-        for term_id in self.column_block_accessor.iter_vals() {
+        bucket_agg_accessor
+            .column_block_accessor
+            .fetch_block(docs, &bucket_agg_accessor.accessor);
+        for term_id in bucket_agg_accessor.column_block_accessor.iter_vals() {
             let entry = self.term_buckets.entries.entry(term_id).or_default();
             *entry += 1;
         }
         // has subagg
         if let Some(blueprint) = self.blueprint.as_ref() {
-            for (doc, term_id) in self.column_block_accessor.iter_docid_vals() {
+            for (doc, term_id) in bucket_agg_accessor.column_block_accessor.iter_docid_vals() {
                 let sub_aggregations = self
                     .term_buckets
                     .sub_aggs
                     .entry(term_id)
                     .or_insert_with(|| blueprint.clone());
-                sub_aggregations.collect(doc, sub_aggregation_accessor)?;
+                sub_aggregations.collect(doc, &mut bucket_agg_accessor.sub_aggregation)?;
             }
         }
         Ok(())
     }
 
-    fn flush(&mut self, agg_with_accessor: &AggregationsWithAccessor) -> crate::Result<()> {
+    fn flush(&mut self, agg_with_accessor: &mut AggregationsWithAccessor) -> crate::Result<()> {
         let sub_aggregation_accessor =
-            &agg_with_accessor.buckets.values[self.accessor_idx].sub_aggregation;
+            &mut agg_with_accessor.buckets.values[self.accessor_idx].sub_aggregation;
 
         self.term_buckets.force_flush(sub_aggregation_accessor)?;
         Ok(())
@@ -337,7 +339,6 @@ impl SegmentTermCollector {
             blueprint,
             field_type,
             accessor_idx,
-            column_block_accessor: Default::default(),
         })
     }
 

--- a/src/aggregation/buf_collector.rs
+++ b/src/aggregation/buf_collector.rs
@@ -46,7 +46,7 @@ impl SegmentAggregationCollector for BufAggregationCollector {
     fn collect(
         &mut self,
         doc: crate::DocId,
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()> {
         self.staged_docs[self.num_staged_docs] = doc;
         self.num_staged_docs += 1;
@@ -62,7 +62,7 @@ impl SegmentAggregationCollector for BufAggregationCollector {
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()> {
         self.collector.collect_block(docs, agg_with_accessor)?;
 
@@ -70,7 +70,7 @@ impl SegmentAggregationCollector for BufAggregationCollector {
     }
 
     #[inline]
-    fn flush(&mut self, agg_with_accessor: &AggregationsWithAccessor) -> crate::Result<()> {
+    fn flush(&mut self, agg_with_accessor: &mut AggregationsWithAccessor) -> crate::Result<()> {
         self.collector
             .collect_block(&self.staged_docs[..self.num_staged_docs], agg_with_accessor)?;
         self.num_staged_docs = 0;

--- a/src/aggregation/collector.rs
+++ b/src/aggregation/collector.rs
@@ -156,7 +156,10 @@ impl SegmentCollector for AggregationSegmentCollector {
         if self.error.is_some() {
             return;
         }
-        if let Err(err) = self.agg_collector.collect(doc, &self.aggs_with_accessor) {
+        if let Err(err) = self
+            .agg_collector
+            .collect(doc, &mut self.aggs_with_accessor)
+        {
             self.error = Some(err);
         }
     }
@@ -170,7 +173,7 @@ impl SegmentCollector for AggregationSegmentCollector {
         }
         if let Err(err) = self
             .agg_collector
-            .collect_block(docs, &self.aggs_with_accessor)
+            .collect_block(docs, &mut self.aggs_with_accessor)
         {
             self.error = Some(err);
         }
@@ -180,7 +183,7 @@ impl SegmentCollector for AggregationSegmentCollector {
         if let Some(err) = self.error {
             return Err(err);
         }
-        self.agg_collector.flush(&self.aggs_with_accessor)?;
+        self.agg_collector.flush(&mut self.aggs_with_accessor)?;
         Box::new(self.agg_collector).into_intermediate_aggregations_result(&self.aggs_with_accessor)
     }
 }

--- a/src/aggregation/segment_agg_result.rs
+++ b/src/aggregation/segment_agg_result.rs
@@ -28,18 +28,18 @@ pub(crate) trait SegmentAggregationCollector: CollectorClone + Debug {
     fn collect(
         &mut self,
         doc: crate::DocId,
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()>;
 
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()>;
 
     /// Finalize method. Some Aggregator collect blocks of docs before calling `collect_block`.
     /// This method ensures those staged docs will be collected.
-    fn flush(&mut self, _agg_with_accessor: &AggregationsWithAccessor) -> crate::Result<()> {
+    fn flush(&mut self, _agg_with_accessor: &mut AggregationsWithAccessor) -> crate::Result<()> {
         Ok(())
     }
 }
@@ -206,7 +206,7 @@ impl SegmentAggregationCollector for GenericSegmentAggregationResultsCollector {
     fn collect(
         &mut self,
         doc: crate::DocId,
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()> {
         self.collect_block(&[doc], agg_with_accessor)?;
 
@@ -216,7 +216,7 @@ impl SegmentAggregationCollector for GenericSegmentAggregationResultsCollector {
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()> {
         if let Some(metrics) = self.metrics.as_mut() {
             for collector in metrics {
@@ -233,7 +233,7 @@ impl SegmentAggregationCollector for GenericSegmentAggregationResultsCollector {
         Ok(())
     }
 
-    fn flush(&mut self, agg_with_accessor: &AggregationsWithAccessor) -> crate::Result<()> {
+    fn flush(&mut self, agg_with_accessor: &mut AggregationsWithAccessor) -> crate::Result<()> {
         if let Some(metrics) = &mut self.metrics {
             for collector in metrics {
                 collector.flush(agg_with_accessor)?;


### PR DESCRIPTION
- fetch blocks of vals in aggregation for all cardinality
- move caching in common accessor

```
 aggregation::agg_tests::bench::bench_aggregation_average_f64                       5,942,104        5,148,082             -794,022  -13.36%   x 1.15 
 aggregation::agg_tests::bench::bench_aggregation_average_f64_multi                 11,417,079       11,905,300             488,221    4.28%   x 0.96 
 aggregation::agg_tests::bench::bench_aggregation_average_f64_opt                   10,851,455       10,328,652            -522,803   -4.82%   x 1.05 
 aggregation::agg_tests::bench::bench_aggregation_average_u64                       5,738,694        5,132,859             -605,835  -10.56%   x 1.12 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64               10,323,814       9,441,560             -882,254   -8.55%   x 1.09 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64_multi         26,116,150       25,086,729          -1,029,421   -3.94%   x 1.04 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_and_f64_opt           22,321,784       21,670,827            -650,957   -2.92%   x 1.03 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_multi                 12,767,874       11,943,697            -824,177   -6.46%   x 1.07 
 aggregation::agg_tests::bench::bench_aggregation_average_u64_opt                   10,784,961       9,784,827           -1,000,134   -9.27%   x 1.10 
 aggregation::agg_tests::bench::bench_aggregation_avg_and_range_with_avg            20,777,644       21,730,091             952,447    4.58%   x 0.96 
 aggregation::agg_tests::bench::bench_aggregation_avg_and_range_with_avg_multi      41,094,900       38,388,767          -2,706,133   -6.59%   x 1.07 
 aggregation::agg_tests::bench::bench_aggregation_avg_and_range_with_avg_opt        31,187,511       33,683,952           2,496,441    8.00%   x 0.93 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only                    18,582,468       12,670,097          -5,912,371  -31.82%   x 1.47 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_hard_bounds        14,368,286       8,467,926           -5,900,360  -41.07%   x 1.70 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_hard_bounds_multi  19,800,917       14,194,739          -5,606,178  -28.31%   x 1.39 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_hard_bounds_opt    17,114,142       12,168,552          -4,945,590  -28.90%   x 1.41 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_multi              28,772,087       18,172,721         -10,599,366  -36.84%   x 1.58 
 aggregation::agg_tests::bench::bench_aggregation_histogram_only_opt                23,780,209       15,942,567          -7,837,642  -32.96%   x 1.49 
 aggregation::agg_tests::bench::bench_aggregation_histogram_with_avg                45,636,068       38,374,941          -7,261,127  -15.91%   x 1.19 
 aggregation::agg_tests::bench::bench_aggregation_histogram_with_avg_multi          66,135,585       62,101,487          -4,034,098   -6.10%   x 1.06 
 aggregation::agg_tests::bench::bench_aggregation_histogram_with_avg_opt            63,782,712       59,397,435          -4,385,277   -6.88%   x 1.07 
 aggregation::agg_tests::bench::bench_aggregation_range_only                        8,859,395        8,744,853             -114,542   -1.29%   x 1.01 
 aggregation::agg_tests::bench::bench_aggregation_range_only_multi                  18,561,760       14,729,939          -3,831,821  -20.64%   x 1.26 
 aggregation::agg_tests::bench::bench_aggregation_range_only_opt                    10,784,218       11,994,109           1,209,891   11.22%   x 0.90 
 aggregation::agg_tests::bench::bench_aggregation_range_with_avg                    17,530,600       15,944,098          -1,586,502   -9.05%   x 1.10 
 aggregation::agg_tests::bench::bench_aggregation_range_with_avg_multi              31,067,284       25,016,654          -6,050,630  -19.48%   x 1.24 
 aggregation::agg_tests::bench::bench_aggregation_range_with_avg_opt                24,251,764       24,028,501            -223,263   -0.92%   x 1.01 
 aggregation::agg_tests::bench::bench_aggregation_stats_f64                         5,597,841        4,815,704             -782,137  -13.97%   x 1.16 
 aggregation::agg_tests::bench::bench_aggregation_stats_f64_multi                   12,227,305       10,762,508          -1,464,797  -11.98%   x 1.14 
 aggregation::agg_tests::bench::bench_aggregation_stats_f64_opt                     10,552,396       9,358,999           -1,193,397  -11.31%   x 1.13 
 aggregation::agg_tests::bench::bench_aggregation_terms_few                         3,398,698        3,349,821              -48,877   -1.44%   x 1.01 
 aggregation::agg_tests::bench::bench_aggregation_terms_few_multi                   18,604,549       10,138,197          -8,466,352  -45.51%   x 1.84 
 aggregation::agg_tests::bench::bench_aggregation_terms_few_opt                     12,700,642       7,060,409           -5,640,233  -44.41%   x 1.80 
 aggregation::agg_tests::bench::bench_aggregation_terms_many2                       14,355,628       13,626,684            -728,944   -5.08%   x 1.05 
 aggregation::agg_tests::bench::bench_aggregation_terms_many2_multi                 40,380,602       19,984,981         -20,395,621  -50.51%   x 2.02 
 aggregation::agg_tests::bench::bench_aggregation_terms_many2_opt                   28,780,245       17,929,649         -10,850,596  -37.70%   x 1.61 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term          15,770,133       15,161,564            -608,569   -3.86%   x 1.04 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term_multi    35,212,879       22,290,228         -12,922,651  -36.70%   x 1.58 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_order_by_term_opt      31,339,182       18,947,793         -12,391,389  -39.54%   x 1.65 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg           128,122,516      115,084,171        -13,038,345  -10.18%   x 1.11 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg_multi     200,759,294      177,645,007        -23,114,287  -11.51%   x 1.13 
 aggregation::agg_tests::bench::bench_aggregation_terms_many_with_sub_agg_opt       181,130,229      162,938,489        -18,191,740  -10.04%   x 1.11 
```