### PR TITLE
fix phrase prefix query

### DIFF
--- a/src/query/phrase_prefix_query/phrase_prefix_scorer.rs
+++ b/src/query/phrase_prefix_query/phrase_prefix_scorer.rs
@@ -141,8 +141,10 @@ impl<TPostings: Postings> PhrasePrefixScorer<TPostings> {
             suffix_offset: (max_offset - suffix_pos) as u32,
             phrase_count: 0,
         };
-        if !phrase_prefix_scorer.matches_prefix() {
-            phrase_prefix_scorer.advance();
+        if phrase_prefix_scorer.doc() != TERMINATED {
+            if !phrase_prefix_scorer.matches_prefix() {
+                phrase_prefix_scorer.advance();
+            }
         }
         phrase_prefix_scorer
     }
@@ -182,7 +184,6 @@ impl<TPostings: Postings> DocSet for PhrasePrefixScorer<TPostings> {
     }
 
     fn seek(&mut self, target: DocId) -> DocId {
-        self.phrase_scorer.seek(target);
         let doc = self.phrase_scorer.seek(target);
         if doc == TERMINATED || self.matches_prefix() {
             return doc;

--- a/src/query/phrase_prefix_query/phrase_prefix_scorer.rs
+++ b/src/query/phrase_prefix_query/phrase_prefix_scorer.rs
@@ -141,10 +141,8 @@ impl<TPostings: Postings> PhrasePrefixScorer<TPostings> {
             suffix_offset: (max_offset - suffix_pos) as u32,
             phrase_count: 0,
         };
-        if phrase_prefix_scorer.doc() != TERMINATED {
-            if !phrase_prefix_scorer.matches_prefix() {
-                phrase_prefix_scorer.advance();
-            }
+        if phrase_prefix_scorer.doc() != TERMINATED && !phrase_prefix_scorer.matches_prefix() {
+            phrase_prefix_scorer.advance();
         }
         phrase_prefix_scorer
     }


### PR DESCRIPTION
it would fail spectacularly when no doc in the segment would match the phrase part of the query