### PR TITLE
refactor vint

### DIFF
--- a/common/benches/bench.rs
+++ b/common/benches/bench.rs
@@ -1,0 +1,39 @@
+#![feature(test)]
+
+extern crate test;
+
+#[cfg(test)]
+mod tests {
+    use rand::seq::IteratorRandom;
+    use rand::thread_rng;
+    use tantivy_common::serialize_vint_u32;
+    use test::Bencher;
+
+    #[bench]
+    fn bench_vint(b: &mut Bencher) {
+        let vals: Vec<u32> = (0..20_000).collect();
+        b.iter(|| {
+            let mut out = 0u64;
+            for val in vals.iter().cloned() {
+                let mut buf = [0u8; 8];
+                serialize_vint_u32(val, &mut buf);
+                out += u64::from(buf[0]);
+            }
+            out
+        });
+    }
+
+    #[bench]
+    fn bench_vint_rand(b: &mut Bencher) {
+        let vals: Vec<u32> = (0..20_000).choose_multiple(&mut thread_rng(), 100_000);
+        b.iter(|| {
+            let mut out = 0u64;
+            for val in vals.iter().cloned() {
+                let mut buf = [0u8; 8];
+                serialize_vint_u32(val, &mut buf);
+                out += u64::from(buf[0]);
+            }
+            out
+        });
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -19,8 +19,7 @@ pub use group_by::GroupByIteratorExtended;
 pub use ownedbytes::{OwnedBytes, StableDeref};
 pub use serialize::{BinarySerializable, DeserializeFrom, FixedSize};
 pub use vint::{
-    deserialize_vint_u128, read_u32_vint, read_u32_vint_no_advance, serialize_vint_u128,
-    serialize_vint_u32, write_u32_vint, VInt, VIntU128,
+    read_u32_vint, read_u32_vint_no_advance, serialize_vint_u32, write_u32_vint, VInt, VIntU128,
 };
 pub use writer::{AntiCallToken, CountingWriter, TerminatingWrite};
 

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -268,6 +268,7 @@ where B: AsRef<[u8]>
     ///
     /// Do NOT rely on this byte representation in the index.
     /// This value is likely to change in the future.
+    #[inline]
     pub fn serialized_term(&self) -> &[u8] {
         self.0.as_ref()
     }

--- a/src/tokenizer/regex_tokenizer.rs
+++ b/src/tokenizer/regex_tokenizer.rs
@@ -137,11 +137,11 @@ mod tests {
 
     #[test]
     fn test_regexp_tokenizer_error_on_invalid_regex() {
-        let tokenizer = RegexTokenizer::new(r"\@");
+        let tokenizer = RegexTokenizer::new(r"\@(");
         assert_eq!(tokenizer.is_err(), true);
         assert_eq!(
             tokenizer.err().unwrap().to_string(),
-            "An invalid argument was passed: '\\@'"
+            "An invalid argument was passed: '\\@('"
         );
     }
 

--- a/stacker/src/expull.rs
+++ b/stacker/src/expull.rs
@@ -99,12 +99,14 @@ fn ensure_capacity<'a>(
 }
 
 impl<'a> ExpUnrolledLinkedListWriter<'a> {
+    #[inline]
     pub fn write_u32_vint(&mut self, val: u32) {
         let mut buf = [0u8; 8];
         let data = serialize_vint_u32(val, &mut buf);
         self.extend_from_slice(data);
     }
 
+    #[inline]
     pub fn extend_from_slice(&mut self, mut buf: &[u8]) {
         while !buf.is_empty() {
             let add_len: usize;


### PR DESCRIPTION
- improve performance of vint
vint serialization shows up in performance profiles during indexing.
It would also make sense to limit the value space to u29 and operate on 4 bytes only.
- remove unused code
- add missing inlines
