### PR TITLE
fix slop

### DIFF
--- a/src/query/phrase_query/mod.rs
+++ b/src/query/phrase_query/mod.rs
@@ -184,6 +184,20 @@ pub mod tests {
         Ok(())
     }
 
+    #[test]
+    pub fn test_phrase_score_with_slop_bug_2() -> crate::Result<()> {
+        // fails
+        let index = create_index(&["a x b x c", "a a c"])?;
+        let scores = test_query(2, &index, vec!["a", "b", "c"]);
+        assert_eq!(scores.len(), 1);
+
+        let index = create_index(&["a x b x c", "b c c"])?;
+        let scores = test_query(2, &index, vec!["a", "b", "c"]);
+        assert_eq!(scores.len(), 1);
+
+        Ok(())
+    }
+
     fn test_query(slop: u32, index: &Index, texts: Vec<&str>) -> Vec<f32> {
         let text_field = index.schema().get_field("text").unwrap();
         let searcher = index.reader().unwrap().searcher();
@@ -212,8 +226,30 @@ pub mod tests {
     pub fn test_phrase_score_with_slop_size() -> crate::Result<()> {
         let index = create_index(&["a b e c", "a e e e c", "a e e e e c"])?;
         let scores = test_query(3, &index, vec!["a", "c"]);
+        assert_eq!(scores.len(), 2);
         assert_nearly_equals!(scores[0], 0.29086056);
         assert_nearly_equals!(scores[1], 0.26706287);
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_phrase_slop() -> crate::Result<()> {
+        let index = create_index(&["a x b c"])?;
+        let scores = test_query(1, &index, vec!["a", "b", "c"]);
+        assert_eq!(scores.len(), 1);
+
+        let index = create_index(&["a x b x c"])?;
+        let scores = test_query(1, &index, vec!["a", "b", "c"]);
+        assert_eq!(scores.len(), 0);
+
+        let index = create_index(&["a b"])?;
+        let scores = test_query(1, &index, vec!["b", "a"]);
+        assert_eq!(scores.len(), 0);
+
+        let index = create_index(&["a b"])?;
+        let scores = test_query(2, &index, vec!["b", "a"]);
+        assert_eq!(scores.len(), 1);
+
         Ok(())
     }
 

--- a/src/query/phrase_query/phrase_query.rs
+++ b/src/query/phrase_query/phrase_query.rs
@@ -66,6 +66,16 @@ impl PhraseQuery {
     /// Slop allowed for the phrase.
     ///
     /// The query will match if its terms are separated by `slop` terms at most.
+    /// The slop can be considered a budget between all terms.
+    /// E.g. "A B C" with slop 1 allows "A X B C", "A B X C", but not "A X B X C".
+    ///
+    /// Transposition costs 2, e.g. "A B" with slop 1 will not match "B A" but it would with slop 2
+    /// Transposition is not a special case, in the example above A is moved 1 position and B is
+    /// moved 1 position, so the slop is 2.
+    ///
+    /// As a result slop works in both directions, so the order of the terms may changed as long as
+    /// they respect the slop.
+    ///
     /// By default the slop is 0 meaning query terms need to be adjacent.
     pub fn set_slop(&mut self, value: u32) {
         self.slop = value;

--- a/src/query/phrase_query/phrase_scorer.rs
+++ b/src/query/phrase_query/phrase_scorer.rs
@@ -52,6 +52,9 @@ pub struct PhraseScorer<TPostings: Postings> {
     fieldnorm_reader: FieldNormReader,
     similarity_weight_opt: Option<Bm25Weight>,
     slop: u32,
+    left_slops: Vec<u8>,
+    positions_buffer: Vec<u32>,
+    slops_buffer: Vec<u8>,
 }
 
 /// Returns true if and only if the two sorted arrays contain a common element
@@ -211,6 +214,136 @@ fn intersection_exists_with_slop(
     false
 }
 
+/// Intersection variant for multi term searches that keeps track of slop so far.
+///
+/// In contrast to the regular algorithm this solves some issues:
+/// - Keep track of the slop so far. Slop is a budget that is spent on the distance between terms.
+/// - When encountering a match between two positions, which position is the best match is unclear
+/// and depends on intersections afterwards, therefore this algorithm keeps left and right as
+/// matches, but only counts one.
+///
+/// This algorithm may return an incorrect count in some cases (e.g. left, right expansion and is
+/// then matches both on the following term.)
+/// I think to fix this we would need to iterate all positions simultaneously,
+/// but not sure if that's worth it. (It may be considerable slower - untested)
+///
+/// left_slops is allowed to be empty, which equals to a slop of 0 so far.
+#[inline]
+fn intersection_count_with_carrying_slop(
+    left_positions: &mut Vec<u32>,
+    left_slops: &mut Vec<u8>,
+    right_positions: &[u32],
+    max_slop: u32,
+    update_left: bool,
+    positions_buffer: &mut Vec<u32>,
+    slops_buffer: &mut Vec<u8>,
+) -> u32 {
+    let mut left_index = 0;
+    let mut right_index = 0;
+    let mut count = 0;
+
+    if left_positions.is_empty() || right_positions.is_empty() {
+        if update_left {
+            left_positions.clear();
+            left_slops.clear();
+        }
+        return 0;
+    }
+
+    let add_val = |val: (u8, u32), new_left: &mut Vec<u32>, new_slops: &mut Vec<u8>| {
+        if update_left {
+            let pos_exists = new_left.last().map(|v| *v == val.1).unwrap_or(false);
+            if pos_exists {
+                let last_slop = new_slops.last_mut().unwrap();
+                *last_slop = (*last_slop).min(val.0);
+            } else {
+                new_left.push(val.1);
+                new_slops.push(val.0);
+            }
+        }
+    };
+    loop {
+        let left_val = left_positions[left_index];
+        let slop_so_far = left_slops.get(left_index).cloned().unwrap_or(0);
+        let right_val = right_positions[right_index];
+
+        let distance = slop_so_far as u32 + left_val.abs_diff(right_val);
+        if distance <= max_slop {
+            let (smaller_val, larger_val, mut smaller_val_idx, smaller_val_positions) =
+                if left_val < right_val {
+                    (left_val, right_val, left_index, left_positions.as_slice())
+                } else {
+                    (right_val, left_val, right_index, right_positions)
+                };
+
+            let mut new_slop = distance;
+            add_val(
+                (new_slop as u8, smaller_val),
+                positions_buffer,
+                slops_buffer,
+            );
+            while smaller_val_idx + 1 < smaller_val_positions.len() {
+                // there could be a better match
+                let next_val = smaller_val_positions[smaller_val_idx + 1];
+                if next_val > larger_val {
+                    // the next value is outside the range, so current one is the best.
+                    break;
+                }
+                let distance = next_val.abs_diff(larger_val);
+
+                // the next value is better.
+                smaller_val_idx += 1;
+                // better slop
+                new_slop = slop_so_far as u32 + distance;
+                add_val((new_slop as u8, next_val), positions_buffer, slops_buffer);
+            }
+
+            add_val((new_slop as u8, larger_val), positions_buffer, slops_buffer);
+            count += 1;
+            left_index += 1;
+            right_index += 1;
+        } else if left_val < right_val {
+            left_index += 1;
+        } else {
+            right_index += 1;
+        }
+
+        if left_index >= left_positions.len() || right_index >= right_positions.len() {
+            // finish rest
+            if left_index >= left_positions.len() {
+                let left_val = *left_positions.last().unwrap();
+                let slop_so_far: u8 = *left_slops.last().unwrap_or(&0);
+                for right_val in &right_positions[right_index..] {
+                    let new_slop = left_val.abs_diff(*right_val) + slop_so_far as u32;
+                    if new_slop <= max_slop {
+                        add_val((new_slop as u8, *right_val), positions_buffer, slops_buffer);
+                    }
+                }
+            } else {
+                let right_val = *right_positions.last().unwrap();
+                for left_idx in left_index..left_positions.len() {
+                    let left_val = left_positions[left_idx];
+                    let slop_so_far = *left_slops.get(left_idx).unwrap_or(&0);
+                    let new_slop = left_val.abs_diff(right_val) + slop_so_far as u32;
+                    if new_slop <= max_slop {
+                        add_val((new_slop as u8, left_val), positions_buffer, slops_buffer);
+                    }
+                }
+            };
+
+            break;
+        }
+    }
+    if update_left {
+        std::mem::swap(left_positions, positions_buffer);
+        std::mem::swap(left_slops, slops_buffer);
+        positions_buffer.clear();
+        slops_buffer.clear();
+    }
+
+    count
+}
+
 impl<TPostings: Postings> PhraseScorer<TPostings> {
     // If similarity_weight is None, then scoring is disabled.
     pub fn new(
@@ -257,6 +390,9 @@ impl<TPostings: Postings> PhraseScorer<TPostings> {
             similarity_weight_opt,
             fieldnorm_reader,
             slop,
+            left_slops: Vec::with_capacity(100),
+            slops_buffer: Vec::with_capacity(100),
+            positions_buffer: Vec::with_capacity(100),
         };
         if scorer.doc() != TERMINATED && !scorer.phrase_match() {
             scorer.advance();
@@ -299,12 +435,24 @@ impl<TPostings: Postings> PhraseScorer<TPostings> {
     fn compute_phrase_count(&mut self) -> u32 {
         self.compute_phrase_match();
         if self.has_slop() {
-            intersection_count_with_slop(
-                &mut self.left_positions,
-                &self.right_positions[..],
-                self.slop,
-                false,
-            ) as u32
+            if self.num_terms > 2 {
+                intersection_count_with_carrying_slop(
+                    &mut self.left_positions,
+                    &mut self.left_slops,
+                    &self.right_positions[..],
+                    self.slop,
+                    false,
+                    &mut self.positions_buffer,
+                    &mut self.slops_buffer,
+                )
+            } else {
+                intersection_count_with_slop(
+                    &mut self.left_positions,
+                    &self.right_positions[..],
+                    self.slop,
+                    false,
+                ) as u32
+            }
         } else {
             intersection_count(&self.left_positions, &self.right_positions[..]) as u32
         }
@@ -315,6 +463,9 @@ impl<TPostings: Postings> PhraseScorer<TPostings> {
             self.intersection_docset
                 .docset_mut_specialized(0)
                 .positions(&mut self.left_positions);
+            if self.has_slop() {
+                self.left_slops.clear();
+            }
         }
         for i in 1..self.num_terms - 1 {
             {
@@ -323,12 +474,24 @@ impl<TPostings: Postings> PhraseScorer<TPostings> {
                     .positions(&mut self.right_positions);
             }
             if self.has_slop() {
-                intersection_count_with_slop(
-                    &mut self.left_positions,
-                    &self.right_positions[..],
-                    self.slop,
-                    true,
-                );
+                if self.num_terms > 2 {
+                    intersection_count_with_carrying_slop(
+                        &mut self.left_positions,
+                        &mut self.left_slops,
+                        &self.right_positions[..],
+                        self.slop,
+                        true,
+                        &mut self.positions_buffer,
+                        &mut self.slops_buffer,
+                    );
+                } else {
+                    intersection_count_with_slop(
+                        &mut self.left_positions,
+                        &self.right_positions[..],
+                        self.slop,
+                        true,
+                    );
+                }
             } else {
                 intersection(&mut self.left_positions, &self.right_positions);
             };
@@ -388,7 +551,7 @@ impl<TPostings: Postings> Scorer for PhraseScorer<TPostings> {
 
 #[cfg(test)]
 mod tests {
-    use super::{intersection, intersection_count, intersection_count_with_slop};
+    use super::*;
 
     fn test_intersection_sym(left: &[u32], right: &[u32], expected: &[u32]) {
         test_intersection_aux(left, right, expected, 0);
@@ -446,6 +609,63 @@ mod tests {
         test_merge(&[3], &[4], &[4], 2);
         test_merge(&[1, 5, 6, 9, 10, 12], &[6, 8, 9, 12], &[6, 8, 9, 12], 10);
     }
+
+    fn test_carry_slop_intersection_aux(
+        right: &[&[u32]],
+        expected: &[(u8, u32)],
+        slop: u32,
+        expected_count: u32,
+    ) {
+        let mut left_vec = right[0].to_vec();
+        let mut slops = vec![0; left_vec.len()];
+        let mut count = 0;
+        for right in &right[1..] {
+            count = intersection_count_with_carrying_slop(
+                &mut left_vec,
+                &mut slops,
+                right,
+                slop,
+                true,
+                &mut Vec::new(),
+                &mut Vec::new(),
+            );
+        }
+        let out: Vec<(u8, u32)> = slops
+            .iter()
+            .cloned()
+            .zip(left_vec.iter().cloned())
+            .collect();
+        assert_eq!(&out, expected);
+        assert_eq!(count, expected_count);
+    }
+
+    #[test]
+    fn test_carry_slop_intersection() {
+        test_carry_slop_intersection_aux(&[&[1], &[]], &[], 1, 0);
+        test_carry_slop_intersection_aux(&[&[1], &[2]], &[(1, 1), (1, 2)], 1, 1);
+        test_carry_slop_intersection_aux(&[&[1], &[3]], &[], 1, 0);
+        test_carry_slop_intersection_aux(&[&[1], &[2]], &[(1, 1), (1, 2)], 1, 1);
+
+        // The order may still matter
+        test_carry_slop_intersection_aux(&[&[1], &[2], &[2]], &[(1, 2)], 1, 1);
+        test_carry_slop_intersection_aux(&[&[2], &[1], &[2]], &[(1, 2)], 1, 1);
+        test_carry_slop_intersection_aux(&[&[2], &[2], &[1]], &[(1, 1), (1, 2)], 1, 1);
+
+        test_carry_slop_intersection_aux(&[&[2], &[2], &[1], &[2]], &[(1, 2)], 1, 1);
+        test_carry_slop_intersection_aux(&[&[1], &[2], &[2], &[2]], &[(1, 2)], 1, 1);
+
+        test_carry_slop_intersection_aux(&[&[1], &[2], &[1]], &[(1, 1)], 1, 1);
+
+        test_carry_slop_intersection_aux(&[&[11], &[10, 12]], &[(1, 10), (1, 11), (1, 12)], 1, 1);
+        test_carry_slop_intersection_aux(&[&[10, 12], &[11]], &[(1, 10), (1, 11), (1, 12)], 1, 1);
+
+        test_carry_slop_intersection_aux(
+            &[&[5, 7, 11], &[1, 5, 10, 12]],
+            &[(0, 5), (1, 10), (1, 11), (1, 12)],
+            1,
+            2,
+        );
+    }
 }
 
 #[cfg(all(test, feature = "unstable"))]
@@ -453,7 +673,32 @@ mod bench {
 
     use test::Bencher;
 
-    use super::{intersection, intersection_count};
+    use super::*;
+
+    #[bench]
+    fn bench_intersection_short_slop_carrying(b: &mut Bencher) {
+        let mut left = Vec::new();
+        let mut left_slops = Vec::new();
+        let mut buffer = Vec::new();
+        let mut slop_buffer = Vec::new();
+        b.iter(|| {
+            left.clear();
+            left.extend_from_slice(&[1, 5, 10, 12]);
+            left_slops.extend_from_slice(&[0, 0, 0, 0]);
+            let right = [5, 7];
+            intersection(&mut left, &right);
+
+            intersection_count_with_carrying_slop(
+                &mut left,
+                &mut left_slops,
+                &right,
+                2,
+                true,
+                &mut buffer,
+                &mut slop_buffer,
+            )
+        });
+    }
 
     #[bench]
     fn bench_intersection_short(b: &mut Bencher) {
@@ -462,6 +707,59 @@ mod bench {
             left.clear();
             left.extend_from_slice(&[1, 5, 10, 12]);
             let right = [5, 7];
+            intersection(&mut left, &right);
+        });
+    }
+
+    #[bench]
+    fn bench_intersection_medium_slop_carrying(b: &mut Bencher) {
+        let mut left = Vec::new();
+        let mut left_slops: Vec<u8> = Vec::new();
+        let mut buffer = Vec::new();
+        let mut slop_buffer = Vec::new();
+        let left_data: Vec<u32> = (0..100).collect();
+        let left_slop_data: Vec<u8> = (0..100).map(|_| 0).collect();
+
+        b.iter(|| {
+            left.clear();
+            left.extend_from_slice(&left_data);
+            left_slops.clear();
+            left_slops.extend_from_slice(&left_slop_data);
+            let right = [5, 7, 55, 200];
+
+            intersection_count_with_carrying_slop(
+                &mut left,
+                &mut left_slops,
+                &right,
+                2,
+                true,
+                &mut buffer,
+                &mut slop_buffer,
+            )
+        });
+    }
+
+    #[bench]
+    fn bench_intersection_medium_slop(b: &mut Bencher) {
+        let mut left = Vec::new();
+        let left_data: Vec<u32> = (0..100).collect();
+
+        b.iter(|| {
+            left.clear();
+            left.extend_from_slice(&left_data);
+            let right = [5, 7, 55, 200];
+            intersection_count_with_slop(&mut left, &right[..], 2, true) as u32
+        });
+    }
+
+    #[bench]
+    fn bench_intersection_medium(b: &mut Bencher) {
+        let mut left = Vec::new();
+        let left_data: Vec<u32> = (0..100).collect();
+        b.iter(|| {
+            left.clear();
+            left.extend_from_slice(&left_data);
+            let right = [5, 7, 55, 200];
             intersection(&mut left, &right);
         });
     }


### PR DESCRIPTION
Fix slop by carrying slop so far for terms > 2.
Define slop contract in the API

* The query will match if its terms are separated by `slop` terms at most.
The slop can be considered a budget between all terms.
E.g. "A B C" with slop 1 allows "A X B C", "A B X C", but not "A X B X C".
* Transposition costs 2, e.g. "A B" with slop 1 will not match "B A" but it would with slop 2
Transposition is not a special case, in the example above A is moved 1 position and B is moved 1 position, so the slop is 2.

* As a result slop works in both directions, so the order of the terms may changed as long as they respect the slop.


The slop carrying algorithm is only active for terms > 2 as it is slightly slower
```
running 6 tests
test query::phrase_query::phrase_scorer::bench::bench_intersection_count_short                                           ... bench:           2 ns/iter (+/- 0)
test query::phrase_query::phrase_scorer::bench::bench_intersection_medium                                                ... bench:         106 ns/iter (+/- 1)
test query::phrase_query::phrase_scorer::bench::bench_intersection_medium_slop                                           ... bench:         104 ns/iter (+/- 7)
test query::phrase_query::phrase_scorer::bench::bench_intersection_medium_slop_carrying                                  ... bench:         194 ns/iter (+/- 3)
test query::phrase_query::phrase_scorer::bench::bench_intersection_short                                                 ... bench:           3 ns/iter (+/- 0)
test query::phrase_query::phrase_scorer::bench::bench_intersection_short_slop                                            ... bench:          16 ns/iter (+/- 0)
```
