### PR TITLE
Renaming Column::idx -> Column::index

### DIFF
--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -20,14 +20,14 @@ use crate::{Cardinality, DocId, EmptyColumnValues, MonotonicallyMappableToU64, R
 
 #[derive(Clone)]
 pub struct Column<T = u64> {
-    pub idx: ColumnIndex,
+    pub index: ColumnIndex,
     pub values: Arc<dyn ColumnValues<T>>,
 }
 
 impl<T: PartialOrd + Default> Column<T> {
     pub fn build_empty_column(num_docs: u32) -> Column<T> {
         Column {
-            idx: ColumnIndex::Empty { num_docs },
+            index: ColumnIndex::Empty { num_docs },
             values: Arc::new(EmptyColumnValues),
         }
     }
@@ -40,7 +40,7 @@ impl<T: MonotonicallyMappableToU64> Column<T> {
             StrictlyMonotonicMappingToInternal::<T>::new(),
         ));
         Column {
-            idx: self.idx,
+            index: self.index,
             values,
         }
     }
@@ -49,11 +49,11 @@ impl<T: MonotonicallyMappableToU64> Column<T> {
 impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
     #[inline]
     pub fn get_cardinality(&self) -> Cardinality {
-        self.idx.get_cardinality()
+        self.index.get_cardinality()
     }
 
     pub fn num_docs(&self) -> RowId {
-        match &self.idx {
+        match &self.index {
             ColumnIndex::Empty { num_docs } => *num_docs,
             ColumnIndex::Full => self.values.num_vals(),
             ColumnIndex::Optional(optional_index) => optional_index.num_docs(),
@@ -91,7 +91,7 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
         doc_ids_out: &mut Vec<DocId>,
         row_ids: &mut Vec<RowId>,
     ) {
-        self.idx.docids_to_rowids(doc_ids, doc_ids_out, row_ids)
+        self.index.docids_to_rowids(doc_ids, doc_ids_out, row_ids)
     }
 
     pub fn values_for_doc(&self, doc_id: DocId) -> impl Iterator<Item = T> + '_ {
@@ -108,13 +108,15 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
         doc_ids: &mut Vec<u32>,
     ) {
         // convert passed docid range to row id range
-        let rowid_range = self.idx.docid_range_to_rowids(selected_docid_range.clone());
+        let rowid_range = self
+            .index
+            .docid_range_to_rowids(selected_docid_range.clone());
 
         // Load rows
         self.values
             .get_row_ids_for_value_range(value_range, rowid_range, doc_ids);
         // Convert rows to docids
-        self.idx
+        self.index
             .select_batch_in_place(selected_docid_range.start, doc_ids);
     }
 
@@ -139,7 +141,7 @@ impl<T> Deref for Column<T> {
     type Target = ColumnIndex;
 
     fn deref(&self) -> &Self::Target {
-        &self.idx
+        &self.index
     }
 }
 
@@ -177,7 +179,7 @@ impl<T: PartialOrd + Debug + Send + Sync + Copy + 'static> ColumnValues<T>
     }
 
     fn num_vals(&self) -> u32 {
-        match &self.column.idx {
+        match &self.column.index {
             ColumnIndex::Empty { .. } => 0u32,
             ColumnIndex::Full => self.column.values.num_vals(),
             ColumnIndex::Optional(optional_idx) => optional_idx.num_docs(),

--- a/columnar/src/column/serialize.rs
+++ b/columnar/src/column/serialize.rs
@@ -52,7 +52,7 @@ pub fn open_column_u64<T: MonotonicallyMappableToU64>(bytes: OwnedBytes) -> io::
     let column_index = crate::column_index::open_column_index(column_index_data)?;
     let column_values = load_u64_based_column_values(column_values_data)?;
     Ok(Column {
-        idx: column_index,
+        index: column_index,
         values: column_values,
     })
 }
@@ -71,7 +71,7 @@ pub fn open_column_u128<T: MonotonicallyMappableToU128>(
     let column_index = crate::column_index::open_column_index(column_index_data)?;
     let column_values = crate::column_values::open_u128_mapped(column_values_data)?;
     Ok(Column {
-        idx: column_index,
+        index: column_index,
         values: column_values,
     })
 }

--- a/columnar/src/columnar/merge/mod.rs
+++ b/columnar/src/columnar/merge/mod.rs
@@ -127,15 +127,15 @@ fn merge_column(
             let mut column_indexes: Vec<ColumnIndex> = Vec::with_capacity(columns.len());
             let mut column_values: Vec<Option<Arc<dyn ColumnValues>>> =
                 Vec::with_capacity(columns.len());
-            for (idx, dynamic_column_opt) in columns.into_iter().enumerate() {
-                if let Some(Column { idx, values }) =
+            for (i, dynamic_column_opt) in columns.into_iter().enumerate() {
+                if let Some(Column { index: idx, values }) =
                     dynamic_column_opt.and_then(dynamic_column_to_u64_monotonic)
                 {
                     column_indexes.push(idx);
                     column_values.push(Some(values));
                 } else {
                     column_indexes.push(ColumnIndex::Empty {
-                        num_docs: num_docs_per_column[idx],
+                        num_docs: num_docs_per_column[i],
                     });
                     column_values.push(None);
                 }
@@ -153,13 +153,15 @@ fn merge_column(
             let mut column_indexes: Vec<ColumnIndex> = Vec::with_capacity(columns.len());
             let mut column_values: Vec<Option<Arc<dyn ColumnValues<Ipv6Addr>>>> =
                 Vec::with_capacity(columns.len());
-            for (idx, dynamic_column_opt) in columns.into_iter().enumerate() {
-                if let Some(DynamicColumn::IpAddr(Column { idx, values })) = dynamic_column_opt {
+            for (i, dynamic_column_opt) in columns.into_iter().enumerate() {
+                if let Some(DynamicColumn::IpAddr(Column { index: idx, values })) =
+                    dynamic_column_opt
+                {
                     column_indexes.push(idx);
                     column_values.push(Some(values));
                 } else {
                     column_indexes.push(ColumnIndex::Empty {
-                        num_docs: num_docs_per_column[idx],
+                        num_docs: num_docs_per_column[i],
                     });
                     column_values.push(None);
                 }
@@ -178,19 +180,19 @@ fn merge_column(
         ColumnType::Bytes | ColumnType::Str => {
             let mut column_indexes: Vec<ColumnIndex> = Vec::with_capacity(columns.len());
             let mut bytes_columns: Vec<Option<BytesColumn>> = Vec::with_capacity(columns.len());
-            for (idx, dynamic_column_opt) in columns.into_iter().enumerate() {
+            for (i, dynamic_column_opt) in columns.into_iter().enumerate() {
                 match dynamic_column_opt {
                     Some(DynamicColumn::Str(str_column)) => {
-                        column_indexes.push(str_column.term_ord_column.idx.clone());
+                        column_indexes.push(str_column.term_ord_column.index.clone());
                         bytes_columns.push(Some(str_column.into()));
                     }
                     Some(DynamicColumn::Bytes(bytes_column)) => {
-                        column_indexes.push(bytes_column.term_ord_column.idx.clone());
+                        column_indexes.push(bytes_column.term_ord_column.index.clone());
                         bytes_columns.push(Some(bytes_column));
                     }
                     _ => {
                         column_indexes.push(ColumnIndex::Empty {
-                            num_docs: num_docs_per_column[idx],
+                            num_docs: num_docs_per_column[i],
                         });
                         bytes_columns.push(None);
                     }

--- a/columnar/src/dynamic_column.rs
+++ b/columnar/src/dynamic_column.rs
@@ -73,11 +73,11 @@ impl DynamicColumn {
     fn coerce_to_f64(self) -> Option<DynamicColumn> {
         match self {
             DynamicColumn::I64(column) => Some(DynamicColumn::F64(Column {
-                idx: column.idx,
+                index: column.index,
                 values: Arc::new(monotonic_map_column(column.values, MapI64ToF64)),
             })),
             DynamicColumn::U64(column) => Some(DynamicColumn::F64(Column {
-                idx: column.idx,
+                index: column.index,
                 values: Arc::new(monotonic_map_column(column.values, MapU64ToF64)),
             })),
             DynamicColumn::F64(_) => Some(self),
@@ -91,7 +91,7 @@ impl DynamicColumn {
                     return None;
                 }
                 Some(DynamicColumn::I64(Column {
-                    idx: column.idx,
+                    index: column.index,
                     values: Arc::new(monotonic_map_column(column.values, MapU64ToI64)),
                 }))
             }
@@ -106,7 +106,7 @@ impl DynamicColumn {
                     return None;
                 }
                 Some(DynamicColumn::U64(Column {
-                    idx: column.idx,
+                    index: column.index,
                     values: Arc::new(monotonic_map_column(column.values, MapI64ToU64)),
                 }))
             }

--- a/columnar/src/tests.rs
+++ b/columnar/src/tests.rs
@@ -126,7 +126,7 @@ fn test_dataframe_writer_numerical() {
     assert_eq!(cols[0].num_bytes(), 33);
     let column = cols[0].open().unwrap();
     let DynamicColumn::I64(column_i64) = column else { panic!(); };
-    assert_eq!(column_i64.idx.get_cardinality(), Cardinality::Optional);
+    assert_eq!(column_i64.index.get_cardinality(), Cardinality::Optional);
     assert_eq!(column_i64.first(0), None);
     assert_eq!(column_i64.first(1), Some(12i64));
     assert_eq!(column_i64.first(2), Some(13i64));


### PR DESCRIPTION
There was some variable name ghosting happening.