### PR TITLE
add percentiles aggregations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ query-grammar = { version= "0.19.0", path="./query-grammar", package = "tantivy-
 tantivy-bitpacker = { version= "0.3", path="./bitpacker" }
 common = { version= "0.5", path = "./common/", package = "tantivy-common" }
 tokenizer-api = { version="0.1", path="./tokenizer-api", package="tantivy-tokenizer-api" }
+sketches-ddsketch = { git = "https://github.com/PSeitz/rust-sketches-ddsketch", version = "0.2.0", features = ["use_serde"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"
@@ -78,6 +79,8 @@ env_logger = "0.10.0"
 pprof = { version = "0.11.0", features = ["flamegraph", "criterion"] }
 futures = "0.3.21"
 paste = "1.0.11"
+more-asserts = "0.3.1"
+rand_distr = "0.4.3"
 
 [dev-dependencies.fail]
 version = "0.5.0"

--- a/examples/aggregation.rs
+++ b/examples/aggregation.rs
@@ -9,10 +9,9 @@
 use serde_json::{Deserializer, Value};
 use tantivy::aggregation::agg_req::{
     Aggregation, Aggregations, BucketAggregation, BucketAggregationType, MetricAggregation,
-    RangeAggregation,
 };
 use tantivy::aggregation::agg_result::AggregationResults;
-use tantivy::aggregation::bucket::RangeAggregationRange;
+use tantivy::aggregation::bucket::{RangeAggregation, RangeAggregationRange};
 use tantivy::aggregation::metric::AverageAggregation;
 use tantivy::aggregation::AggregationCollector;
 use tantivy::query::AllQuery;

--- a/src/aggregation/agg_bench.rs
+++ b/src/aggregation/agg_bench.rs
@@ -10,10 +10,10 @@ mod bench {
 
     use crate::aggregation::agg_req::{
         Aggregation, Aggregations, BucketAggregation, BucketAggregationType, MetricAggregation,
-        RangeAggregation,
     };
     use crate::aggregation::bucket::{
-        CustomOrder, HistogramAggregation, HistogramBounds, Order, OrderTarget, TermsAggregation,
+        CustomOrder, HistogramAggregation, HistogramBounds, Order, OrderTarget, RangeAggregation,
+        TermsAggregation,
     };
     use crate::aggregation::metric::{AverageAggregation, StatsAggregation};
     use crate::aggregation::AggregationCollector;

--- a/src/aggregation/agg_bench.rs
+++ b/src/aggregation/agg_bench.rs
@@ -3,17 +3,27 @@ mod bench {
 
     use columnar::Cardinality;
     use rand::prelude::SliceRandom;
-    use rand::{thread_rng, Rng};
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+    use rand_distr::Distribution;
     use test::{self, Bencher};
 
-    use super::*;
+    use crate::aggregation::agg_req::{
+        Aggregation, Aggregations, BucketAggregation, BucketAggregationType, MetricAggregation,
+        RangeAggregation,
+    };
     use crate::aggregation::bucket::{
         CustomOrder, HistogramAggregation, HistogramBounds, Order, OrderTarget, TermsAggregation,
     };
-    use crate::aggregation::metric::StatsAggregation;
-    use crate::query::AllQuery;
-    use crate::schema::{Schema, TextFieldIndexing, FAST, STRING};
-    use crate::Index;
+    use crate::aggregation::metric::{AverageAggregation, StatsAggregation};
+    use crate::aggregation::AggregationCollector;
+    use crate::query::{AllQuery, TermQuery};
+    use crate::schema::{IndexRecordOption, Schema, TextFieldIndexing, FAST, STRING};
+    use crate::{Index, Term};
+
+    fn get_collector(agg_req: Aggregations) -> AggregationCollector {
+        AggregationCollector::from_aggs(agg_req, Default::default())
+    }
 
     fn get_test_index_bench(cardinality: Cardinality) -> crate::Result<Index> {
         let mut schema_builder = Schema::builder();
@@ -31,11 +41,14 @@ mod bench {
         let score_field_i64 = schema_builder.add_i64_field("score_i64", score_fieldtype);
         let index = Index::create_from_tempdir(schema_builder.build())?;
         let few_terms_data = vec!["INFO", "ERROR", "WARN", "DEBUG"];
+
+        let lg_norm = rand_distr::LogNormal::new(2.996f64, 0.979f64).unwrap();
+
         let many_terms_data = (0..150_000)
             .map(|num| format!("author{}", num))
             .collect::<Vec<_>>();
         {
-            let mut rng = thread_rng();
+            let mut rng = StdRng::from_seed([1u8; 32]);
             let mut index_writer = index.writer_with_num_threads(1, 100_000_000)?;
             // To make the different test cases comparable we just change one doc to force the
             // cardinality
@@ -52,8 +65,8 @@ mod bench {
                     text_field_few_terms => "cool",
                     score_field => 1u64,
                     score_field => 1u64,
-                    score_field_f64 => 1.0,
-                    score_field_f64 => 1.0,
+                    score_field_f64 => lg_norm.sample(&mut rng),
+                    score_field_f64 => lg_norm.sample(&mut rng),
                     score_field_i64 => 1i64,
                     score_field_i64 => 1i64,
                 ))?;
@@ -65,7 +78,7 @@ mod bench {
                     text_field_many_terms => many_terms_data.choose(&mut rng).unwrap().to_string(),
                     text_field_few_terms => few_terms_data.choose(&mut rng).unwrap().to_string(),
                     score_field => val as u64,
-                    score_field_f64 => val,
+                    score_field_f64 => lg_norm.sample(&mut rng),
                     score_field_i64 => val as i64,
                 ))?;
             }
@@ -183,6 +196,31 @@ mod bench {
 
             let searcher = reader.searcher();
             searcher.search(&term_query, &collector).unwrap()
+        });
+    }
+
+    bench_all_cardinalities!(bench_aggregation_percentiles_f64);
+
+    fn bench_aggregation_percentiles_f64_card(b: &mut Bencher, cardinality: Cardinality) {
+        let index = get_test_index_bench(cardinality).unwrap();
+        let reader = index.reader().unwrap();
+
+        b.iter(|| {
+            let agg_req_str = r#"
+            {
+              "mypercentiles": {
+                "percentiles": {
+                  "field": "score_f64",
+                  "percents": [ 95, 99, 99.9 ]
+                }
+              }
+            } "#;
+            let agg_req_1: Aggregations = serde_json::from_str(agg_req_str).unwrap();
+
+            let collector = get_collector(agg_req_1);
+
+            let searcher = reader.searcher();
+            searcher.search(&AllQuery, &collector).unwrap()
         });
     }
 

--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -49,8 +49,9 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-pub use super::bucket::RangeAggregation;
-use super::bucket::{DateHistogramAggregationReq, HistogramAggregation, TermsAggregation};
+use super::bucket::{
+    DateHistogramAggregationReq, HistogramAggregation, RangeAggregation, TermsAggregation,
+};
 use super::metric::{
     AverageAggregation, CountAggregation, MaxAggregation, MinAggregation,
     PercentilesAggregationReq, StatsAggregation, SumAggregation,

--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -52,8 +52,8 @@ use serde::{Deserialize, Serialize};
 pub use super::bucket::RangeAggregation;
 use super::bucket::{DateHistogramAggregationReq, HistogramAggregation, TermsAggregation};
 use super::metric::{
-    AverageAggregation, CountAggregation, MaxAggregation, MinAggregation, StatsAggregation,
-    SumAggregation,
+    AverageAggregation, CountAggregation, MaxAggregation, MinAggregation,
+    PercentilesAggregationReq, StatsAggregation, SumAggregation,
 };
 use super::VecWithNames;
 
@@ -246,9 +246,19 @@ pub enum MetricAggregation {
     /// Computes the sum of the extracted values.
     #[serde(rename = "sum")]
     Sum(SumAggregation),
+    /// Computes the sum of the extracted values.
+    #[serde(rename = "percentiles")]
+    Percentiles(PercentilesAggregationReq),
 }
 
 impl MetricAggregation {
+    pub(crate) fn as_percentile(&self) -> Option<&PercentilesAggregationReq> {
+        match &self {
+            MetricAggregation::Percentiles(percentile_req) => Some(percentile_req),
+            _ => None,
+        }
+    }
+
     fn get_fast_field_name(&self) -> &str {
         match self {
             MetricAggregation::Average(avg) => avg.field_name(),
@@ -257,6 +267,7 @@ impl MetricAggregation {
             MetricAggregation::Min(min) => min.field_name(),
             MetricAggregation::Stats(stats) => stats.field_name(),
             MetricAggregation::Sum(sum) => sum.field_name(),
+            MetricAggregation::Percentiles(per) => per.field_name(),
         }
     }
 }

--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -144,6 +144,20 @@ impl MetricAggregationWithAccessor {
                     column_block_accessor: Default::default(),
                 })
             }
+            MetricAggregation::Percentiles(percentiles) => {
+                let (accessor, field_type) = get_ff_reader_and_validate(
+                    reader,
+                    percentiles.field_name(),
+                    Some(get_numeric_or_date_column_types()),
+                )?;
+
+                Ok(MetricAggregationWithAccessor {
+                    accessor,
+                    field_type,
+                    metric: metric.clone(),
+                    column_block_accessor: Default::default(),
+                })
+            }
         }
     }
 }

