### PR TITLE
Better mixed types support in aggs and fix serialization issue

### DIFF
--- a/src/aggregation/agg_bench.rs
+++ b/src/aggregation/agg_bench.rs
@@ -1,0 +1,611 @@
+#[cfg(all(test, feature = "unstable"))]
+mod bench {
+
+    use columnar::Cardinality;
+    use rand::prelude::SliceRandom;
+    use rand::{thread_rng, Rng};
+    use test::{self, Bencher};
+
+    use super::*;
+    use crate::aggregation::bucket::{
+        CustomOrder, HistogramAggregation, HistogramBounds, Order, OrderTarget, TermsAggregation,
+    };
+    use crate::aggregation::metric::StatsAggregation;
+    use crate::query::AllQuery;
+    use crate::schema::{Schema, TextFieldIndexing, FAST, STRING};
+    use crate::Index;
+
+    fn get_test_index_bench(cardinality: Cardinality) -> crate::Result<Index> {
+        let mut schema_builder = Schema::builder();
+        let text_fieldtype = crate::schema::TextOptions::default()
+            .set_indexing_options(
+                TextFieldIndexing::default().set_index_option(IndexRecordOption::WithFreqs),
+            )
+            .set_stored();
+        let text_field = schema_builder.add_text_field("text", text_fieldtype);
+        let text_field_many_terms = schema_builder.add_text_field("text_many_terms", STRING | FAST);
+        let text_field_few_terms = schema_builder.add_text_field("text_few_terms", STRING | FAST);
+        let score_fieldtype = crate::schema::NumericOptions::default().set_fast();
+        let score_field = schema_builder.add_u64_field("score", score_fieldtype.clone());
+        let score_field_f64 = schema_builder.add_f64_field("score_f64", score_fieldtype.clone());
+        let score_field_i64 = schema_builder.add_i64_field("score_i64", score_fieldtype);
+        let index = Index::create_from_tempdir(schema_builder.build())?;
+        let few_terms_data = vec!["INFO", "ERROR", "WARN", "DEBUG"];
+        let many_terms_data = (0..150_000)
+            .map(|num| format!("author{}", num))
+            .collect::<Vec<_>>();
+        {
+            let mut rng = thread_rng();
+            let mut index_writer = index.writer_with_num_threads(1, 100_000_000)?;
+            // To make the different test cases comparable we just change one doc to force the
+            // cardinality
+            if cardinality == Cardinality::Optional {
+                index_writer.add_document(doc!())?;
+            }
+            if cardinality == Cardinality::Multivalued {
+                index_writer.add_document(doc!(
+                    text_field => "cool",
+                    text_field => "cool",
+                    text_field_many_terms => "cool",
+                    text_field_many_terms => "cool",
+                    text_field_few_terms => "cool",
+                    text_field_few_terms => "cool",
+                    score_field => 1u64,
+                    score_field => 1u64,
+                    score_field_f64 => 1.0,
+                    score_field_f64 => 1.0,
+                    score_field_i64 => 1i64,
+                    score_field_i64 => 1i64,
+                ))?;
+            }
+            for _ in 0..1_000_000 {
+                let val: f64 = rng.gen_range(0.0..1_000_000.0);
+                index_writer.add_document(doc!(
+                    text_field => "cool",
+                    text_field_many_terms => many_terms_data.choose(&mut rng).unwrap().to_string(),
+                    text_field_few_terms => few_terms_data.choose(&mut rng).unwrap().to_string(),
+                    score_field => val as u64,
+                    score_field_f64 => val,
+                    score_field_i64 => val as i64,
+                ))?;
+            }
+            // writing the segment
+            index_writer.commit()?;
+        }
+
+        Ok(index)
+    }
+
+    use paste::paste;
+    #[macro_export]
+    macro_rules! bench_all_cardinalities {
+        (  $x:ident ) => {
+            paste! {
+                #[bench]
+                fn $x(b: &mut Bencher) {
+                    [<$x _card>](b, Cardinality::Full)
+                }
+
+                #[bench]
+                fn [<$x _opt>](b: &mut Bencher) {
+                    [<$x _card>](b, Cardinality::Optional)
+                }
+
+                #[bench]
+                fn [<$x _multi>](b: &mut Bencher) {
+                    [<$x _card>](b, Cardinality::Multivalued)
+                }
+            }
+        };
+    }
+
+    bench_all_cardinalities!(bench_aggregation_average_u64);
+
+    fn bench_aggregation_average_u64_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+        let text_field = reader.searcher().schema().get_field("text").unwrap();
+
+        b.iter(|| {
+            let term_query = TermQuery::new(
+                Term::from_field_text(text_field, "cool"),
+                IndexRecordOption::Basic,
+            );
+
+            let agg_req_1: Aggregations = vec![(
+                "average".to_string(),
+                Aggregation::Metric(MetricAggregation::Average(
+                    AverageAggregation::from_field_name("score".to_string()),
+                )),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req_1);
+
+            let searcher = reader.searcher();
+            searcher.search(&term_query, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_stats_f64);
+
+    fn bench_aggregation_stats_f64_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+        let text_field = reader.searcher().schema().get_field("text").unwrap();
+
+        b.iter(|| {
+            let term_query = TermQuery::new(
+                Term::from_field_text(text_field, "cool"),
+                IndexRecordOption::Basic,
+            );
+
+            let agg_req_1: Aggregations = vec![(
+                "average_f64".to_string(),
+                Aggregation::Metric(MetricAggregation::Stats(StatsAggregation::from_field_name(
+                    "score_f64".to_string(),
+                ))),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req_1);
+
+            let searcher = reader.searcher();
+            searcher.search(&term_query, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_average_f64);
+
+    fn bench_aggregation_average_f64_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+        let text_field = reader.searcher().schema().get_field("text").unwrap();
+
+        b.iter(|| {
+            let term_query = TermQuery::new(
+                Term::from_field_text(text_field, "cool"),
+                IndexRecordOption::Basic,
+            );
+
+            let agg_req_1: Aggregations = vec![(
+                "average_f64".to_string(),
+                Aggregation::Metric(MetricAggregation::Average(
+                    AverageAggregation::from_field_name("score_f64".to_string()),
+                )),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req_1);
+
+            let searcher = reader.searcher();
+            searcher.search(&term_query, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_average_u64_and_f64);
+
+    fn bench_aggregation_average_u64_and_f64_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+        let text_field = reader.searcher().schema().get_field("text").unwrap();
+
+        b.iter(|| {
+            let term_query = TermQuery::new(
+                Term::from_field_text(text_field, "cool"),
+                IndexRecordOption::Basic,
+            );
+
+            let agg_req_1: Aggregations = vec![
+                (
+                    "average_f64".to_string(),
+                    Aggregation::Metric(MetricAggregation::Average(
+                        AverageAggregation::from_field_name("score_f64".to_string()),
+                    )),
+                ),
+                (
+                    "average".to_string(),
+                    Aggregation::Metric(MetricAggregation::Average(
+                        AverageAggregation::from_field_name("score".to_string()),
+                    )),
+                ),
+            ]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req_1);
+
+            let searcher = reader.searcher();
+            searcher.search(&term_query, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_terms_few);
+
+    fn bench_aggregation_terms_few_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+
+        b.iter(|| {
+            let agg_req: Aggregations = vec![(
+                "my_texts".to_string(),
+                Aggregation::Bucket(
+                    BucketAggregation {
+                        bucket_agg: BucketAggregationType::Terms(TermsAggregation {
+                            field: "text_few_terms".to_string(),
+                            ..Default::default()
+                        }),
+                        sub_aggregation: Default::default(),
+                    }
+                    .into(),
+                ),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req);
+
+            let searcher = reader.searcher();
+            searcher.search(&AllQuery, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_terms_many_with_sub_agg);
+
+    fn bench_aggregation_terms_many_with_sub_agg_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+
+        b.iter(|| {
+            let sub_agg_req: Aggregations = vec![(
+                "average_f64".to_string(),
+                Aggregation::Metric(MetricAggregation::Average(
+                    AverageAggregation::from_field_name("score_f64".to_string()),
+                )),
+            )]
+            .into_iter()
+            .collect();
+
+            let agg_req: Aggregations = vec![(
+                "my_texts".to_string(),
+                Aggregation::Bucket(
+                    BucketAggregation {
+                        bucket_agg: BucketAggregationType::Terms(TermsAggregation {
+                            field: "text_many_terms".to_string(),
+                            ..Default::default()
+                        }),
+                        sub_aggregation: sub_agg_req,
+                    }
+                    .into(),
+                ),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req);
+
+            let searcher = reader.searcher();
+            searcher.search(&AllQuery, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_terms_many2);
+
+    fn bench_aggregation_terms_many2_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+
+        b.iter(|| {
+            let agg_req: Aggregations = vec![(
+                "my_texts".to_string(),
+                Aggregation::Bucket(
+                    BucketAggregation {
+                        bucket_agg: BucketAggregationType::Terms(TermsAggregation {
+                            field: "text_many_terms".to_string(),
+                            ..Default::default()
+                        }),
+                        sub_aggregation: Default::default(),
+                    }
+                    .into(),
+                ),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req);
+
+            let searcher = reader.searcher();
+            searcher.search(&AllQuery, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_terms_many_order_by_term);
+
+    fn bench_aggregation_terms_many_order_by_term_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+
+        b.iter(|| {
+            let agg_req: Aggregations = vec![(
+                "my_texts".to_string(),
+                Aggregation::Bucket(
+                    BucketAggregation {
+                        bucket_agg: BucketAggregationType::Terms(TermsAggregation {
+                            field: "text_many_terms".to_string(),
+                            order: Some(CustomOrder {
+                                order: Order::Desc,
+                                target: OrderTarget::Key,
+                            }),
+                            ..Default::default()
+                        }),
+                        sub_aggregation: Default::default(),
+                    }
+                    .into(),
+                ),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req);
+
+            let searcher = reader.searcher();
+            searcher.search(&AllQuery, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_range_only);
+
+    fn bench_aggregation_range_only_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+
+        b.iter(|| {
+            let agg_req_1: Aggregations = vec![(
+                "rangef64".to_string(),
+                Aggregation::Bucket(
+                    BucketAggregation {
+                        bucket_agg: BucketAggregationType::Range(RangeAggregation {
+                            field: "score_f64".to_string(),
+                            ranges: vec![
+                                (3f64..7000f64).into(),
+                                (7000f64..20000f64).into(),
+                                (20000f64..30000f64).into(),
+                                (30000f64..40000f64).into(),
+                                (40000f64..50000f64).into(),
+                                (50000f64..60000f64).into(),
+                            ],
+                            ..Default::default()
+                        }),
+                        sub_aggregation: Default::default(),
+                    }
+                    .into(),
+                ),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req_1);
+
+            let searcher = reader.searcher();
+            searcher.search(&AllQuery, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_range_with_avg);
+
+    fn bench_aggregation_range_with_avg_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+
+        b.iter(|| {
+            let sub_agg_req: Aggregations = vec![(
+                "average_f64".to_string(),
+                Aggregation::Metric(MetricAggregation::Average(
+                    AverageAggregation::from_field_name("score_f64".to_string()),
+                )),
+            )]
+            .into_iter()
+            .collect();
+
+            let agg_req_1: Aggregations = vec![(
+                "rangef64".to_string(),
+                Aggregation::Bucket(
+                    BucketAggregation {
+                        bucket_agg: BucketAggregationType::Range(RangeAggregation {
+                            field: "score_f64".to_string(),
+                            ranges: vec![
+                                (3f64..7000f64).into(),
+                                (7000f64..20000f64).into(),
+                                (20000f64..30000f64).into(),
+                                (30000f64..40000f64).into(),
+                                (40000f64..50000f64).into(),
+                                (50000f64..60000f64).into(),
+                            ],
+                            ..Default::default()
+                        }),
+                        sub_aggregation: sub_agg_req,
+                    }
+                    .into(),
+                ),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req_1);
+
+            let searcher = reader.searcher();
+            searcher.search(&AllQuery, &collector).unwrap()
+        });
+    }
+
+    // hard bounds has a different algorithm, because it actually limits collection range
+    //
+    bench_all_cardinalities!(bench_aggregation_histogram_only_hard_bounds);
+
+    fn bench_aggregation_histogram_only_hard_bounds_card(
+        b: &mut Bencher,
+        cardinality: Cardinality,
+    ) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+
+        b.iter(|| {
+            let agg_req_1: Aggregations = vec![(
+                "rangef64".to_string(),
+                Aggregation::Bucket(
+                    BucketAggregation {
+                        bucket_agg: BucketAggregationType::Histogram(HistogramAggregation {
+                            field: "score_f64".to_string(),
+                            interval: 100f64,
+                            hard_bounds: Some(HistogramBounds {
+                                min: 1000.0,
+                                max: 300_000.0,
+                            }),
+                            ..Default::default()
+                        }),
+                        sub_aggregation: Default::default(),
+                    }
+                    .into(),
+                ),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req_1);
+            let searcher = reader.searcher();
+            searcher.search(&AllQuery, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_histogram_with_avg);
+
+    fn bench_aggregation_histogram_with_avg_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+
+        b.iter(|| {
+            let sub_agg_req: Aggregations = vec![(
+                "average_f64".to_string(),
+                Aggregation::Metric(MetricAggregation::Average(
+                    AverageAggregation::from_field_name("score_f64".to_string()),
+                )),
+            )]
+            .into_iter()
+            .collect();
+
+            let agg_req_1: Aggregations = vec![(
+                "rangef64".to_string(),
+                Aggregation::Bucket(
+                    BucketAggregation {
+                        bucket_agg: BucketAggregationType::Histogram(HistogramAggregation {
+                            field: "score_f64".to_string(),
+                            interval: 100f64, // 1000 buckets
+                            ..Default::default()
+                        }),
+                        sub_aggregation: sub_agg_req,
+                    }
+                    .into(),
+                ),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req_1);
+
+            let searcher = reader.searcher();
+            searcher.search(&AllQuery, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_histogram_only);
+
+    fn bench_aggregation_histogram_only_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+
+        b.iter(|| {
+            let agg_req_1: Aggregations = vec![(
+                "rangef64".to_string(),
+                Aggregation::Bucket(
+                    BucketAggregation {
+                        bucket_agg: BucketAggregationType::Histogram(HistogramAggregation {
+                            field: "score_f64".to_string(),
+                            interval: 100f64, // 1000 buckets
+                            ..Default::default()
+                        }),
+                        sub_aggregation: Default::default(),
+                    }
+                    .into(),
+                ),
+            )]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req_1);
+
+            let searcher = reader.searcher();
+            searcher.search(&AllQuery, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_avg_and_range_with_avg);
+
+    fn bench_aggregation_avg_and_range_with_avg_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+        let text_field = reader.searcher().schema().get_field("text").unwrap();
+
+        b.iter(|| {
+            let term_query = TermQuery::new(
+                Term::from_field_text(text_field, "cool"),
+                IndexRecordOption::Basic,
+            );
+
+            let sub_agg_req_1: Aggregations = vec![(
+                "average_in_range".to_string(),
+                Aggregation::Metric(MetricAggregation::Average(
+                    AverageAggregation::from_field_name("score".to_string()),
+                )),
+            )]
+            .into_iter()
+            .collect();
+
+            let agg_req_1: Aggregations = vec![
+                (
+                    "average".to_string(),
+                    Aggregation::Metric(MetricAggregation::Average(
+                        AverageAggregation::from_field_name("score".to_string()),
+                    )),
+                ),
+                (
+                    "rangef64".to_string(),
+                    Aggregation::Bucket(
+                        BucketAggregation {
+                            bucket_agg: BucketAggregationType::Range(RangeAggregation {
+                                field: "score_f64".to_string(),
+                                ranges: vec![
+                                    (3f64..7000f64).into(),
+                                    (7000f64..20000f64).into(),
+                                    (20000f64..60000f64).into(),
+                                ],
+                                ..Default::default()
+                            }),
+                            sub_aggregation: sub_agg_req_1,
+                        }
+                        .into(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect();
+
+            let collector = get_collector(agg_req_1);
+
+            let searcher = reader.searcher();
+            searcher.search(&term_query, &collector).unwrap()
+        });
+    }
+}

--- a/src/aggregation/agg_tests.rs
+++ b/src/aggregation/agg_tests.rs
@@ -769,614 +769,98 @@ fn test_aggregation_on_json_object_empty_columns() {
     );
 }
 
-#[cfg(all(test, feature = "unstable"))]
-mod bench {
+#[test]
+fn test_aggregation_on_json_object_mixed_types() {
+    let mut schema_builder = Schema::builder();
+    let json = schema_builder.add_json_field("json", FAST);
+    let schema = schema_builder.build();
+    let index = Index::create_in_ram(schema);
+    let mut index_writer = index.writer_for_tests().unwrap();
+    // => Segment with all values numeric
+    index_writer
+        .add_document(doc!(json => json!({"mixed_type": 10.0})))
+        .unwrap();
+    index_writer.commit().unwrap();
+    // => Segment with all values text
+    index_writer
+        .add_document(doc!(json => json!({"mixed_type": "blue"})))
+        .unwrap();
+    index_writer.commit().unwrap();
+    // => Segment with all boolen
+    index_writer
+        .add_document(doc!(json => json!({"mixed_type": true})))
+        .unwrap();
+    index_writer.commit().unwrap();
 
-    use columnar::Cardinality;
-    use rand::prelude::SliceRandom;
-    use rand::{thread_rng, Rng};
-    use test::{self, Bencher};
+    // => Segment with mixed values
+    index_writer
+        .add_document(doc!(json => json!({"mixed_type": "red"})))
+        .unwrap();
+    index_writer
+        .add_document(doc!(json => json!({"mixed_type": -20.5})))
+        .unwrap();
+    index_writer
+        .add_document(doc!(json => json!({"mixed_type": true})))
+        .unwrap();
 
-    use super::*;
-    use crate::aggregation::bucket::{
-        CustomOrder, HistogramAggregation, HistogramBounds, Order, OrderTarget, TermsAggregation,
-    };
-    use crate::aggregation::metric::StatsAggregation;
-    use crate::query::AllQuery;
-    use crate::schema::{Schema, TextFieldIndexing, FAST, STRING};
-    use crate::Index;
+    index_writer.commit().unwrap();
 
-    fn get_test_index_bench(cardinality: Cardinality) -> crate::Result<Index> {
-        let mut schema_builder = Schema::builder();
-        let text_fieldtype = crate::schema::TextOptions::default()
-            .set_indexing_options(
-                TextFieldIndexing::default().set_index_option(IndexRecordOption::WithFreqs),
-            )
-            .set_stored();
-        let text_field = schema_builder.add_text_field("text", text_fieldtype);
-        let text_field_many_terms = schema_builder.add_text_field("text_many_terms", STRING | FAST);
-        let text_field_few_terms = schema_builder.add_text_field("text_few_terms", STRING | FAST);
-        let score_fieldtype = crate::schema::NumericOptions::default().set_fast();
-        let score_field = schema_builder.add_u64_field("score", score_fieldtype.clone());
-        let score_field_f64 = schema_builder.add_f64_field("score_f64", score_fieldtype.clone());
-        let score_field_i64 = schema_builder.add_i64_field("score_i64", score_fieldtype);
-        let index = Index::create_from_tempdir(schema_builder.build())?;
-        let few_terms_data = vec!["INFO", "ERROR", "WARN", "DEBUG"];
-        let many_terms_data = (0..150_000)
-            .map(|num| format!("author{}", num))
-            .collect::<Vec<_>>();
-        {
-            let mut rng = thread_rng();
-            let mut index_writer = index.writer_with_num_threads(1, 100_000_000)?;
-            // To make the different test cases comparable we just change one doc to force the
-            // cardinality
-            if cardinality == Cardinality::Optional {
-                index_writer.add_document(doc!())?;
+    // All bucket types
+    let agg_req_str = r#"
+    {
+        "termagg": {
+            "terms": {
+                "field": "json.mixed_type",
+                "order": { "min_price": "desc" }
+            },
+            "aggs": {
+                "min_price": { "min": { "field": "json.mixed_type" } }
             }
-            if cardinality == Cardinality::Multivalued {
-                index_writer.add_document(doc!(
-                    text_field => "cool",
-                    text_field => "cool",
-                    text_field_many_terms => "cool",
-                    text_field_many_terms => "cool",
-                    text_field_few_terms => "cool",
-                    text_field_few_terms => "cool",
-                    score_field => 1u64,
-                    score_field => 1u64,
-                    score_field_f64 => 1.0,
-                    score_field_f64 => 1.0,
-                    score_field_i64 => 1i64,
-                    score_field_i64 => 1i64,
-                ))?;
+        },
+        "rangeagg": {
+            "range": {
+                "field": "json.mixed_type",
+                "ranges": [
+                    { "to": 3.0 },
+                    { "from": 19.0, "to": 20.0 },
+                    { "from": 20.0 }
+                ]
+            },
+            "aggs": {
+                "average_in_range": { "avg": { "field": "json.mixed_type" } }
             }
-            for _ in 0..1_000_000 {
-                let val: f64 = rng.gen_range(0.0..1_000_000.0);
-                index_writer.add_document(doc!(
-                    text_field => "cool",
-                    text_field_many_terms => many_terms_data.choose(&mut rng).unwrap().to_string(),
-                    text_field_few_terms => few_terms_data.choose(&mut rng).unwrap().to_string(),
-                    score_field => val as u64,
-                    score_field_f64 => val,
-                    score_field_i64 => val as i64,
-                ))?;
-            }
-            // writing the segment
-            index_writer.commit()?;
         }
+    } "#;
+    let agg: Aggregations = serde_json::from_str(agg_req_str).unwrap();
+    let aggregation_collector = get_collector(agg);
+    let reader = index.reader().unwrap();
+    let searcher = reader.searcher();
 
-        Ok(index)
-    }
-
-    use paste::paste;
-    #[macro_export]
-    macro_rules! bench_all_cardinalities {
-        (  $x:ident ) => {
-            paste! {
-                #[bench]
-                fn $x(b: &mut Bencher) {
-                    [<$x _card>](b, Cardinality::Full)
-                }
-
-                #[bench]
-                fn [<$x _opt>](b: &mut Bencher) {
-                    [<$x _card>](b, Cardinality::Optional)
-                }
-
-                #[bench]
-                fn [<$x _multi>](b: &mut Bencher) {
-                    [<$x _card>](b, Cardinality::Multivalued)
-                }
-            }
-        };
-    }
-
-    bench_all_cardinalities!(bench_aggregation_average_u64);
-
-    fn bench_aggregation_average_u64_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-        let text_field = reader.searcher().schema().get_field("text").unwrap();
-
-        b.iter(|| {
-            let term_query = TermQuery::new(
-                Term::from_field_text(text_field, "cool"),
-                IndexRecordOption::Basic,
-            );
-
-            let agg_req_1: Aggregations = vec![(
-                "average".to_string(),
-                Aggregation::Metric(MetricAggregation::Average(
-                    AverageAggregation::from_field_name("score".to_string()),
-                )),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req_1);
-
-            let searcher = reader.searcher();
-            searcher.search(&term_query, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_stats_f64);
-
-    fn bench_aggregation_stats_f64_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-        let text_field = reader.searcher().schema().get_field("text").unwrap();
-
-        b.iter(|| {
-            let term_query = TermQuery::new(
-                Term::from_field_text(text_field, "cool"),
-                IndexRecordOption::Basic,
-            );
-
-            let agg_req_1: Aggregations = vec![(
-                "average_f64".to_string(),
-                Aggregation::Metric(MetricAggregation::Stats(StatsAggregation::from_field_name(
-                    "score_f64".to_string(),
-                ))),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req_1);
-
-            let searcher = reader.searcher();
-            searcher.search(&term_query, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_average_f64);
-
-    fn bench_aggregation_average_f64_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-        let text_field = reader.searcher().schema().get_field("text").unwrap();
-
-        b.iter(|| {
-            let term_query = TermQuery::new(
-                Term::from_field_text(text_field, "cool"),
-                IndexRecordOption::Basic,
-            );
-
-            let agg_req_1: Aggregations = vec![(
-                "average_f64".to_string(),
-                Aggregation::Metric(MetricAggregation::Average(
-                    AverageAggregation::from_field_name("score_f64".to_string()),
-                )),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req_1);
-
-            let searcher = reader.searcher();
-            searcher.search(&term_query, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_average_u64_and_f64);
-
-    fn bench_aggregation_average_u64_and_f64_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-        let text_field = reader.searcher().schema().get_field("text").unwrap();
-
-        b.iter(|| {
-            let term_query = TermQuery::new(
-                Term::from_field_text(text_field, "cool"),
-                IndexRecordOption::Basic,
-            );
-
-            let agg_req_1: Aggregations = vec![
-                (
-                    "average_f64".to_string(),
-                    Aggregation::Metric(MetricAggregation::Average(
-                        AverageAggregation::from_field_name("score_f64".to_string()),
-                    )),
-                ),
-                (
-                    "average".to_string(),
-                    Aggregation::Metric(MetricAggregation::Average(
-                        AverageAggregation::from_field_name("score".to_string()),
-                    )),
-                ),
+    let aggregation_results = searcher.search(&AllQuery, &aggregation_collector).unwrap();
+    let aggregation_res_json = serde_json::to_value(aggregation_results).unwrap();
+    assert_eq!(
+        &aggregation_res_json,
+        &serde_json::json!({
+          "rangeagg": {
+            "buckets": [
+              { "average_in_range": { "value": -20.5 }, "doc_count": 1, "key": "*-3", "to": 3.0 },
+              { "average_in_range": { "value": 10.0 }, "doc_count": 1, "from": 3.0, "key": "3-19", "to": 19.0 },
+              { "average_in_range": { "value": null }, "doc_count": 0, "from": 19.0, "key": "19-20", "to": 20.0 },
+              { "average_in_range": { "value": null }, "doc_count": 0, "from": 20.0, "key": "20-*" }
             ]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req_1);
-
-            let searcher = reader.searcher();
-            searcher.search(&term_query, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_terms_few);
-
-    fn bench_aggregation_terms_few_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-
-        b.iter(|| {
-            let agg_req: Aggregations = vec![(
-                "my_texts".to_string(),
-                Aggregation::Bucket(
-                    BucketAggregation {
-                        bucket_agg: BucketAggregationType::Terms(TermsAggregation {
-                            field: "text_few_terms".to_string(),
-                            ..Default::default()
-                        }),
-                        sub_aggregation: Default::default(),
-                    }
-                    .into(),
-                ),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req);
-
-            let searcher = reader.searcher();
-            searcher.search(&AllQuery, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_terms_many_with_sub_agg);
-
-    fn bench_aggregation_terms_many_with_sub_agg_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-
-        b.iter(|| {
-            let sub_agg_req: Aggregations = vec![(
-                "average_f64".to_string(),
-                Aggregation::Metric(MetricAggregation::Average(
-                    AverageAggregation::from_field_name("score_f64".to_string()),
-                )),
-            )]
-            .into_iter()
-            .collect();
-
-            let agg_req: Aggregations = vec![(
-                "my_texts".to_string(),
-                Aggregation::Bucket(
-                    BucketAggregation {
-                        bucket_agg: BucketAggregationType::Terms(TermsAggregation {
-                            field: "text_many_terms".to_string(),
-                            ..Default::default()
-                        }),
-                        sub_aggregation: sub_agg_req,
-                    }
-                    .into(),
-                ),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req);
-
-            let searcher = reader.searcher();
-            searcher.search(&AllQuery, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_terms_many2);
-
-    fn bench_aggregation_terms_many2_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-
-        b.iter(|| {
-            let agg_req: Aggregations = vec![(
-                "my_texts".to_string(),
-                Aggregation::Bucket(
-                    BucketAggregation {
-                        bucket_agg: BucketAggregationType::Terms(TermsAggregation {
-                            field: "text_many_terms".to_string(),
-                            ..Default::default()
-                        }),
-                        sub_aggregation: Default::default(),
-                    }
-                    .into(),
-                ),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req);
-
-            let searcher = reader.searcher();
-            searcher.search(&AllQuery, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_terms_many_order_by_term);
-
-    fn bench_aggregation_terms_many_order_by_term_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-
-        b.iter(|| {
-            let agg_req: Aggregations = vec![(
-                "my_texts".to_string(),
-                Aggregation::Bucket(
-                    BucketAggregation {
-                        bucket_agg: BucketAggregationType::Terms(TermsAggregation {
-                            field: "text_many_terms".to_string(),
-                            order: Some(CustomOrder {
-                                order: Order::Desc,
-                                target: OrderTarget::Key,
-                            }),
-                            ..Default::default()
-                        }),
-                        sub_aggregation: Default::default(),
-                    }
-                    .into(),
-                ),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req);
-
-            let searcher = reader.searcher();
-            searcher.search(&AllQuery, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_range_only);
-
-    fn bench_aggregation_range_only_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-
-        b.iter(|| {
-            let agg_req_1: Aggregations = vec![(
-                "rangef64".to_string(),
-                Aggregation::Bucket(
-                    BucketAggregation {
-                        bucket_agg: BucketAggregationType::Range(RangeAggregation {
-                            field: "score_f64".to_string(),
-                            ranges: vec![
-                                (3f64..7000f64).into(),
-                                (7000f64..20000f64).into(),
-                                (20000f64..30000f64).into(),
-                                (30000f64..40000f64).into(),
-                                (40000f64..50000f64).into(),
-                                (50000f64..60000f64).into(),
-                            ],
-                            ..Default::default()
-                        }),
-                        sub_aggregation: Default::default(),
-                    }
-                    .into(),
-                ),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req_1);
-
-            let searcher = reader.searcher();
-            searcher.search(&AllQuery, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_range_with_avg);
-
-    fn bench_aggregation_range_with_avg_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-
-        b.iter(|| {
-            let sub_agg_req: Aggregations = vec![(
-                "average_f64".to_string(),
-                Aggregation::Metric(MetricAggregation::Average(
-                    AverageAggregation::from_field_name("score_f64".to_string()),
-                )),
-            )]
-            .into_iter()
-            .collect();
-
-            let agg_req_1: Aggregations = vec![(
-                "rangef64".to_string(),
-                Aggregation::Bucket(
-                    BucketAggregation {
-                        bucket_agg: BucketAggregationType::Range(RangeAggregation {
-                            field: "score_f64".to_string(),
-                            ranges: vec![
-                                (3f64..7000f64).into(),
-                                (7000f64..20000f64).into(),
-                                (20000f64..30000f64).into(),
-                                (30000f64..40000f64).into(),
-                                (40000f64..50000f64).into(),
-                                (50000f64..60000f64).into(),
-                            ],
-                            ..Default::default()
-                        }),
-                        sub_aggregation: sub_agg_req,
-                    }
-                    .into(),
-                ),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req_1);
-
-            let searcher = reader.searcher();
-            searcher.search(&AllQuery, &collector).unwrap()
-        });
-    }
-
-    // hard bounds has a different algorithm, because it actually limits collection range
-    //
-    bench_all_cardinalities!(bench_aggregation_histogram_only_hard_bounds);
-
-    fn bench_aggregation_histogram_only_hard_bounds_card(
-        b: &mut Bencher,
-        cardinality: Cardinality,
-    ) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-
-        b.iter(|| {
-            let agg_req_1: Aggregations = vec![(
-                "rangef64".to_string(),
-                Aggregation::Bucket(
-                    BucketAggregation {
-                        bucket_agg: BucketAggregationType::Histogram(HistogramAggregation {
-                            field: "score_f64".to_string(),
-                            interval: 100f64,
-                            hard_bounds: Some(HistogramBounds {
-                                min: 1000.0,
-                                max: 300_000.0,
-                            }),
-                            ..Default::default()
-                        }),
-                        sub_aggregation: Default::default(),
-                    }
-                    .into(),
-                ),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req_1);
-            let searcher = reader.searcher();
-            searcher.search(&AllQuery, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_histogram_with_avg);
-
-    fn bench_aggregation_histogram_with_avg_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-
-        b.iter(|| {
-            let sub_agg_req: Aggregations = vec![(
-                "average_f64".to_string(),
-                Aggregation::Metric(MetricAggregation::Average(
-                    AverageAggregation::from_field_name("score_f64".to_string()),
-                )),
-            )]
-            .into_iter()
-            .collect();
-
-            let agg_req_1: Aggregations = vec![(
-                "rangef64".to_string(),
-                Aggregation::Bucket(
-                    BucketAggregation {
-                        bucket_agg: BucketAggregationType::Histogram(HistogramAggregation {
-                            field: "score_f64".to_string(),
-                            interval: 100f64, // 1000 buckets
-                            ..Default::default()
-                        }),
-                        sub_aggregation: sub_agg_req,
-                    }
-                    .into(),
-                ),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req_1);
-
-            let searcher = reader.searcher();
-            searcher.search(&AllQuery, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_histogram_only);
-
-    fn bench_aggregation_histogram_only_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-
-        b.iter(|| {
-            let agg_req_1: Aggregations = vec![(
-                "rangef64".to_string(),
-                Aggregation::Bucket(
-                    BucketAggregation {
-                        bucket_agg: BucketAggregationType::Histogram(HistogramAggregation {
-                            field: "score_f64".to_string(),
-                            interval: 100f64, // 1000 buckets
-                            ..Default::default()
-                        }),
-                        sub_aggregation: Default::default(),
-                    }
-                    .into(),
-                ),
-            )]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req_1);
-
-            let searcher = reader.searcher();
-            searcher.search(&AllQuery, &collector).unwrap()
-        });
-    }
-
-    bench_all_cardinalities!(bench_aggregation_avg_and_range_with_avg);
-
-    fn bench_aggregation_avg_and_range_with_avg_card(b: &mut Bencher, cardinality: Cardinality) {
-        let index = get_test_index_bench(cardinality).unwrap();
-        let reader = index.reader().unwrap();
-        let text_field = reader.searcher().schema().get_field("text").unwrap();
-
-        b.iter(|| {
-            let term_query = TermQuery::new(
-                Term::from_field_text(text_field, "cool"),
-                IndexRecordOption::Basic,
-            );
-
-            let sub_agg_req_1: Aggregations = vec![(
-                "average_in_range".to_string(),
-                Aggregation::Metric(MetricAggregation::Average(
-                    AverageAggregation::from_field_name("score".to_string()),
-                )),
-            )]
-            .into_iter()
-            .collect();
-
-            let agg_req_1: Aggregations = vec![
-                (
-                    "average".to_string(),
-                    Aggregation::Metric(MetricAggregation::Average(
-                        AverageAggregation::from_field_name("score".to_string()),
-                    )),
-                ),
-                (
-                    "rangef64".to_string(),
-                    Aggregation::Bucket(
-                        BucketAggregation {
-                            bucket_agg: BucketAggregationType::Range(RangeAggregation {
-                                field: "score_f64".to_string(),
-                                ranges: vec![
-                                    (3f64..7000f64).into(),
-                                    (7000f64..20000f64).into(),
-                                    (20000f64..60000f64).into(),
-                                ],
-                                ..Default::default()
-                            }),
-                            sub_aggregation: sub_agg_req_1,
-                        }
-                        .into(),
-                    ),
-                ),
-            ]
-            .into_iter()
-            .collect();
-
-            let collector = get_collector(agg_req_1);
-
-            let searcher = reader.searcher();
-            searcher.search(&term_query, &collector).unwrap()
-        });
-    }
+          },
+          "termagg": {
+            "buckets": [
+              { "doc_count": 1, "key": 10.0, "min_price": { "value": 10.0 } },
+              { "doc_count": 1, "key": -20.5, "min_price": { "value": -20.5 } },
+              // TODO red is missing since there is no multi aggregation within one
+              // segment for multiple types
+              // TODO bool is also not yet handled in aggregation
+              { "doc_count": 1, "key": "blue", "min_price": { "value": null } }
+            ],
+            "sum_other_doc_count": 0
+          }
+        }
+        )
+    );
 }

--- a/src/collector/histogram_collector.rs
+++ b/src/collector/histogram_collector.rs
@@ -113,7 +113,7 @@ impl Collector for HistogramCollector {
         segment: &crate::SegmentReader,
     ) -> crate::Result<Self::Child> {
         let column_opt = segment.fast_fields().u64_lenient(&self.field)?;
-        let column = column_opt.ok_or_else(|| FastFieldNotAvailableError {
+        let (column, _column_type) = column_opt.ok_or_else(|| FastFieldNotAvailableError {
             field_name: self.field.clone(),
         })?;
         let column_u64 = column.first_or_default_col(0u64);

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -155,12 +155,13 @@ impl CustomScorer<u64> for ScorerByField {
         //
         // The conversion will then happen only on the top-K docs.
         let sort_column_opt = segment_reader.fast_fields().u64_lenient(&self.field)?;
-        let sort_column = sort_column_opt
-            .ok_or_else(|| FastFieldNotAvailableError {
+        let (sort_column, _sort_column_type) =
+            sort_column_opt.ok_or_else(|| FastFieldNotAvailableError {
                 field_name: self.field.clone(),
-            })?
-            .first_or_default_col(0u64);
-        Ok(ScorerByFastFieldReader { sort_column })
+            })?;
+        Ok(ScorerByFastFieldReader {
+            sort_column: sort_column.first_or_default_col(0u64),
+        })
     }
 }
 

--- a/src/fastfield/readers.rs
+++ b/src/fastfield/readers.rs
@@ -259,14 +259,14 @@ impl FastFieldReaders {
     #[doc(hidden)]
     pub fn u64_lenient_for_type(
         &self,
-        type_white_list: Option<&[ColumnType]>,
+        type_white_list_opt: Option<&[ColumnType]>,
         field_name: &str,
     ) -> crate::Result<Option<(Column<u64>, ColumnType)>> {
         let Some(resolved_field_name) = self.resolve_field(field_name)? else {
             return Ok(None);
         };
         for col in self.columnar.read_columns(&resolved_field_name)? {
-            if let Some(type_white_list) = type_white_list {
+            if let Some(type_white_list) = type_white_list_opt {
                 if !type_white_list.contains(&col.column_type()) {
                     continue;
                 }

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -306,7 +306,7 @@ impl IndexMerger {
         sort_by_field: &IndexSortByField,
     ) -> crate::Result<Arc<dyn ColumnValues>> {
         reader.schema().get_field(&sort_by_field.field)?;
-        let value_accessor = reader
+        let (value_accessor, _column_type) = reader
             .fast_fields()
             .u64_lenient(&sort_by_field.field)?
             .ok_or_else(|| FastFieldNotAvailableError {

--- a/src/query/range_query/range_query_u64_fastfield.rs
+++ b/src/query/range_query/range_query_u64_fastfield.rs
@@ -33,7 +33,7 @@ impl FastFieldRangeWeight {
 impl Weight for FastFieldRangeWeight {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
         let fast_field_reader = reader.fast_fields();
-        let Some(column) = fast_field_reader.u64_lenient(&self.field)? else {
+        let Some((column, _)) = fast_field_reader.u64_lenient(&self.field)? else {
             return Ok(Box::new(EmptyScorer));
         };
         let value_range = bound_to_value_range(


### PR DESCRIPTION
- Improve support for mixed types in JSON field aggregations (pick the right field, #1913)
- Resolve the issue with JSON serialization for numeric keys (fixes #1967)
- Add JSON round-trip test for term buckets
- Remove `u64_lenient`, as this is a footgun without the type
- move aggregation benchmarks
