### PR TITLE
add sparse to agg benchmark

### DIFF
--- a/src/aggregation/agg_bench.rs
+++ b/src/aggregation/agg_bench.rs
@@ -21,7 +21,7 @@ mod bench {
     use crate::{Index, Term};
 
     #[derive(Clone, Copy, Hash, Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
-    pub enum Cardinality {
+    enum Cardinality {
         /// All documents contain exactly one value.
         /// `Full` is the default for auto-detecting the Cardinality, since it is the most strict.
         #[default]

--- a/src/aggregation/agg_bench.rs
+++ b/src/aggregation/agg_bench.rs
@@ -1,7 +1,6 @@
 #[cfg(all(test, feature = "unstable"))]
 mod bench {
 
-    use columnar::Cardinality;
     use rand::prelude::SliceRandom;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
@@ -20,6 +19,20 @@ mod bench {
     use crate::query::{AllQuery, TermQuery};
     use crate::schema::{IndexRecordOption, Schema, TextFieldIndexing, FAST, STRING};
     use crate::{Index, Term};
+
+    #[derive(Clone, Copy, Hash, Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    pub enum Cardinality {
+        /// All documents contain exactly one value.
+        /// `Full` is the default for auto-detecting the Cardinality, since it is the most strict.
+        #[default]
+        Full = 0,
+        /// All documents contain at most one value.
+        Optional = 1,
+        /// All documents may contain any number of values.
+        Multivalued = 2,
+        /// 1 / 20 documents has a value
+        Sparse = 3,
+    }
 
     fn get_collector(agg_req: Aggregations) -> AggregationCollector {
         AggregationCollector::from_aggs(agg_req, Default::default())
@@ -71,7 +84,11 @@ mod bench {
                     score_field_i64 => 1i64,
                 ))?;
             }
-            for _ in 0..1_000_000 {
+            let mut doc_with_value = 1_000_000;
+            if cardinality == Cardinality::Sparse {
+                doc_with_value /= 20;
+            }
+            for _ in 0..doc_with_value {
                 let val: f64 = rng.gen_range(0.0..1_000_000.0);
                 index_writer.add_document(doc!(
                     text_field => "cool",
@@ -81,6 +98,11 @@ mod bench {
                     score_field_f64 => lg_norm.sample(&mut rng),
                     score_field_i64 => val as i64,
                 ))?;
+                if cardinality == Cardinality::Sparse {
+                    for _ in 0..20 {
+                        index_writer.add_document(doc!(text_field => "cool"))?;
+                    }
+                }
             }
             // writing the segment
             index_writer.commit()?;
@@ -108,6 +130,12 @@ mod bench {
                 fn [<$x _multi>](b: &mut Bencher) {
                     [<$x _card>](b, Cardinality::Multivalued)
                 }
+
+                #[bench]
+                fn [<$x _sparse>](b: &mut Bencher) {
+                    [<$x _card>](b, Cardinality::Sparse)
+                }
+
             }
         };
     }


### PR DESCRIPTION
The sparse variant has the same amount of docs, but only 1/20 of the values.
So the performance difference is quite large, considering the aggregation collector has only 1/20 of the work

closes https://github.com/quickwit-oss/tantivy/issues/1935
 
```
test aggregation::agg_bench::bench::bench_aggregation_average_f64                                                        ... bench:   5,563,130 ns/iter (+/- 40,739)
test aggregation::agg_bench::bench::bench_aggregation_average_f64_multi                                                  ... bench:  11,245,500 ns/iter (+/- 768,914)
test aggregation::agg_bench::bench::bench_aggregation_average_f64_opt                                                    ... bench:   9,918,193 ns/iter (+/- 150,054)
test aggregation::agg_bench::bench::bench_aggregation_average_f64_sparse                                                 ... bench:  20,023,387 ns/iter (+/- 191,724)
test aggregation::agg_bench::bench::bench_aggregation_average_u64                                                        ... bench:   5,715,629 ns/iter (+/- 126,963)
test aggregation::agg_bench::bench::bench_aggregation_average_u64_and_f64                                                ... bench:   9,842,800 ns/iter (+/- 107,018)
test aggregation::agg_bench::bench::bench_aggregation_average_u64_and_f64_multi                                          ... bench:  21,136,723 ns/iter (+/- 151,645)
test aggregation::agg_bench::bench::bench_aggregation_average_u64_and_f64_opt                                            ... bench:  17,714,251 ns/iter (+/- 164,926)
test aggregation::agg_bench::bench::bench_aggregation_average_u64_and_f64_sparse                                         ... bench:  37,287,388 ns/iter (+/- 431,776)
test aggregation::agg_bench::bench::bench_aggregation_average_u64_multi                                                  ... bench:  11,228,831 ns/iter (+/- 754,393)
test aggregation::agg_bench::bench::bench_aggregation_average_u64_opt                                                    ... bench:   9,568,394 ns/iter (+/- 70,254)
test aggregation::agg_bench::bench::bench_aggregation_average_u64_sparse                                                 ... bench:  20,083,300 ns/iter (+/- 278,449)
test aggregation::agg_bench::bench::bench_aggregation_avg_and_range_with_avg                                             ... bench:  18,163,557 ns/iter (+/- 119,412)
test aggregation::agg_bench::bench::bench_aggregation_avg_and_range_with_avg_multi                                       ... bench:  34,909,146 ns/iter (+/- 1,676,649)
test aggregation::agg_bench::bench::bench_aggregation_avg_and_range_with_avg_opt                                         ... bench:  29,978,632 ns/iter (+/- 269,109)
test aggregation::agg_bench::bench::bench_aggregation_avg_and_range_with_avg_sparse                                      ... bench:  39,046,042 ns/iter (+/- 175,957)
test aggregation::agg_bench::bench::bench_aggregation_histogram_only                                                     ... bench:   9,569,157 ns/iter (+/- 48,514)
test aggregation::agg_bench::bench::bench_aggregation_histogram_only_hard_bounds                                         ... bench:   4,038,382 ns/iter (+/- 29,911)
test aggregation::agg_bench::bench::bench_aggregation_histogram_only_hard_bounds_multi                                   ... bench:   9,615,161 ns/iter (+/- 859,700)
test aggregation::agg_bench::bench::bench_aggregation_histogram_only_hard_bounds_opt                                     ... bench:   7,919,175 ns/iter (+/- 95,462)
test aggregation::agg_bench::bench::bench_aggregation_histogram_only_hard_bounds_sparse                                  ... bench:  18,501,745 ns/iter (+/- 91,449)
test aggregation::agg_bench::bench::bench_aggregation_histogram_only_multi                                               ... bench:  15,134,399 ns/iter (+/- 679,205)
test aggregation::agg_bench::bench::bench_aggregation_histogram_only_opt                                                 ... bench:  13,471,455 ns/iter (+/- 87,597)
test aggregation::agg_bench::bench::bench_aggregation_histogram_only_sparse                                              ... bench:  19,235,891 ns/iter (+/- 119,259)
test aggregation::agg_bench::bench::bench_aggregation_histogram_with_avg                                                 ... bench:  22,682,641 ns/iter (+/- 223,820)
test aggregation::agg_bench::bench::bench_aggregation_histogram_with_avg_multi                                           ... bench:  35,171,415 ns/iter (+/- 256,460)
test aggregation::agg_bench::bench::bench_aggregation_histogram_with_avg_opt                                             ... bench:  31,412,712 ns/iter (+/- 444,254)
test aggregation::agg_bench::bench::bench_aggregation_histogram_with_avg_sparse                                          ... bench:  21,502,142 ns/iter (+/- 77,035)
test aggregation::agg_bench::bench::bench_aggregation_percentiles_f64                                                    ... bench:  17,094,744 ns/iter (+/- 96,173)
test aggregation::agg_bench::bench::bench_aggregation_percentiles_f64_multi                                              ... bench:  23,222,049 ns/iter (+/- 120,193)
test aggregation::agg_bench::bench::bench_aggregation_percentiles_f64_opt                                                ... bench:  21,904,171 ns/iter (+/- 301,285)
test aggregation::agg_bench::bench::bench_aggregation_percentiles_f64_sparse                                             ... bench:  19,453,373 ns/iter (+/- 71,449)
test aggregation::agg_bench::bench::bench_aggregation_range_only                                                         ... bench:   4,672,711 ns/iter (+/- 36,180)
test aggregation::agg_bench::bench::bench_aggregation_range_only_multi                                                   ... bench:  10,742,690 ns/iter (+/- 232,010)
test aggregation::agg_bench::bench::bench_aggregation_range_only_opt                                                     ... bench:   8,895,092 ns/iter (+/- 78,446)
test aggregation::agg_bench::bench::bench_aggregation_range_only_sparse                                                  ... bench:  18,698,207 ns/iter (+/- 98,275)
test aggregation::agg_bench::bench::bench_aggregation_range_with_avg                                                     ... bench:  12,763,782 ns/iter (+/- 72,987)
test aggregation::agg_bench::bench::bench_aggregation_range_with_avg_multi                                               ... bench:  22,401,946 ns/iter (+/- 1,613,835)
test aggregation::agg_bench::bench::bench_aggregation_range_with_avg_opt                                                 ... bench:  20,598,480 ns/iter (+/- 2,017,848)
test aggregation::agg_bench::bench::bench_aggregation_range_with_avg_sparse                                              ... bench:  20,847,067 ns/iter (+/- 415,647)
test aggregation::agg_bench::bench::bench_aggregation_stats_f64                                                          ... bench:   5,601,337 ns/iter (+/- 32,556)
test aggregation::agg_bench::bench::bench_aggregation_stats_f64_multi                                                    ... bench:  11,779,243 ns/iter (+/- 754,800)
test aggregation::agg_bench::bench::bench_aggregation_stats_f64_opt                                                      ... bench:  10,575,847 ns/iter (+/- 712,674)
test aggregation::agg_bench::bench::bench_aggregation_stats_f64_sparse                                                   ... bench:  20,363,703 ns/iter (+/- 499,754)
test aggregation::agg_bench::bench::bench_aggregation_terms_few                                                          ... bench:   3,669,918 ns/iter (+/- 19,270)
test aggregation::agg_bench::bench::bench_aggregation_terms_few_multi                                                    ... bench:  10,748,377 ns/iter (+/- 721,089)
test aggregation::agg_bench::bench::bench_aggregation_terms_few_opt                                                      ... bench:   8,001,392 ns/iter (+/- 50,916)
test aggregation::agg_bench::bench::bench_aggregation_terms_few_sparse                                                   ... bench:  19,376,816 ns/iter (+/- 372,621)
test aggregation::agg_bench::bench::bench_aggregation_terms_many2                                                        ... bench:  14,986,592 ns/iter (+/- 762,469)
test aggregation::agg_bench::bench::bench_aggregation_terms_many2_multi                                                  ... bench:  20,586,030 ns/iter (+/- 1,136,461)
test aggregation::agg_bench::bench::bench_aggregation_terms_many2_opt                                                    ... bench:  19,519,971 ns/iter (+/- 684,153)
test aggregation::agg_bench::bench::bench_aggregation_terms_many2_sparse                                                 ... bench:  25,970,022 ns/iter (+/- 434,924)
test aggregation::agg_bench::bench::bench_aggregation_terms_many_order_by_term                                           ... bench:  16,861,025 ns/iter (+/- 920,246)
test aggregation::agg_bench::bench::bench_aggregation_terms_many_order_by_term_multi                                     ... bench:  22,912,672 ns/iter (+/- 4,265,315)
test aggregation::agg_bench::bench::bench_aggregation_terms_many_order_by_term_opt                                       ... bench:  19,711,694 ns/iter (+/- 466,632)
test aggregation::agg_bench::bench::bench_aggregation_terms_many_order_by_term_sparse                                    ... bench:  31,289,838 ns/iter (+/- 464,374)
test aggregation::agg_bench::bench::bench_aggregation_terms_many_with_sub_agg                                            ... bench: 135,952,282 ns/iter (+/- 13,160,553)
test aggregation::agg_bench::bench::bench_aggregation_terms_many_with_sub_agg_multi                                      ... bench: 189,980,495 ns/iter (+/- 69,355,562)
test aggregation::agg_bench::bench::bench_aggregation_terms_many_with_sub_agg_opt                                        ... bench: 130,414,187 ns/iter (+/- 4,882,054)
test aggregation::agg_bench::bench::bench_aggregation_terms_many_with_sub_agg_sparse                                     ... bench:  31,006,448 ns/iter (+/- 1,033,662)
test aggregation::bucket::range::bench::bench_range_100_buckets                                                          ... bench:     286,984 ns/iter (+/- 4,541)
test aggregation::bucket::range::bench::bench_range_10_buckets                                                           ... bench:     153,631 ns/iter (+/- 2,838)
```