### PR TITLE
Readding s in datetime precision variant names

### DIFF
--- a/common/src/datetime.rs
+++ b/common/src/datetime.rs
@@ -15,21 +15,12 @@ use time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
 pub enum DateTimePrecision {
     /// Second precision.
     #[default]
-    Second,
-    /// Millisecond precision.
-    Millisecond,
-    /// Microsecond precision.
-    Microsecond,
-    /// Nanosecond precision.
-    Nanosecond,
-    // TODO: Remove deprecated variants after 2 releases.
-    #[deprecated(since = "0.20.0", note = "Use `Second` instead")]
     Seconds,
-    #[deprecated(since = "0.20.0", note = "Use `Millisecond` instead")]
+    /// Millisecond precision.
     Milliseconds,
-    #[deprecated(since = "0.20.0", note = "Use `Microsecond` instead")]
+    /// Microsecond precision.
     Microseconds,
-    #[deprecated(since = "0.20.0", note = "Use `Nanosecond` instead")]
+    /// Nanosecond precision.
     Nanoseconds,
 }
 
@@ -156,16 +147,10 @@ impl DateTime {
     /// Truncates the microseconds value to the corresponding precision.
     pub fn truncate(self, precision: DateTimePrecision) -> Self {
         let truncated_timestamp_micros = match precision {
-            DateTimePrecision::Second | DateTimePrecision::Seconds => {
-                (self.timestamp_nanos / 1_000_000_000) * 1_000_000_000
-            }
-            DateTimePrecision::Millisecond | DateTimePrecision::Milliseconds => {
-                (self.timestamp_nanos / 1_000_000) * 1_000_000
-            }
-            DateTimePrecision::Microsecond | DateTimePrecision::Microseconds => {
-                (self.timestamp_nanos / 1_000) * 1_000
-            }
-            DateTimePrecision::Nanosecond | DateTimePrecision::Nanoseconds => self.timestamp_nanos,
+            DateTimePrecision::Seconds => (self.timestamp_nanos / 1_000_000_000) * 1_000_000_000,
+            DateTimePrecision::Milliseconds => (self.timestamp_nanos / 1_000_000) * 1_000_000,
+            DateTimePrecision::Microseconds => (self.timestamp_nanos / 1_000) * 1_000,
+            DateTimePrecision::Nanoseconds => self.timestamp_nanos,
         };
         Self {
             timestamp_nanos: truncated_timestamp_micros,
@@ -174,7 +159,7 @@ impl DateTime {
 }
 
 impl fmt::Debug for DateTime {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let utc_rfc3339 = self.into_utc().format(&Rfc3339).map_err(|_| fmt::Error)?;
         f.write_str(&utc_rfc3339)
     }

--- a/examples/date_time_field.rs
+++ b/examples/date_time_field.rs
@@ -13,7 +13,7 @@ fn main() -> tantivy::Result<()> {
     let opts = DateOptions::from(INDEXED)
         .set_stored()
         .set_fast()
-        .set_precision(tantivy::DateTimePrecision::Second);
+        .set_precision(tantivy::DateTimePrecision::Seconds);
     // Add `occurred_at` date field type
     let occurred_at = schema_builder.add_date_field("occurred_at", opts);
     let event_type = schema_builder.add_text_field("event", STRING | STORED);

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -686,12 +686,12 @@ mod tests {
         let mut schema_builder = Schema::builder();
         let date_field = schema_builder.add_date_field(
             "date",
-            DateOptions::from(FAST).set_precision(DateTimePrecision::Nanosecond),
+            DateOptions::from(FAST).set_precision(DateTimePrecision::Nanoseconds),
         );
         let multi_date_field = schema_builder.add_date_field(
             "multi_date",
             DateOptions::default()
-                .set_precision(DateTimePrecision::Nanosecond)
+                .set_precision(DateTimePrecision::Nanoseconds)
                 .set_fast(),
         );
         let schema = schema_builder.build();
@@ -862,9 +862,9 @@ mod tests {
 
     #[test]
     pub fn test_gcd_date() {
-        let size_prec_sec = test_gcd_date_with_codec(DateTimePrecision::Second);
+        let size_prec_sec = test_gcd_date_with_codec(DateTimePrecision::Seconds);
         assert!((1000 * 13 / 8..100 + 1000 * 13 / 8).contains(&size_prec_sec.get_bytes())); // 13 bits per val = ceil(log_2(number of seconds in 2hours);
-        let size_prec_micros = test_gcd_date_with_codec(DateTimePrecision::Microsecond);
+        let size_prec_micros = test_gcd_date_with_codec(DateTimePrecision::Microseconds);
         assert!((1000 * 33 / 8..100 + 1000 * 33 / 8).contains(&size_prec_micros.get_bytes()));
         // 33 bits per
         // val = ceil(log_2(number

--- a/src/schema/date_time_options.rs
+++ b/src/schema/date_time_options.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::schema::flags::{FastFlag, IndexedFlag, SchemaFlagList, StoredFlag};
 
 /// The precision of the indexed date/time values in the inverted index.
-pub const DATE_TIME_PRECISION_INDEXED: DateTimePrecision = DateTimePrecision::Second;
+pub const DATE_TIME_PRECISION_INDEXED: DateTimePrecision = DateTimePrecision::Seconds;
 
 /// Defines how DateTime field should be handled by tantivy.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -973,7 +973,7 @@ mod tests {
       "fieldnorms": true,
       "fast": true,
       "stored": true,
-      "precision": "second"
+      "precision": "seconds"
     }
   },
   {


### PR DESCRIPTION
There is no clear win and it change some serialization in quickwit.