### PR TITLE
chore!:drop JSON support on intermediate agg result

### DIFF
--- a/src/aggregation/agg_tests.rs
+++ b/src/aggregation/agg_tests.rs
@@ -4,7 +4,6 @@ use crate::aggregation::agg_req::{Aggregation, Aggregations};
 use crate::aggregation::agg_result::AggregationResults;
 use crate::aggregation::buf_collector::DOC_BLOCK_SIZE;
 use crate::aggregation::collector::AggregationCollector;
-use crate::aggregation::intermediate_agg_result::IntermediateAggregationResults;
 use crate::aggregation::segment_agg_result::AggregationLimits;
 use crate::aggregation::tests::{get_test_index_2_segments, get_test_index_from_values_and_terms};
 use crate::aggregation::DistributedAggregationCollector;
@@ -421,9 +420,6 @@ fn test_aggregation_level2(
 
         let searcher = reader.searcher();
         let res = searcher.search(&term_query, &collector).unwrap();
-        // Test de/serialization roundtrip on intermediate_agg_result
-        let res: IntermediateAggregationResults =
-            serde_json::from_str(&serde_json::to_string(&res).unwrap()).unwrap();
         res.into_final_result(agg_req.clone(), &Default::default())
             .unwrap()
     } else {

--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -166,7 +166,7 @@ impl SegmentRangeBucketEntry {
         };
 
         Ok(IntermediateRangeBucketEntry {
-            key: self.key,
+            key: self.key.into(),
             doc_count: self.doc_count,
             sub_aggregation: sub_aggregation_res,
             from: self.from,

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -54,6 +54,14 @@ impl From<Key> for IntermediateKey {
         }
     }
 }
+impl From<IntermediateKey> for Key {
+    fn from(value: IntermediateKey) -> Self {
+        match value {
+            IntermediateKey::Str(s) => Self::Str(s),
+            IntermediateKey::F64(f) => Self::F64(f),
+        }
+    }
+}
 
 impl Eq for IntermediateKey {}
 

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -38,6 +38,8 @@ pub struct IntermediateAggregationResults {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq)]
 /// The key to identify a bucket.
+/// This might seem redundant with `Key`, but the point is to have a different
+/// Serialize implementation.
 pub enum IntermediateKey {
     /// String key
     Str(String),

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -245,14 +245,6 @@ pub enum Key {
     /// `f64` key
     F64(f64),
 }
-impl From<IntermediateKey> for Key {
-    fn from(value: IntermediateKey) -> Self {
-        match value {
-            IntermediateKey::Str(s) => Self::Str(s),
-            IntermediateKey::F64(f) => Self::F64(f),
-        }
-    }
-}
 impl Eq for Key {}
 impl std::hash::Hash for Key {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {


### PR DESCRIPTION
JSON support is flaky anyway due it's lack on f64::INF etc. handling

add support for other formats by removing skip_serialize and untagged

In conjunction with: https://github.com/quickwit-oss/quickwit/pull/3170