### PR TITLE
tokenizer-api: reduce Tokenizer overhead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ proptest = "1.0.0"
 criterion = "0.5"
 test-log = "0.2.10"
 env_logger = "0.10.0"
-pprof = { version = "0.11.0", features = ["flamegraph", "criterion"] }
+pprof = { git = "https://github.com/PSeitz/pprof-rs/", rev = "53af24b", features = ["flamegraph", "criterion"] } # temp fork that works with criterion 0.5
 futures = "0.3.21"
 paste = "1.0.11"
 more-asserts = "0.3.1"

--- a/benches/analyzer.rs
+++ b/benches/analyzer.rs
@@ -5,7 +5,7 @@ const ALICE_TXT: &str = include_str!("alice.txt");
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let tokenizer_manager = TokenizerManager::default();
-    let tokenizer = tokenizer_manager.get("default").unwrap();
+    let mut tokenizer = tokenizer_manager.get("default").unwrap();
     c.bench_function("default-tokenize-alice", |b| {
         b.iter(|| {
             let mut word_count = 0;

--- a/examples/pre_tokenized_text.rs
+++ b/examples/pre_tokenized_text.rs
@@ -17,7 +17,8 @@ use tantivy::{doc, Index, ReloadPolicy};
 use tempfile::TempDir;
 
 fn pre_tokenize_text(text: &str) -> Vec<Token> {
-    let mut token_stream = SimpleTokenizer.token_stream(text);
+    let mut tokenizer = SimpleTokenizer::default();
+    let mut token_stream = tokenizer.token_stream(text);
     let mut tokens = vec![];
     while token_stream.advance() {
         tokens.push(token_stream.token().clone());

--- a/examples/stop_words.rs
+++ b/examples/stop_words.rs
@@ -50,7 +50,7 @@ fn main() -> tantivy::Result<()> {
 
     // This tokenizer lowers all of the text (to help with stop word matching)
     // then removes all instances of `the` and `and` from the corpus
-    let tokenizer = TextAnalyzer::builder(SimpleTokenizer)
+    let tokenizer = TextAnalyzer::builder(SimpleTokenizer::default())
         .filter(LowerCaser)
         .filter(StopWordFilter::remove(vec![
             "the".to_string(),

--- a/src/core/json_utils.rs
+++ b/src/core/json_utils.rs
@@ -67,7 +67,7 @@ impl IndexingPositionsPerPath {
 pub(crate) fn index_json_values<'a>(
     doc: DocId,
     json_values: impl Iterator<Item = crate::Result<&'a serde_json::Map<String, serde_json::Value>>>,
-    text_analyzer: &TextAnalyzer,
+    text_analyzer: &mut TextAnalyzer,
     expand_dots_enabled: bool,
     term_buffer: &mut Term,
     postings_writer: &mut dyn PostingsWriter,
@@ -93,7 +93,7 @@ pub(crate) fn index_json_values<'a>(
 fn index_json_object(
     doc: DocId,
     json_value: &serde_json::Map<String, serde_json::Value>,
-    text_analyzer: &TextAnalyzer,
+    text_analyzer: &mut TextAnalyzer,
     json_term_writer: &mut JsonTermWriter,
     postings_writer: &mut dyn PostingsWriter,
     ctx: &mut IndexingContext,
@@ -117,7 +117,7 @@ fn index_json_object(
 fn index_json_value(
     doc: DocId,
     json_value: &serde_json::Value,
-    text_analyzer: &TextAnalyzer,
+    text_analyzer: &mut TextAnalyzer,
     json_term_writer: &mut JsonTermWriter,
     postings_writer: &mut dyn PostingsWriter,
     ctx: &mut IndexingContext,
@@ -239,7 +239,7 @@ pub(crate) fn set_fastvalue_and_get_term<T: FastValue>(
 pub(crate) fn set_string_and_get_terms(
     json_term_writer: &mut JsonTermWriter,
     value: &str,
-    text_analyzer: &TextAnalyzer,
+    text_analyzer: &mut TextAnalyzer,
 ) -> Vec<(usize, Term)> {
     let mut positions_and_terms = Vec::<(usize, Term)>::new();
     json_term_writer.close_path_and_set_type(Type::Str);

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -1208,7 +1208,7 @@ mod tests {
         let ff_tokenizer_manager = TokenizerManager::default();
         ff_tokenizer_manager.register(
             "custom_lowercase",
-            TextAnalyzer::builder(RawTokenizer)
+            TextAnalyzer::builder(RawTokenizer::default())
                 .filter(LowerCaser)
                 .build(),
         );

--- a/src/fastfield/writer.rs
+++ b/src/fastfield/writer.rs
@@ -147,7 +147,7 @@ impl FastFieldsWriter {
                     }
                     Value::Str(text_val) => {
                         if let Some(tokenizer) =
-                            &self.per_field_tokenizer[field_value.field().field_id() as usize]
+                            &mut self.per_field_tokenizer[field_value.field().field_id() as usize]
                         {
                             let mut token_stream = tokenizer.token_stream(text_val);
                             token_stream.process(&mut |token: &Token| {
@@ -202,7 +202,7 @@ impl FastFieldsWriter {
                         self.json_path_buffer.push_str(field_name);
 
                         let text_analyzer =
-                            &self.per_field_tokenizer[field_value.field().field_id() as usize];
+                            &mut self.per_field_tokenizer[field_value.field().field_id() as usize];
 
                         record_json_obj_to_columnar_writer(
                             doc_id,
@@ -263,7 +263,7 @@ fn record_json_obj_to_columnar_writer(
     remaining_depth_limit: usize,
     json_path_buffer: &mut String,
     columnar_writer: &mut columnar::ColumnarWriter,
-    tokenizer: &Option<TextAnalyzer>,
+    tokenizer: &mut Option<TextAnalyzer>,
 ) {
     for (key, child) in json_obj {
         let len_path = json_path_buffer.len();
@@ -302,7 +302,7 @@ fn record_json_value_to_columnar_writer(
     mut remaining_depth_limit: usize,
     json_path_writer: &mut String,
     columnar_writer: &mut columnar::ColumnarWriter,
-    tokenizer: &Option<TextAnalyzer>,
+    tokenizer: &mut Option<TextAnalyzer>,
 ) {
     if remaining_depth_limit == 0 {
         return;
@@ -321,7 +321,7 @@ fn record_json_value_to_columnar_writer(
             }
         }
         serde_json::Value::String(text) => {
-            if let Some(text_analyzer) = tokenizer {
+            if let Some(text_analyzer) = tokenizer.as_mut() {
                 let mut token_stream = text_analyzer.token_stream(text);
                 token_stream.process(&mut |token| {
                     columnar_writer.record_str(doc, json_path_writer.as_str(), &token.text);
@@ -379,7 +379,7 @@ mod tests {
                 JSON_DEPTH_LIMIT,
                 &mut json_path,
                 &mut columnar_writer,
-                &None,
+                &mut None,
             );
         }
         let mut buffer = Vec::new();

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -185,10 +185,11 @@ impl SegmentWriter {
 
             match field_entry.field_type() {
                 FieldType::Facet(_) => {
+                    let mut facet_tokenizer = FacetTokenizer::default(); // this can be global
                     for value in values {
                         let facet = value.as_facet().ok_or_else(make_schema_error)?;
                         let facet_str = facet.encoded_str();
-                        let mut facet_tokenizer = FacetTokenizer.token_stream(facet_str);
+                        let mut facet_tokenizer = facet_tokenizer.token_stream(facet_str);
                         let mut indexing_position = IndexingPosition::default();
                         postings_writer.index_text(
                             doc_id,
@@ -208,7 +209,7 @@ impl SegmentWriter {
                             }
                             Value::Str(ref text) => {
                                 let text_analyzer =
-                                    &self.per_field_text_analyzers[field.field_id() as usize];
+                                    &mut self.per_field_text_analyzers[field.field_id() as usize];
                                 text_analyzer.token_stream(text)
                             }
                             _ => {
@@ -304,7 +305,8 @@ impl SegmentWriter {
                     }
                 }
                 FieldType::JsonObject(json_options) => {
-                    let text_analyzer = &self.per_field_text_analyzers[field.field_id() as usize];
+                    let text_analyzer =
+                        &mut self.per_field_text_analyzers[field.field_id() as usize];
                     let json_values_it =
                         values.map(|value| value.as_json().ok_or_else(make_schema_error));
                     index_json_values(

--- a/src/postings/mod.rs
+++ b/src/postings/mod.rs
@@ -162,7 +162,7 @@ pub mod tests {
         let index = Index::create_in_ram(schema);
         index
             .tokenizers()
-            .register("simple_no_truncation", SimpleTokenizer);
+            .register("simple_no_truncation", SimpleTokenizer::default());
         let reader = index.reader()?;
         let mut index_writer = index.writer_for_tests()?;
 
@@ -194,7 +194,7 @@ pub mod tests {
         let index = Index::create_in_ram(schema);
         index
             .tokenizers()
-            .register("simple_no_truncation", SimpleTokenizer);
+            .register("simple_no_truncation", SimpleTokenizer::default());
         let reader = index.reader()?;
         let mut index_writer = index.writer_for_tests()?;
 

--- a/src/query/more_like_this/more_like_this.rs
+++ b/src/query/more_like_this/more_like_this.rs
@@ -192,44 +192,48 @@ impl MoreLikeThis {
                     })
                     .collect::<Result<Vec<_>>>()?;
                 for fake_str in facets {
-                    FacetTokenizer.token_stream(fake_str).process(&mut |token| {
-                        if self.is_noise_word(token.text.clone()) {
-                            let term = Term::from_field_text(field, &token.text);
-                            *term_frequencies.entry(term).or_insert(0) += 1;
-                        }
-                    });
+                    FacetTokenizer::default()
+                        .token_stream(fake_str)
+                        .process(&mut |token| {
+                            if self.is_noise_word(token.text.clone()) {
+                                let term = Term::from_field_text(field, &token.text);
+                                *term_frequencies.entry(term).or_insert(0) += 1;
+                            }
+                        });
                 }
             }
             FieldType::Str(text_options) => {
-                let mut token_streams: Vec<BoxTokenStream> = vec![];
-
                 for value in values {
                     match value {
                         Value::PreTokStr(tok_str) => {
-                            token_streams.push(PreTokenizedStream::from(tok_str.clone()).into());
+                            let mut token_stream: BoxTokenStream =
+                                PreTokenizedStream::from(tok_str.clone()).into();
+                            token_stream.process(&mut |token| {
+                                if !self.is_noise_word(token.text.clone()) {
+                                    let term = Term::from_field_text(field, &token.text);
+                                    *term_frequencies.entry(term).or_insert(0) += 1;
+                                }
+                            });
                         }
                         Value::Str(ref text) => {
-                            if let Some(tokenizer) = text_options
+                            if let Some(mut tokenizer) = text_options
                                 .get_indexing_options()
                                 .map(|text_indexing_options| {
                                     text_indexing_options.tokenizer().to_string()
                                 })
                                 .and_then(|tokenizer_name| tokenizer_manager.get(&tokenizer_name))
                             {
-                                token_streams.push(tokenizer.token_stream(text));
+                                let mut token_stream = tokenizer.token_stream(text);
+                                token_stream.process(&mut |token| {
+                                    if !self.is_noise_word(token.text.clone()) {
+                                        let term = Term::from_field_text(field, &token.text);
+                                        *term_frequencies.entry(term).or_insert(0) += 1;
+                                    }
+                                });
                             }
                         }
                         _ => (),
                     }
-                }
-
-                for mut token_stream in token_streams {
-                    token_stream.process(&mut |token| {
-                        if !self.is_noise_word(token.text.clone()) {
-                            let term = Term::from_field_text(field, &token.text);
-                            *term_frequencies.entry(term).or_insert(0) += 1;
-                        }
-                    });
                 }
             }
             FieldType::U64(_) => {

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -145,7 +145,7 @@ impl Snippet {
 /// Fragments must be valid in the sense that `&text[fragment.start..fragment.stop]`\
 /// has to be a valid string.
 fn search_fragments(
-    tokenizer: &TextAnalyzer,
+    tokenizer: &mut TextAnalyzer,
     text: &str,
     terms: &BTreeMap<String, Score>,
     max_num_chars: usize,
@@ -370,8 +370,12 @@ impl SnippetGenerator {
 
     /// Generates a snippet for the given text.
     pub fn snippet(&self, text: &str) -> Snippet {
-        let fragment_candidates =
-            search_fragments(&self.tokenizer, text, &self.terms_text, self.max_num_chars);
+        let fragment_candidates = search_fragments(
+            &mut self.tokenizer.clone(),
+            text,
+            &self.terms_text,
+            self.max_num_chars,
+        );
         select_best_fragment_combination(&fragment_candidates[..], text)
     }
 }
@@ -408,7 +412,12 @@ Survey in 2016, 2017, and 2018."#;
             String::from("rust") => 1.0,
             String::from("language") => 0.9
         };
-        let fragments = search_fragments(&From::from(SimpleTokenizer), TEST_TEXT, &terms, 100);
+        let fragments = search_fragments(
+            &mut From::from(SimpleTokenizer::default()),
+            TEST_TEXT,
+            &terms,
+            100,
+        );
         assert_eq!(fragments.len(), 7);
         {
             let first = &fragments[0];
@@ -435,7 +444,12 @@ Survey in 2016, 2017, and 2018."#;
                 String::from("rust") =>1.0,
                 String::from("language") => 0.9
             };
-            let fragments = search_fragments(&From::from(SimpleTokenizer), TEST_TEXT, &terms, 20);
+            let fragments = search_fragments(
+                &mut From::from(SimpleTokenizer::default()),
+                TEST_TEXT,
+                &terms,
+                20,
+            );
             {
                 let first = &fragments[0];
                 assert_eq!(first.score, 1.0);
@@ -449,7 +463,12 @@ Survey in 2016, 2017, and 2018."#;
                 String::from("rust") =>0.9,
                 String::from("language") => 1.0
             };
-            let fragments = search_fragments(&From::from(SimpleTokenizer), TEST_TEXT, &terms, 20);
+            let fragments = search_fragments(
+                &mut From::from(SimpleTokenizer::default()),
+                TEST_TEXT,
+                &terms,
+                20,
+            );
             // assert_eq!(fragments.len(), 7);
             {
                 let first = &fragments[0];
@@ -468,7 +487,8 @@ Survey in 2016, 2017, and 2018."#;
         let mut terms = BTreeMap::new();
         terms.insert(String::from("c"), 1.0);
 
-        let fragments = search_fragments(&From::from(SimpleTokenizer), text, &terms, 3);
+        let fragments =
+            search_fragments(&mut From::from(SimpleTokenizer::default()), text, &terms, 3);
 
         assert_eq!(fragments.len(), 1);
         {
@@ -490,7 +510,8 @@ Survey in 2016, 2017, and 2018."#;
         let mut terms = BTreeMap::new();
         terms.insert(String::from("f"), 1.0);
 
-        let fragments = search_fragments(&From::from(SimpleTokenizer), text, &terms, 3);
+        let fragments =
+            search_fragments(&mut From::from(SimpleTokenizer::default()), text, &terms, 3);
 
         assert_eq!(fragments.len(), 2);
         {
@@ -513,7 +534,8 @@ Survey in 2016, 2017, and 2018."#;
         terms.insert(String::from("f"), 1.0);
         terms.insert(String::from("a"), 0.9);
 
-        let fragments = search_fragments(&From::from(SimpleTokenizer), text, &terms, 7);
+        let fragments =
+            search_fragments(&mut From::from(SimpleTokenizer::default()), text, &terms, 7);
 
         assert_eq!(fragments.len(), 2);
         {
@@ -535,7 +557,8 @@ Survey in 2016, 2017, and 2018."#;
         let mut terms = BTreeMap::new();
         terms.insert(String::from("z"), 1.0);
 
-        let fragments = search_fragments(&From::from(SimpleTokenizer), text, &terms, 3);
+        let fragments =
+            search_fragments(&mut From::from(SimpleTokenizer::default()), text, &terms, 3);
 
         assert_eq!(fragments.len(), 0);
 
@@ -550,7 +573,8 @@ Survey in 2016, 2017, and 2018."#;
         let text = "a b c d";
 
         let terms = BTreeMap::new();
-        let fragments = search_fragments(&From::from(SimpleTokenizer), text, &terms, 3);
+        let fragments =
+            search_fragments(&mut From::from(SimpleTokenizer::default()), text, &terms, 3);
         assert_eq!(fragments.len(), 0);
 
         let snippet = select_best_fragment_combination(&fragments[..], text);
@@ -669,7 +693,7 @@ Survey in 2016, 2017, and 2018."#;
         terms.insert(String::from("bc"), 1.0);
 
         let fragments = search_fragments(
-            &From::from(NgramTokenizer::all_ngrams(2, 2)),
+            &mut From::from(NgramTokenizer::all_ngrams(2, 2)),
             text,
             &terms,
             3,
@@ -691,7 +715,12 @@ Survey in 2016, 2017, and 2018."#;
     #[test]
     fn test_snippet_generator_custom_highlighted_elements() {
         let terms = btreemap! { String::from("rust") => 1.0, String::from("language") => 0.9 };
-        let fragments = search_fragments(&From::from(SimpleTokenizer), TEST_TEXT, &terms, 100);
+        let fragments = search_fragments(
+            &mut From::from(SimpleTokenizer::default()),
+            TEST_TEXT,
+            &terms,
+            100,
+        );
         let mut snippet = select_best_fragment_combination(&fragments[..], TEST_TEXT);
         assert_eq!(
             snippet.to_html(),

--- a/src/tokenizer/alphanum_only.rs
+++ b/src/tokenizer/alphanum_only.rs
@@ -50,9 +50,9 @@ impl TokenFilter for AlphaNumOnlyFilter {
 pub struct AlphaNumOnlyFilterWrapper<T>(T);
 
 impl<T: Tokenizer> Tokenizer for AlphaNumOnlyFilterWrapper<T> {
-    type TokenStream<'a, 'b> = AlphaNumOnlyFilterStream<T::TokenStream<'a, 'b>>;
+    type TokenStream<'a> = AlphaNumOnlyFilterStream<T::TokenStream<'a>>;
 
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
         AlphaNumOnlyFilterStream {
             tail: self.0.token_stream(text),
         }

--- a/src/tokenizer/alphanum_only.rs
+++ b/src/tokenizer/alphanum_only.rs
@@ -2,7 +2,7 @@
 //! ```rust
 //! use tantivy::tokenizer::*;
 //!
-//! let tokenizer = TextAnalyzer::builder(RawTokenizer)
+//! let mut tokenizer = TextAnalyzer::builder(RawTokenizer::default())
 //!   .filter(AlphaNumOnlyFilter)
 //!   .build();
 //!
@@ -11,7 +11,7 @@
 //! // contains a space
 //! assert!(stream.next().is_none());
 //!
-//! let tokenizer = TextAnalyzer::builder(SimpleTokenizer)
+//! let mut tokenizer = TextAnalyzer::builder(SimpleTokenizer::default())
 //!   .filter(AlphaNumOnlyFilter)
 //!   .build();
 //!
@@ -50,9 +50,9 @@ impl TokenFilter for AlphaNumOnlyFilter {
 pub struct AlphaNumOnlyFilterWrapper<T>(T);
 
 impl<T: Tokenizer> Tokenizer for AlphaNumOnlyFilterWrapper<T> {
-    type TokenStream<'a> = AlphaNumOnlyFilterStream<T::TokenStream<'a>>;
+    type TokenStream<'a, 'b> = AlphaNumOnlyFilterStream<T::TokenStream<'a, 'b>>;
 
-    fn token_stream<'a>(&self, text: &'a str) -> Self::TokenStream<'a> {
+    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
         AlphaNumOnlyFilterStream {
             tail: self.0.token_stream(text),
         }
@@ -96,7 +96,7 @@ mod tests {
     }
 
     fn token_stream_helper(text: &str) -> Vec<Token> {
-        let a = TextAnalyzer::builder(SimpleTokenizer)
+        let mut a = TextAnalyzer::builder(SimpleTokenizer::default())
             .filter(AlphaNumOnlyFilter)
             .build();
         let mut token_stream = a.token_stream(text);

--- a/src/tokenizer/ascii_folding_filter.rs
+++ b/src/tokenizer/ascii_folding_filter.rs
@@ -20,9 +20,9 @@ impl TokenFilter for AsciiFoldingFilter {
 pub struct AsciiFoldingFilterWrapper<T>(T);
 
 impl<T: Tokenizer> Tokenizer for AsciiFoldingFilterWrapper<T> {
-    type TokenStream<'a> = AsciiFoldingFilterTokenStream<T::TokenStream<'a>>;
+    type TokenStream<'a, 'b> = AsciiFoldingFilterTokenStream<T::TokenStream<'a, 'b>>;
 
-    fn token_stream<'a>(&self, text: &'a str) -> Self::TokenStream<'a> {
+    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
         AsciiFoldingFilterTokenStream {
             buffer: String::with_capacity(100),
             tail: self.0.token_stream(text),
@@ -1573,7 +1573,7 @@ mod tests {
 
     fn folding_helper(text: &str) -> Vec<String> {
         let mut tokens = Vec::new();
-        TextAnalyzer::builder(SimpleTokenizer)
+        TextAnalyzer::builder(SimpleTokenizer::default())
             .filter(AsciiFoldingFilter)
             .build()
             .token_stream(text)
@@ -1584,10 +1584,10 @@ mod tests {
     }
 
     fn folding_using_raw_tokenizer_helper(text: &str) -> String {
-        let mut token_stream = TextAnalyzer::builder(RawTokenizer)
+        let mut tokenizer = TextAnalyzer::builder(RawTokenizer::default())
             .filter(AsciiFoldingFilter)
-            .build()
-            .token_stream(text);
+            .build();
+        let mut token_stream = tokenizer.token_stream(text);
         token_stream.advance();
         token_stream.token().text.clone()
     }

--- a/src/tokenizer/ascii_folding_filter.rs
+++ b/src/tokenizer/ascii_folding_filter.rs
@@ -20,9 +20,9 @@ impl TokenFilter for AsciiFoldingFilter {
 pub struct AsciiFoldingFilterWrapper<T>(T);
 
 impl<T: Tokenizer> Tokenizer for AsciiFoldingFilterWrapper<T> {
-    type TokenStream<'a, 'b> = AsciiFoldingFilterTokenStream<T::TokenStream<'a, 'b>>;
+    type TokenStream<'a> = AsciiFoldingFilterTokenStream<T::TokenStream<'a>>;
 
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
         AsciiFoldingFilterTokenStream {
             buffer: String::with_capacity(100),
             tail: self.0.token_stream(text),

--- a/src/tokenizer/empty_tokenizer.rs
+++ b/src/tokenizer/empty_tokenizer.rs
@@ -4,7 +4,7 @@ use crate::tokenizer::{Token, TokenStream, Tokenizer};
 pub(crate) struct EmptyTokenizer;
 
 impl Tokenizer for EmptyTokenizer {
-    type TokenStream<'a, 'b> = EmptyTokenStream;
+    type TokenStream<'a> = EmptyTokenStream;
     fn token_stream(&mut self, _text: &str) -> EmptyTokenStream {
         EmptyTokenStream::default()
     }

--- a/src/tokenizer/empty_tokenizer.rs
+++ b/src/tokenizer/empty_tokenizer.rs
@@ -4,8 +4,8 @@ use crate::tokenizer::{Token, TokenStream, Tokenizer};
 pub(crate) struct EmptyTokenizer;
 
 impl Tokenizer for EmptyTokenizer {
-    type TokenStream<'a> = EmptyTokenStream;
-    fn token_stream(&self, _text: &str) -> EmptyTokenStream {
+    type TokenStream<'a, 'b> = EmptyTokenStream;
+    fn token_stream(&mut self, _text: &str) -> EmptyTokenStream {
         EmptyTokenStream::default()
     }
 }
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn test_empty_tokenizer() {
-        let tokenizer = super::EmptyTokenizer;
+        let mut tokenizer = super::EmptyTokenizer;
         let mut empty = tokenizer.token_stream("whatever string");
         assert!(!empty.advance());
     }

--- a/src/tokenizer/facet_tokenizer.rs
+++ b/src/tokenizer/facet_tokenizer.rs
@@ -21,15 +21,15 @@ enum State {
     Terminated,
 }
 
-pub struct FacetTokenStream<'a, 'b> {
+pub struct FacetTokenStream<'a> {
     text: &'a str,
     state: State,
-    token: &'b mut Token,
+    token: &'a mut Token,
 }
 
 impl Tokenizer for FacetTokenizer {
-    type TokenStream<'a, 'b> = FacetTokenStream<'a, 'b>;
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> FacetTokenStream<'a, 'b> {
+    type TokenStream<'a> = FacetTokenStream<'a>;
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> FacetTokenStream<'a> {
         self.token.reset();
         self.token.position = 0;
         FacetTokenStream {
@@ -40,7 +40,7 @@ impl Tokenizer for FacetTokenizer {
     }
 }
 
-impl<'a, 'b> TokenStream for FacetTokenStream<'a, 'b> {
+impl<'a> TokenStream for FacetTokenStream<'a> {
     fn advance(&mut self) -> bool {
         match self.state {
             State::RootFacetNotEmitted => {

--- a/src/tokenizer/facet_tokenizer.rs
+++ b/src/tokenizer/facet_tokenizer.rs
@@ -9,8 +9,10 @@ use crate::schema::FACET_SEP_BYTE;
 ///     - `/america/north_america/canada`
 ///     - `/america/north_america`
 ///     - `/america`
-#[derive(Clone)]
-pub struct FacetTokenizer;
+#[derive(Clone, Default)]
+pub struct FacetTokenizer {
+    token: Token,
+}
 
 #[derive(Debug)]
 enum State {
@@ -19,28 +21,26 @@ enum State {
     Terminated,
 }
 
-pub struct FacetTokenStream<'a> {
+pub struct FacetTokenStream<'a, 'b> {
     text: &'a str,
     state: State,
-    token: Token,
+    token: &'b mut Token,
 }
 
 impl Tokenizer for FacetTokenizer {
-    type TokenStream<'a> = FacetTokenStream<'a>;
-    fn token_stream<'a>(&self, text: &'a str) -> FacetTokenStream<'a> {
-        let token = Token {
-            position: 0,
-            ..Default::default()
-        };
+    type TokenStream<'a, 'b> = FacetTokenStream<'a, 'b>;
+    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> FacetTokenStream<'a, 'b> {
+        self.token.reset();
+        self.token.position = 0;
         FacetTokenStream {
             text,
             state: State::RootFacetNotEmitted, //< pos is the first char that has not been processed yet.
-            token,
+            token: &mut self.token,
         }
     }
 }
 
-impl<'a> TokenStream for FacetTokenStream<'a> {
+impl<'a, 'b> TokenStream for FacetTokenStream<'a, 'b> {
     fn advance(&mut self) -> bool {
         match self.state {
             State::RootFacetNotEmitted => {
@@ -74,11 +74,11 @@ impl<'a> TokenStream for FacetTokenStream<'a> {
     }
 
     fn token(&self) -> &Token {
-        &self.token
+        self.token
     }
 
     fn token_mut(&mut self) -> &mut Token {
-        &mut self.token
+        self.token
     }
 }
 
@@ -98,7 +98,7 @@ mod tests {
                 let facet = Facet::from_encoded(token.text.as_bytes().to_owned()).unwrap();
                 tokens.push(format!("{}", facet));
             };
-            FacetTokenizer
+            FacetTokenizer::default()
                 .token_stream(facet.encoded_str())
                 .process(&mut add_token);
         }
@@ -118,7 +118,7 @@ mod tests {
                 let facet = Facet::from_encoded(token.text.as_bytes().to_owned()).unwrap(); // ok test
                 tokens.push(format!("{}", facet));
             };
-            FacetTokenizer
+            FacetTokenizer::default()
                 .token_stream(facet.encoded_str()) // ok test
                 .process(&mut add_token);
         }

--- a/src/tokenizer/lower_caser.rs
+++ b/src/tokenizer/lower_caser.rs
@@ -18,9 +18,9 @@ impl TokenFilter for LowerCaser {
 pub struct LowerCaserFilter<T>(T);
 
 impl<T: Tokenizer> Tokenizer for LowerCaserFilter<T> {
-    type TokenStream<'a, 'b> = LowerCaserTokenStream<T::TokenStream<'a, 'b>>;
+    type TokenStream<'a> = LowerCaserTokenStream<T::TokenStream<'a>>;
 
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
         LowerCaserTokenStream {
             tail: self.0.token_stream(text),
             buffer: String::new(), // TODO move to global buffer

--- a/src/tokenizer/lower_caser.rs
+++ b/src/tokenizer/lower_caser.rs
@@ -18,12 +18,12 @@ impl TokenFilter for LowerCaser {
 pub struct LowerCaserFilter<T>(T);
 
 impl<T: Tokenizer> Tokenizer for LowerCaserFilter<T> {
-    type TokenStream<'a> = LowerCaserTokenStream<T::TokenStream<'a>>;
+    type TokenStream<'a, 'b> = LowerCaserTokenStream<T::TokenStream<'a, 'b>>;
 
-    fn token_stream<'a>(&self, text: &'a str) -> Self::TokenStream<'a> {
+    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
         LowerCaserTokenStream {
             tail: self.0.token_stream(text),
-            buffer: String::new(),
+            buffer: String::new(), // TODO move to global buffer
         }
     }
 }
@@ -86,10 +86,11 @@ mod tests {
     }
 
     fn token_stream_helper(text: &str) -> Vec<Token> {
-        let mut token_stream = TextAnalyzer::builder(SimpleTokenizer)
+        let mut token_stream = TextAnalyzer::builder(SimpleTokenizer::default())
             .filter(LowerCaser)
-            .build()
-            .token_stream(text);
+            .build();
+
+        let mut token_stream = token_stream.token_stream(text);
         let mut tokens = vec![];
         let mut add_token = |token: &Token| {
             tokens.push(token.clone());

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -66,7 +66,7 @@
 //! ```rust
 //! use tantivy::tokenizer::*;
 //!
-//! let en_stem = TextAnalyzer::builder(SimpleTokenizer)
+//! let en_stem = TextAnalyzer::builder(SimpleTokenizer::default())
 //!     .filter(RemoveLongFilter::limit(40))
 //!     .filter(LowerCaser)
 //!     .filter(Stemmer::new(Language::English))
@@ -81,7 +81,7 @@
 //! # use tantivy::tokenizer::*;
 //! # use tantivy::Index;
 //! #
-//! let custom_en_tokenizer = SimpleTokenizer;
+//! let custom_en_tokenizer = SimpleTokenizer::default();
 //! # let schema = Schema::builder().build();
 //! let index = Index::create_in_ram(schema);
 //! index.tokenizers()
@@ -113,7 +113,7 @@
 //! let index = Index::create_in_ram(schema);
 //!
 //! // We need to register our tokenizer :
-//! let custom_en_tokenizer = TextAnalyzer::builder(SimpleTokenizer)
+//! let custom_en_tokenizer = TextAnalyzer::builder(SimpleTokenizer::default())
 //!     .filter(RemoveLongFilter::limit(40))
 //!     .filter(LowerCaser)
 //!     .build();
@@ -188,9 +188,9 @@ pub mod tests {
     }
 
     #[test]
-    fn test_raw_tokenizer() {
+    fn test_raw_tokenizer2() {
         let tokenizer_manager = TokenizerManager::default();
-        let en_tokenizer = tokenizer_manager.get("raw").unwrap();
+        let mut en_tokenizer = tokenizer_manager.get("raw").unwrap();
         let mut tokens: Vec<Token> = vec![];
         {
             let mut add_token = |token: &Token| {
@@ -208,7 +208,7 @@ pub mod tests {
     fn test_en_tokenizer() {
         let tokenizer_manager = TokenizerManager::default();
         assert!(tokenizer_manager.get("en_doesnotexist").is_none());
-        let en_tokenizer = tokenizer_manager.get("en_stem").unwrap();
+        let mut en_tokenizer = tokenizer_manager.get("en_stem").unwrap();
         let mut tokens: Vec<Token> = vec![];
         {
             let mut add_token = |token: &Token| {
@@ -231,13 +231,13 @@ pub mod tests {
         let tokenizer_manager = TokenizerManager::default();
         tokenizer_manager.register(
             "el_stem",
-            TextAnalyzer::builder(SimpleTokenizer)
+            TextAnalyzer::builder(SimpleTokenizer::default())
                 .filter(RemoveLongFilter::limit(40))
                 .filter(LowerCaser)
                 .filter(Stemmer::new(Language::Greek))
                 .build(),
         );
-        let en_tokenizer = tokenizer_manager.get("el_stem").unwrap();
+        let mut en_tokenizer = tokenizer_manager.get("el_stem").unwrap();
         let mut tokens: Vec<Token> = vec![];
         {
             let mut add_token = |token: &Token| {
@@ -257,7 +257,7 @@ pub mod tests {
     #[test]
     fn test_tokenizer_empty() {
         let tokenizer_manager = TokenizerManager::default();
-        let en_tokenizer = tokenizer_manager.get("en_stem").unwrap();
+        let mut en_tokenizer = tokenizer_manager.get("en_stem").unwrap();
         {
             let mut tokens: Vec<Token> = vec![];
             {
@@ -283,7 +283,7 @@ pub mod tests {
     #[test]
     fn test_whitespace_tokenizer() {
         let tokenizer_manager = TokenizerManager::default();
-        let ws_tokenizer = tokenizer_manager.get("whitespace").unwrap();
+        let mut ws_tokenizer = tokenizer_manager.get("whitespace").unwrap();
         let mut tokens: Vec<Token> = vec![];
         {
             let mut add_token = |token: &Token| {

--- a/src/tokenizer/ngram_tokenizer.rs
+++ b/src/tokenizer/ngram_tokenizer.rs
@@ -121,7 +121,7 @@ impl NgramTokenizer {
 }
 
 /// TokenStream associate to the `NgramTokenizer`
-pub struct NgramTokenStream<'a, 'b> {
+pub struct NgramTokenStream<'a> {
     /// parameters
     ngram_charidx_iterator: StutteringIterator<CodepointFrontiers<'a>>,
     /// true if the NgramTokenStream is in prefix mode.
@@ -129,12 +129,12 @@ pub struct NgramTokenStream<'a, 'b> {
     /// input
     text: &'a str,
     /// output
-    token: &'b mut Token,
+    token: &'a mut Token,
 }
 
 impl Tokenizer for NgramTokenizer {
-    type TokenStream<'a, 'b> = NgramTokenStream<'a, 'b>;
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> NgramTokenStream<'a, 'b> {
+    type TokenStream<'a> = NgramTokenStream<'a>;
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> NgramTokenStream<'a> {
         self.token.reset();
         NgramTokenStream {
             ngram_charidx_iterator: StutteringIterator::new(
@@ -149,7 +149,7 @@ impl Tokenizer for NgramTokenizer {
     }
 }
 
-impl<'a, 'b> TokenStream for NgramTokenStream<'a, 'b> {
+impl<'a> TokenStream for NgramTokenStream<'a> {
     fn advance(&mut self) -> bool {
         if let Some((offset_from, offset_to)) = self.ngram_charidx_iterator.next() {
             if self.prefix_only && offset_from > 0 {

--- a/src/tokenizer/raw_tokenizer.rs
+++ b/src/tokenizer/raw_tokenizer.rs
@@ -12,7 +12,7 @@ pub struct RawTokenStream<'a> {
 }
 
 impl Tokenizer for RawTokenizer {
-    type TokenStream<'b, 'a> = RawTokenStream<'a>;
+    type TokenStream<'a> = RawTokenStream<'a>;
     fn token_stream<'a>(&'a mut self, text: &str) -> RawTokenStream<'a> {
         self.token.reset();
         self.token.position = 0;

--- a/src/tokenizer/regex_tokenizer.rs
+++ b/src/tokenizer/regex_tokenizer.rs
@@ -64,8 +64,8 @@ impl RegexTokenizer {
 }
 
 impl Tokenizer for RegexTokenizer {
-    type TokenStream<'a, 'b> = RegexTokenStream<'a, 'b>;
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> RegexTokenStream<'a, 'b> {
+    type TokenStream<'a> = RegexTokenStream<'a>;
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> RegexTokenStream<'a> {
         self.token.reset();
         RegexTokenStream {
             regex: self.regex.clone(),
@@ -76,14 +76,14 @@ impl Tokenizer for RegexTokenizer {
     }
 }
 
-pub struct RegexTokenStream<'a, 'b> {
+pub struct RegexTokenStream<'a> {
     regex: Regex,
     text: &'a str,
-    token: &'b mut Token,
+    token: &'a mut Token,
     cursor: usize,
 }
 
-impl<'a, 'b> TokenStream for RegexTokenStream<'a, 'b> {
+impl<'a> TokenStream for RegexTokenStream<'a> {
     fn advance(&mut self) -> bool {
         let Some(regex_match) = self.regex.find(self.text) else {
             return false;
@@ -105,11 +105,11 @@ impl<'a, 'b> TokenStream for RegexTokenStream<'a, 'b> {
     }
 
     fn token(&self) -> &Token {
-        &self.token
+        self.token
     }
 
     fn token_mut(&mut self) -> &mut Token {
-        &mut self.token
+        self.token
     }
 }
 

--- a/src/tokenizer/remove_long.rs
+++ b/src/tokenizer/remove_long.rs
@@ -2,7 +2,7 @@
 //! ```rust
 //! use tantivy::tokenizer::*;
 //!
-//! let tokenizer = TextAnalyzer::builder(SimpleTokenizer)
+//! let mut tokenizer = TextAnalyzer::builder(SimpleTokenizer::default())
 //!   .filter(RemoveLongFilter::limit(5))
 //!   .build();
 //!
@@ -55,9 +55,9 @@ pub struct RemoveLongFilterWrapper<T: Tokenizer> {
 }
 
 impl<T: Tokenizer> Tokenizer for RemoveLongFilterWrapper<T> {
-    type TokenStream<'a> = RemoveLongFilterStream<T::TokenStream<'a>>;
+    type TokenStream<'a, 'b> = RemoveLongFilterStream<T::TokenStream<'a, 'b>>;
 
-    fn token_stream<'a>(&self, text: &'a str) -> Self::TokenStream<'a> {
+    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
         RemoveLongFilterStream {
             token_length_limit: self.length_limit,
             tail: self.inner.token_stream(text),
@@ -103,7 +103,7 @@ mod tests {
     }
 
     fn token_stream_helper(text: &str) -> Vec<Token> {
-        let a = TextAnalyzer::builder(SimpleTokenizer)
+        let mut a = TextAnalyzer::builder(SimpleTokenizer::default())
             .filter(RemoveLongFilter::limit(6))
             .build();
         let mut token_stream = a.token_stream(text);

--- a/src/tokenizer/remove_long.rs
+++ b/src/tokenizer/remove_long.rs
@@ -55,9 +55,9 @@ pub struct RemoveLongFilterWrapper<T: Tokenizer> {
 }
 
 impl<T: Tokenizer> Tokenizer for RemoveLongFilterWrapper<T> {
-    type TokenStream<'a, 'b> = RemoveLongFilterStream<T::TokenStream<'a, 'b>>;
+    type TokenStream<'a> = RemoveLongFilterStream<T::TokenStream<'a>>;
 
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
         RemoveLongFilterStream {
             token_length_limit: self.length_limit,
             tail: self.inner.token_stream(text),

--- a/src/tokenizer/simple_tokenizer.rs
+++ b/src/tokenizer/simple_tokenizer.rs
@@ -9,15 +9,15 @@ pub struct SimpleTokenizer {
 }
 
 /// TokenStream produced by the `SimpleTokenizer`.
-pub struct SimpleTokenStream<'a, 'b> {
+pub struct SimpleTokenStream<'a> {
     text: &'a str,
     chars: CharIndices<'a>,
-    token: &'b mut Token,
+    token: &'a mut Token,
 }
 
 impl Tokenizer for SimpleTokenizer {
-    type TokenStream<'a, 'b> = SimpleTokenStream<'a, 'b>;
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> SimpleTokenStream<'a, 'b> {
+    type TokenStream<'a> = SimpleTokenStream<'a>;
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> SimpleTokenStream<'a> {
         self.token.reset();
         SimpleTokenStream {
             text,
@@ -27,7 +27,7 @@ impl Tokenizer for SimpleTokenizer {
     }
 }
 
-impl<'a, 'b> SimpleTokenStream<'a, 'b> {
+impl<'a> SimpleTokenStream<'a> {
     // search for the end of the current token.
     fn search_token_end(&mut self) -> usize {
         (&mut self.chars)
@@ -38,7 +38,7 @@ impl<'a, 'b> SimpleTokenStream<'a, 'b> {
     }
 }
 
-impl<'a, 'b> TokenStream for SimpleTokenStream<'a, 'b> {
+impl<'a> TokenStream for SimpleTokenStream<'a> {
     fn advance(&mut self) -> bool {
         self.token.text.clear();
         self.token.position = self.token.position.wrapping_add(1);

--- a/src/tokenizer/split_compound_words.rs
+++ b/src/tokenizer/split_compound_words.rs
@@ -20,8 +20,8 @@ use super::{Token, TokenFilter, TokenStream, Tokenizer};
 /// ```rust
 /// use tantivy::tokenizer::{SimpleTokenizer, SplitCompoundWords, TextAnalyzer};
 ///
-/// let tokenizer =
-///        TextAnalyzer::builder(SimpleTokenizer)
+/// let mut tokenizer =
+///        TextAnalyzer::builder(SimpleTokenizer::default())
 ///        .filter(
 ///            SplitCompoundWords::from_dictionary([
 ///                 "dampf", "schiff", "fahrt", "brot", "backen", "automat",
@@ -29,13 +29,13 @@ use super::{Token, TokenFilter, TokenStream, Tokenizer};
 ///            .unwrap()
 ///        )
 ///        .build();
-///
-/// let mut stream = tokenizer.token_stream("dampfschifffahrt");
-/// assert_eq!(stream.next().unwrap().text, "dampf");
-/// assert_eq!(stream.next().unwrap().text, "schiff");
-/// assert_eq!(stream.next().unwrap().text, "fahrt");
-/// assert_eq!(stream.next(), None);
-///
+/// {
+///     let mut stream = tokenizer.token_stream("dampfschifffahrt");
+///     assert_eq!(stream.next().unwrap().text, "dampf");
+///     assert_eq!(stream.next().unwrap().text, "schiff");
+///     assert_eq!(stream.next().unwrap().text, "fahrt");
+///     assert_eq!(stream.next(), None);
+/// }
 /// let mut stream = tokenizer.token_stream("brotbackautomat");
 /// assert_eq!(stream.next().unwrap().text, "brotbackautomat");
 /// assert_eq!(stream.next(), None);
@@ -97,9 +97,9 @@ pub struct SplitCompoundWordsFilter<T> {
 }
 
 impl<T: Tokenizer> Tokenizer for SplitCompoundWordsFilter<T> {
-    type TokenStream<'a> = SplitCompoundWordsTokenStream<T::TokenStream<'a>>;
+    type TokenStream<'a, 'b> = SplitCompoundWordsTokenStream<T::TokenStream<'a, 'b>>;
 
-    fn token_stream<'a>(&self, text: &'a str) -> Self::TokenStream<'a> {
+    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
         SplitCompoundWordsTokenStream {
             dict: self.dict.clone(),
             tail: self.inner.token_stream(text),
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn splitting_compound_words_works() {
-        let tokenizer = TextAnalyzer::builder(SimpleTokenizer)
+        let mut tokenizer = TextAnalyzer::builder(SimpleTokenizer::default())
             .filter(SplitCompoundWords::from_dictionary(["foo", "bar"]).unwrap())
             .build();
 

--- a/src/tokenizer/split_compound_words.rs
+++ b/src/tokenizer/split_compound_words.rs
@@ -97,9 +97,9 @@ pub struct SplitCompoundWordsFilter<T> {
 }
 
 impl<T: Tokenizer> Tokenizer for SplitCompoundWordsFilter<T> {
-    type TokenStream<'a, 'b> = SplitCompoundWordsTokenStream<T::TokenStream<'a, 'b>>;
+    type TokenStream<'a> = SplitCompoundWordsTokenStream<T::TokenStream<'a>>;
 
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
         SplitCompoundWordsTokenStream {
             dict: self.dict.clone(),
             tail: self.inner.token_stream(text),

--- a/src/tokenizer/stemmer.rs
+++ b/src/tokenizer/stemmer.rs
@@ -98,9 +98,9 @@ pub struct StemmerFilter<T> {
 }
 
 impl<T: Tokenizer> Tokenizer for StemmerFilter<T> {
-    type TokenStream<'a, 'b> = StemmerTokenStream<T::TokenStream<'a, 'b>>;
+    type TokenStream<'a> = StemmerTokenStream<T::TokenStream<'a>>;
 
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
         let stemmer = rust_stemmers::Stemmer::create(self.stemmer_algorithm);
         StemmerTokenStream {
             tail: self.inner.token_stream(text),

--- a/src/tokenizer/stemmer.rs
+++ b/src/tokenizer/stemmer.rs
@@ -98,9 +98,9 @@ pub struct StemmerFilter<T> {
 }
 
 impl<T: Tokenizer> Tokenizer for StemmerFilter<T> {
-    type TokenStream<'a> = StemmerTokenStream<T::TokenStream<'a>>;
+    type TokenStream<'a, 'b> = StemmerTokenStream<T::TokenStream<'a, 'b>>;
 
-    fn token_stream<'a>(&self, text: &'a str) -> Self::TokenStream<'a> {
+    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
         let stemmer = rust_stemmers::Stemmer::create(self.stemmer_algorithm);
         StemmerTokenStream {
             tail: self.inner.token_stream(text),

--- a/src/tokenizer/stop_word_filter/mod.rs
+++ b/src/tokenizer/stop_word_filter/mod.rs
@@ -2,7 +2,7 @@
 //! ```rust
 //! use tantivy::tokenizer::*;
 //!
-//! let tokenizer = TextAnalyzer::builder(SimpleTokenizer)
+//! let mut tokenizer = TextAnalyzer::builder(SimpleTokenizer::default())
 //!   .filter(StopWordFilter::remove(vec!["the".to_string(), "is".to_string()]))
 //!   .build();
 //!
@@ -88,9 +88,9 @@ pub struct StopWordFilterWrapper<T> {
 }
 
 impl<T: Tokenizer> Tokenizer for StopWordFilterWrapper<T> {
-    type TokenStream<'a> = StopWordFilterStream<T::TokenStream<'a>>;
+    type TokenStream<'a, 'b> = StopWordFilterStream<T::TokenStream<'a, 'b>>;
 
-    fn token_stream<'a>(&self, text: &'a str) -> Self::TokenStream<'a> {
+    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
         StopWordFilterStream {
             words: self.words.clone(),
             tail: self.inner.token_stream(text),
@@ -151,7 +151,7 @@ mod tests {
             "am".to_string(),
             "i".to_string(),
         ];
-        let a = TextAnalyzer::builder(SimpleTokenizer)
+        let mut a = TextAnalyzer::builder(SimpleTokenizer::default())
             .filter(StopWordFilter::remove(stops))
             .build();
         let mut token_stream = a.token_stream(text);

--- a/src/tokenizer/stop_word_filter/mod.rs
+++ b/src/tokenizer/stop_word_filter/mod.rs
@@ -88,9 +88,9 @@ pub struct StopWordFilterWrapper<T> {
 }
 
 impl<T: Tokenizer> Tokenizer for StopWordFilterWrapper<T> {
-    type TokenStream<'a, 'b> = StopWordFilterStream<T::TokenStream<'a, 'b>>;
+    type TokenStream<'a> = StopWordFilterStream<T::TokenStream<'a>>;
 
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b> {
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
         StopWordFilterStream {
             words: self.words.clone(),
             tail: self.inner.token_stream(text),

--- a/src/tokenizer/tokenizer.rs
+++ b/src/tokenizer/tokenizer.rs
@@ -12,13 +12,13 @@ pub struct TextAnalyzer {
 /// A boxable `Tokenizer`, with its `TokenStream` type erased.
 trait BoxableTokenizer: 'static + Send + Sync {
     /// Creates a boxed token stream for a given `str`.
-    fn box_token_stream<'a, 'b: 'a>(&'b mut self, text: &'a str) -> BoxTokenStream<'a>;
+    fn box_token_stream<'a>(&'a mut self, text: &'a str) -> BoxTokenStream<'a>;
     /// Clone this tokenizer.
     fn box_clone(&self) -> Box<dyn BoxableTokenizer>;
 }
 
 impl<T: Tokenizer> BoxableTokenizer for T {
-    fn box_token_stream<'a, 'b: 'a>(&'b mut self, text: &'a str) -> BoxTokenStream<'a> {
+    fn box_token_stream<'a>(&'a mut self, text: &'a str) -> BoxTokenStream<'a> {
         self.token_stream(text).into()
     }
     fn box_clone(&self) -> Box<dyn BoxableTokenizer> {
@@ -53,7 +53,7 @@ impl TextAnalyzer {
     }
 
     /// Creates a token stream for a given `str`.
-    pub fn token_stream<'a, 'b: 'a>(&'b mut self, text: &'a str) -> BoxTokenStream<'a> {
+    pub fn token_stream<'a>(&'a mut self, text: &'a str) -> BoxTokenStream<'a> {
         self.tokenizer.box_token_stream(text)
     }
 }

--- a/src/tokenizer/tokenizer.rs
+++ b/src/tokenizer/tokenizer.rs
@@ -12,13 +12,13 @@ pub struct TextAnalyzer {
 /// A boxable `Tokenizer`, with its `TokenStream` type erased.
 trait BoxableTokenizer: 'static + Send + Sync {
     /// Creates a boxed token stream for a given `str`.
-    fn box_token_stream<'a>(&self, text: &'a str) -> BoxTokenStream<'a>;
+    fn box_token_stream<'a, 'b: 'a>(&'b mut self, text: &'a str) -> BoxTokenStream<'a>;
     /// Clone this tokenizer.
     fn box_clone(&self) -> Box<dyn BoxableTokenizer>;
 }
 
 impl<T: Tokenizer> BoxableTokenizer for T {
-    fn box_token_stream<'a>(&self, text: &'a str) -> BoxTokenStream<'a> {
+    fn box_token_stream<'a, 'b: 'a>(&'b mut self, text: &'a str) -> BoxTokenStream<'a> {
         self.token_stream(text).into()
     }
     fn box_clone(&self) -> Box<dyn BoxableTokenizer> {
@@ -53,7 +53,7 @@ impl TextAnalyzer {
     }
 
     /// Creates a token stream for a given `str`.
-    pub fn token_stream<'a>(&self, text: &'a str) -> BoxTokenStream<'a> {
+    pub fn token_stream<'a, 'b: 'a>(&'b mut self, text: &'a str) -> BoxTokenStream<'a> {
         self.tokenizer.box_token_stream(text)
     }
 }
@@ -71,7 +71,7 @@ impl<T: Tokenizer> TextAnalyzerBuilder<T> {
     /// ```rust
     /// use tantivy::tokenizer::*;
     ///
-    /// let en_stem = TextAnalyzer::builder(SimpleTokenizer)
+    /// let en_stem = TextAnalyzer::builder(SimpleTokenizer::default())
     ///     .filter(RemoveLongFilter::limit(40))
     ///     .filter(LowerCaser)
     ///     .filter(Stemmer::default())

--- a/src/tokenizer/tokenizer_manager.rs
+++ b/src/tokenizer/tokenizer_manager.rs
@@ -58,23 +58,23 @@ impl Default for TokenizerManager {
     /// the default pre-configured tokenizers of `tantivy`.
     fn default() -> TokenizerManager {
         let manager = TokenizerManager::new();
-        manager.register("raw", RawTokenizer);
+        manager.register("raw", RawTokenizer::default());
         manager.register(
             "default",
-            TextAnalyzer::builder(SimpleTokenizer)
+            TextAnalyzer::builder(SimpleTokenizer::default())
                 .filter(RemoveLongFilter::limit(40))
                 .filter(LowerCaser)
                 .build(),
         );
         manager.register(
             "en_stem",
-            TextAnalyzer::builder(SimpleTokenizer)
+            TextAnalyzer::builder(SimpleTokenizer::default())
                 .filter(RemoveLongFilter::limit(40))
                 .filter(LowerCaser)
                 .filter(Stemmer::new(Language::English))
                 .build(),
         );
-        manager.register("whitespace", WhitespaceTokenizer);
+        manager.register("whitespace", WhitespaceTokenizer::default());
         manager
     }
 }

--- a/src/tokenizer/whitespace_tokenizer.rs
+++ b/src/tokenizer/whitespace_tokenizer.rs
@@ -8,15 +8,15 @@ pub struct WhitespaceTokenizer {
     token: Token,
 }
 
-pub struct WhitespaceTokenStream<'a, 'b> {
+pub struct WhitespaceTokenStream<'a> {
     text: &'a str,
     chars: CharIndices<'a>,
-    token: &'b mut Token,
+    token: &'a mut Token,
 }
 
 impl Tokenizer for WhitespaceTokenizer {
-    type TokenStream<'a, 'b> = WhitespaceTokenStream<'a, 'b>;
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> WhitespaceTokenStream<'a, 'b> {
+    type TokenStream<'a> = WhitespaceTokenStream<'a>;
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> WhitespaceTokenStream<'a> {
         self.token.reset();
         WhitespaceTokenStream {
             text,
@@ -26,7 +26,7 @@ impl Tokenizer for WhitespaceTokenizer {
     }
 }
 
-impl<'a, 'b> WhitespaceTokenStream<'a, 'b> {
+impl<'a> WhitespaceTokenStream<'a> {
     // search for the end of the current token.
     fn search_token_end(&mut self) -> usize {
         (&mut self.chars)
@@ -37,7 +37,7 @@ impl<'a, 'b> WhitespaceTokenStream<'a, 'b> {
     }
 }
 
-impl<'a, 'b> TokenStream for WhitespaceTokenStream<'a, 'b> {
+impl<'a> TokenStream for WhitespaceTokenStream<'a> {
     fn advance(&mut self) -> bool {
         self.token.text.clear();
         self.token.position = self.token.position.wrapping_add(1);

--- a/tokenizer-api/src/lib.rs
+++ b/tokenizer-api/src/lib.rs
@@ -34,7 +34,7 @@ impl Default for Token {
             offset_from: 0,
             offset_to: 0,
             position: usize::MAX,
-            text: String::with_capacity(200),
+            text: String::new(),
             position_length: 1,
         }
     }

--- a/tokenizer-api/src/lib.rs
+++ b/tokenizer-api/src/lib.rs
@@ -40,13 +40,24 @@ impl Default for Token {
     }
 }
 
+impl Token {
+    /// reset to default
+    pub fn reset(&mut self) {
+        self.offset_from = 0;
+        self.offset_to = 0;
+        self.position = usize::MAX;
+        self.text.clear();
+        self.position_length = 1;
+    }
+}
+
 /// `Tokenizer` are in charge of splitting text into a stream of token
 /// before indexing.
 pub trait Tokenizer: 'static + Clone + Send + Sync {
     /// The token stream returned by this Tokenizer.
-    type TokenStream<'a>: TokenStream;
+    type TokenStream<'a, 'b>: TokenStream;
     /// Creates a token stream for a given `str`.
-    fn token_stream<'a>(&self, text: &'a str) -> Self::TokenStream<'a>;
+    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b>;
 }
 
 /// Simple wrapper of `Box<dyn TokenStream + 'a>`.

--- a/tokenizer-api/src/lib.rs
+++ b/tokenizer-api/src/lib.rs
@@ -55,9 +55,9 @@ impl Token {
 /// before indexing.
 pub trait Tokenizer: 'static + Clone + Send + Sync {
     /// The token stream returned by this Tokenizer.
-    type TokenStream<'a, 'b>: TokenStream;
+    type TokenStream<'a>: TokenStream;
     /// Creates a token stream for a given `str`.
-    fn token_stream<'a, 'b>(&'b mut self, text: &'a str) -> Self::TokenStream<'a, 'b>;
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a>;
 }
 
 /// Simple wrapper of `Box<dyn TokenStream + 'a>`.


### PR DESCRIPTION
Previously a new `Token` for each text encountered was created, which
contains `String::with_capacity(200)`
In the new API the token_stream gets mutable access to the tokenizer,
this allows state to be shared (in this PR Token is shared).
Ideally the allocation for the BoxTokenStream would also be removed, but
this may require some lifetime tricks.

https://github.com/quickwit-oss/tantivy/issues/1654