### PR TITLE
Handle error for exists on MMapDirectory

### DIFF
--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -352,7 +352,9 @@ impl Directory for MmapDirectory {
 
     fn exists(&self, path: &Path) -> Result<bool, OpenReadError> {
         let full_path = self.resolve_path(path);
-        Ok(full_path.exists())
+        full_path
+            .try_exists()
+            .map_err(|io_err| OpenReadError::wrap_io_error(io_err, path.to_path_buf()))
     }
 
     fn open_write(&self, path: &Path) -> Result<WritePtr, OpenWriteError> {


### PR DESCRIPTION
`exists` will return false in case of other io errors, like permission denied