--- a/src/aggregation/agg_tests.rs
+++ b/src/aggregation/agg_tests.rs
@@ -111,7 +111,7 @@ fn test_aggregation_flushing(
         let searcher = reader.searcher();
         let intermediate_agg_result = searcher.search(&AllQuery, &collector).unwrap();
         intermediate_agg_result
-            .into_final_bucket_result(agg_req, &Default::default())
+            .into_final_result(agg_req, &Default::default())
             .unwrap()
     } else {
         let collector = get_collector(agg_req);
@@ -448,7 +448,7 @@ fn test_aggregation_level2(
         // Test de/serialization roundtrip on intermediate_agg_result
         let res: IntermediateAggregationResults =
             serde_json::from_str(&serde_json::to_string(&res).unwrap()).unwrap();
-        res.into_final_bucket_result(agg_req.clone(), &Default::default())
+        res.into_final_result(agg_req.clone(), &Default::default())
             .unwrap()
     } else {
         let collector = get_collector(agg_req.clone());

--- a/src/aggregation/collector.rs
+++ b/src/aggregation/collector.rs
@@ -104,7 +104,7 @@ impl Collector for AggregationCollector {
         segment_fruits: Vec<<Self::Child as SegmentCollector>::Fruit>,
     ) -> crate::Result<Self::Fruit> {
         let res = merge_fruits(segment_fruits)?;
-        res.into_final_bucket_result(self.agg.clone(), &self.limits)
+        res.into_final_result(self.agg.clone(), &self.limits)
     }
 }
 
@@ -114,7 +114,7 @@ fn merge_fruits(
     if let Some(fruit) = segment_fruits.pop() {
         let mut fruit = fruit?;
         for next_fruit in segment_fruits {
-            fruit.merge_fruits(next_fruit?);
+            fruit.merge_fruits(next_fruit?)?;
         }
         Ok(fruit)
     } else {

--- a/src/aggregation/error.rs
+++ b/src/aggregation/error.rs
@@ -5,6 +5,12 @@ use super::bucket::DateHistogramParseError;
 /// Error that may occur when opening a directory
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum AggregationError {
+    /// InternalError Aggregation Request
+    #[error("InternalError: {0:?}")]
+    InternalError(String),
+    /// Invalid Aggregation Request
+    #[error("InvalidRequest: {0:?}")]
+    InvalidRequest(String),
     /// Date histogram parse error
     #[error("Date histogram parse error: {0:?}")]
     DateHistogramParseError(#[from] DateHistogramParseError),

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -12,12 +12,13 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::agg_req::{
     Aggregations, AggregationsInternal, BucketAggregationInternal, BucketAggregationType,
-    MetricAggregation, RangeAggregation,
+    MetricAggregation,
 };
 use super::agg_result::{AggregationResult, BucketResult, MetricResult, RangeBucketEntry};
 use super::bucket::{
     cut_off_buckets, get_agg_name_and_property, intermediate_histogram_buckets_to_final_buckets,
-    GetDocCount, Order, OrderTarget, SegmentHistogramBucketEntry, TermsAggregation,
+    GetDocCount, Order, OrderTarget, RangeAggregation, SegmentHistogramBucketEntry,
+    TermsAggregation,
 };
 use super::metric::{
     IntermediateAverage, IntermediateCount, IntermediateMax, IntermediateMin, IntermediateStats,

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -6,12 +6,15 @@ mod average;
 mod count;
 mod max;
 mod min;
+mod percentiles;
 mod stats;
 mod sum;
 pub use average::*;
 pub use count::*;
 pub use max::*;
 pub use min::*;
+pub use percentiles::*;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 pub use stats::*;
 pub use sum::*;
@@ -35,6 +38,33 @@ impl From<Option<f64>> for SingleMetricResult {
     fn from(value: Option<f64>) -> Self {
         Self { value }
     }
+}
+
+/// This is the wrapper of percentile entries, which can be vector or hashmap
+/// depending on if it's keyed or not.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PercentileValues {
+    /// Vector format percentile entries
+    Vec(Vec<PercentileValuesVecEntry>),
+    /// HashMap format percentile entries. Key is the serialized percentile
+    HashMap(FxHashMap<String, f64>),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+/// The entry when requesting percentiles with keyed: false
+pub struct PercentileValuesVecEntry {
+    key: f64,
+    value: f64,
+}
+
+/// Single-metric aggregations use this common result structure.
+///
+/// Main reason to wrap it in value is to match elasticsearch output structure.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PercentilesMetricResult {
+    /// The result of the percentile metric.
+    pub values: PercentileValues,
 }
 
 #[cfg(test)]

--- a/src/aggregation/metric/percentiles.rs
+++ b/src/aggregation/metric/percentiles.rs
@@ -83,7 +83,7 @@ pub struct PercentilesAggregationReq {
     pub keyed: bool,
 }
 pub(crate) fn default_percentiles() -> Vec<f64> {
-    vec![1.0, 5.0, 25.0, 50.0, 75.0, 95.0, 99.0]
+    &[1.0, 5.0, 25.0, 50.0, 75.0, 95.0, 99.0]
 }
 fn default_as_true() -> bool {
     true

--- a/src/aggregation/metric/percentiles.rs
+++ b/src/aggregation/metric/percentiles.rs
@@ -82,7 +82,7 @@ pub struct PercentilesAggregationReq {
     #[serde(default = "default_as_true")]
     pub keyed: bool,
 }
-fn default_percentiles() -> &[f64] {
+fn default_percentiles() -> &'static [f64] {
     &[1.0, 5.0, 25.0, 50.0, 75.0, 95.0, 99.0]
 }
 fn default_as_true() -> bool {
@@ -167,7 +167,11 @@ impl PercentilesCollector {
     /// Convert result into final result. This will query the quantils from the underlying quantil
     /// collector.
     pub fn into_final_result(self, req: &PercentilesAggregationReq) -> PercentilesMetricResult {
-        let percentiles: &[f64] = req.percents.as_ref().unwrap_or(default);
+        let percentiles: &[f64] = req
+            .percents
+            .as_ref()
+            .map(|el| el.as_ref())
+            .unwrap_or(default_percentiles());
         let iter_quantile_and_values = percentiles.iter().cloned().map(|percentile| {
             (
                 percentile,

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -267,9 +267,9 @@ mod tests {
 
     use crate::aggregation::agg_req::{
         Aggregation, Aggregations, BucketAggregation, BucketAggregationType, MetricAggregation,
-        RangeAggregation,
     };
     use crate::aggregation::agg_result::AggregationResults;
+    use crate::aggregation::bucket::RangeAggregation;
     use crate::aggregation::metric::StatsAggregation;
     use crate::aggregation::tests::{get_test_index_2_segments, get_test_index_from_values};
     use crate::aggregation::AggregationCollector;

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -316,7 +316,6 @@ mod tests {
 
     #[test]
     fn test_aggregation_stats_simple() -> crate::Result<()> {
-        // test index without segments
         let values = vec![10.0];
 
         let index = get_test_index_from_values(false, &values)?;

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -174,6 +174,8 @@ use std::fmt::Display;
 #[cfg(test)]
 mod agg_tests;
 
+mod agg_bench;
+
 pub use agg_limits::AggregationLimits;
 pub use collector::{
     AggregationCollector, AggregationSegmentCollector, DistributedAggregationCollector,


### PR DESCRIPTION
add percentiles aggregation
fix disabled agg benchmark

Note: temporary github dependency (wait for upstream merge or publish duplicate)

```
test aggregation::agg_bench::bench::bench_aggregation_percentiles_f64                                                    ... bench:  16,975,931 ns/iter (+/- 129,979)
test aggregation::agg_bench::bench::bench_aggregation_percentiles_f64_multi                                              ... bench:  23,931,146 ns/iter (+/- 1,874,794)
test aggregation::agg_bench::bench::bench_aggregation_percentiles_f64_opt                                                ... bench:  22,435,085 ns/iter (+/- 217,680)
```

closes https://github.com/quickwit-oss/tantivy/issues/1763