### PR TITLE
Expose create a query from a user input AST.

### DIFF
--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -314,6 +314,19 @@ impl QueryParser {
         Ok(convert_to_query(&self.fuzzy, logical_ast))
     }
 
+    /// Build a query from an already parsed user input AST
+    ///
+    /// This can be useful if the user input AST parsed using [`query_grammar`]
+    /// needs to be inspected before the query is re-interpreted w.r.t.
+    /// index specifics like field names and tokenizers.
+    pub fn build_query_from_user_input_ast(
+        &self,
+        user_input_ast: UserInputAst,
+    ) -> Result<Box<dyn Query>, QueryParserError> {
+        let logical_ast = self.compute_logical_ast(user_input_ast)?;
+        Ok(convert_to_query(&self.fuzzy, logical_ast))
+    }
+
     /// Parse the user query into an AST.
     fn parse_query_to_logical_ast(&self, query: &str) -> Result<LogicalAst, QueryParserError> {
         let user_input_ast = query_grammar::parse_query(query)


### PR DESCRIPTION
The use case I have for this is described in the doc comment, i.e. I use the raw literals before tokenization to fetch auxiliary information from systems outside the index.

Currently, this means that I have to parse the query twice, once in `QueryParser::parse_query` and then again using `tantivy_query_grammar::parse_query` to extract the raw literals. With this change, I can pass on the `UserInputAST` which I used to collect the raw terms to the `QueryParser` to avoid the redundant work.

Theoretically, since a `UserInputAST` is completely independent of a given index, it could also be used to query multiple independent indexes.