### PR TITLE
fix proximity search #1934

### DIFF
--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -72,7 +72,7 @@ pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync {
         let cutoff = indexes.len() - indexes.len() % step_size;
 
         for idx in cutoff..indexes.len() {
-            output[idx] = self.get_val(indexes[idx] as u32);
+            output[idx] = self.get_val(indexes[idx]);
         }
     }
 

--- a/src/query/intersection.rs
+++ b/src/query/intersection.rs
@@ -69,7 +69,6 @@ impl<TDocSet: DocSet> Intersection<TDocSet, TDocSet> {
     pub(crate) fn new(mut docsets: Vec<TDocSet>) -> Intersection<TDocSet, TDocSet> {
         let num_docsets = docsets.len();
         assert!(num_docsets >= 2);
-        docsets.sort_by_key(|docset| docset.size_hint());
         go_to_first_doc(&mut docsets);
         let left = docsets.remove(0);
         let right = docsets.remove(0);


### PR DESCRIPTION
This is one possible way to fix proximity search.

It might be worthwhile to note that after we made this fix, we discovered that the tantivy [docs](https://docs.rs/tantivy/0.19.2/tantivy/query/struct.PhraseQuery.html#method.set_slop) are inconsistent with [Lucene](https://lucene.apache.org/core/8_0_0/core/org/apache/lucene/search/PhraseQuery.html#getSlop--). Our fix targets the definition of slop that is the maximum allowed offset distance between terms.

We've split the changes into two commits to highlight the race condition. One can test that one commit still leads to nondeterminism in the originally stated case in #1934 while the second commit eliminates this non-determinism.