### PR TITLE
fix BooleanQuery document

### DIFF
--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -11,8 +11,8 @@ use crate::schema::{IndexRecordOption, Term};
 /// `Must` occurrence
 /// * match none of the sub queries associated with the
 /// `MustNot` occurrence.
-/// * match at least one of the subqueries that is not
-/// a `MustNot` occurrence.
+/// * match at least one of the sub queries associated
+/// with the `Should` occurrence.
 ///
 ///
 /// You can combine other query types and their `Occur`ances into one `BooleanQuery`

--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -12,7 +12,7 @@ use crate::schema::{IndexRecordOption, Term};
 /// * match none of the sub queries associated with the
 /// `MustNot` occurrence.
 /// * match at least one of the sub queries associated
-/// with the `Should` occurrence.
+/// with the `Must` or `Should` occurrence.
 ///
 ///
 /// You can combine other query types and their `Occur`ances into one `BooleanQuery`


### PR DESCRIPTION
I think labeling `match at least one of the sub queries` as `Should` makes more sense.