### PR TITLE
update termmap benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,11 @@ opt-level = 3
 debug = false
 debug-assertions = false
 
+[profile.bench]
+opt-level = 3
+debug = true
+debug-assertions = false
+
 [profile.test]
 debug-assertions = true
 overflow-checks = true

--- a/stacker/Cargo.toml
+++ b/stacker/Cargo.toml
@@ -21,8 +21,7 @@ path = "example/hashmap.rs"
 rand = "0.8.5"
 zipf = "7.0.0"
 criterion = "0.4.0"
-
+rustc-hash = "1.1.0"
 
 [features]
 unstable = [] # useful for benches.
-

--- a/stacker/src/arena_hashmap.rs
+++ b/stacker/src/arena_hashmap.rs
@@ -167,6 +167,7 @@ impl ArenaHashMap {
     }
 
     #[inline]
+    #[cfg(not(feature = "compare_hash_only"))]
     fn get_value_addr_if_key_match(&self, target_key: &[u8], addr: Addr) -> Option<Addr> {
         let (stored_key, value_addr) = self.get_key_value(addr);
         if stored_key == target_key {
@@ -174,6 +175,16 @@ impl ArenaHashMap {
         } else {
             None
         }
+    }
+    #[inline]
+    #[cfg(feature = "compare_hash_only")]
+    fn get_value_addr_if_key_match(&self, _target_key: &[u8], addr: Addr) -> Option<Addr> {
+        let data = self.memory_arena.slice_from(addr);
+        let key_bytes_len_bytes = &data[..2];
+        let key_bytes_len = u16::from_le_bytes(key_bytes_len_bytes.try_into().unwrap());
+        let value_addr = addr.offset(2 + key_bytes_len as u32);
+
+        Some(value_addr)
     }
 
     #[inline]


### PR DESCRIPTION
```
CreateHashMap/alice/174693
                        time:   [693.98 µs 696.37 µs 698.86 µs]
                        thrpt:  [238.39 MiB/s 239.24 MiB/s 240.06 MiB/s]
CreateHashMap/alice_expull/174693
                        time:   [913.49 µs 915.26 µs 917.05 µs]
                        thrpt:  [181.67 MiB/s 182.03 MiB/s 182.38 MiB/s]
CreateHashMap/alice_fx_hashmap_ref_expull/174693
                        time:   [907.12 µs 909.84 µs 912.86 µs]
                        thrpt:  [182.50 MiB/s 183.11 MiB/s 183.66 MiB/s]
CreateHashMap/alice_fx_hashmap_owned_expull/174693
                        time:   [1.4779 ms 1.4819 ms 1.4858 ms]
                        thrpt:  [112.13 MiB/s 112.42 MiB/s 112.73 MiB/s]
CreateHashMap/numbers/8000000
                        time:   [54.261 ms 54.944 ms 55.700 ms]
                        thrpt:  [136.97 MiB/s 138.86 MiB/s 140.60 MiB/s]
CreateHashMap/numbers_zipf/8000000
                        time:   [35.783 ms 35.934 ms 36.109 ms]
                        thrpt:  [211.29 MiB/s 212.32 MiB/s 213.21 MiB/s]
```