### PR TITLE
RFC: Use built-in StopWordFilter in the MoreLikeThis implementation

### DIFF
--- a/src/query/more_like_this/more_like_this.rs
+++ b/src/query/more_like_this/more_like_this.rs
@@ -5,7 +5,7 @@ use crate::query::bm25::idf;
 use crate::query::{BooleanQuery, BoostQuery, Occur, Query, TermQuery};
 use crate::schema::{Field, FieldType, IndexRecordOption, Term, Value};
 use crate::tokenizer::{
-    BoxTokenStream, FacetTokenizer, PreTokenizedStream, TokenStream, Tokenizer,
+    BoxTokenStream, FacetTokenizer, PreTokenizedStream, StopWordFilter, TokenStream, Tokenizer,
 };
 use crate::{DocAddress, Result, Searcher, TantivyError};
 
@@ -57,8 +57,8 @@ pub struct MoreLikeThis {
     pub max_word_length: Option<usize>,
     /// Boost factor to use when boosting the terms
     pub boost_factor: Option<f32>,
-    /// Current set of stop words.
-    pub stop_words: Vec<String>,
+    /// Filter for stop words.
+    pub stop_words: Option<StopWordFilter>,
 }
 
 impl Default for MoreLikeThis {
@@ -71,7 +71,7 @@ impl Default for MoreLikeThis {
             min_word_length: None,
             max_word_length: None,
             boost_factor: Some(1.0),
-            stop_words: vec![],
+            stop_words: None,
         }
     }
 }
@@ -299,7 +299,9 @@ impl MoreLikeThis {
         {
             return true;
         }
-        self.stop_words.contains(&word)
+        self.stop_words
+            .as_ref()
+            .map_or(false, |stop_words| stop_words.contains(&word))
     }
 
     /// Couputes the score for each term while ignoring not useful terms

--- a/src/tokenizer/stop_word_filter/mod.rs
+++ b/src/tokenizer/stop_word_filter/mod.rs
@@ -24,7 +24,7 @@ use super::Language;
 use super::{Token, TokenFilter, TokenStream, Tokenizer};
 
 /// `TokenFilter` that removes stop words from a token stream
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct StopWordFilter {
     words: Arc<FxHashSet<String>>,
 }
@@ -67,6 +67,10 @@ impl StopWordFilter {
         StopWordFilter {
             words: Arc::new(words.into_iter().collect()),
         }
+    }
+
+    pub(crate) fn contains(&self, word: &str) -> bool {
+        self.words.contains(word)
     }
 }
 


### PR DESCRIPTION
Regarding the implementation, this mainly replaces the linear search with a potentially much faster hash table look-up. (But it also introduces an unnecessary Arc layer.) Regarding API and ergonomics, this would allow using the built-in stop word filters when enabled.