### PR TITLE
Fix building on windows with mmap

### DIFF
--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock, Weak};
 use std::{fmt, result};
 
+use aho_corasick::Anchored::No;
 use common::StableDeref;
 use fs4::FileExt;
 use memmap2::Mmap;
@@ -105,6 +106,8 @@ impl MmapCache {
         MmapCache {
             counters: CacheCounters::default(),
             cache: HashMap::default(),
+            #[cfg(unix)]
+            madvice_opt: None,
         }
     }
 
@@ -192,7 +195,7 @@ impl MmapDirectoryInner {
 
     #[cfg(unix)]
     fn with_advice(&mut self, madvice_opt: Option<Advice>) {
-        self.mmap_cache.write().with_advice(madvice_opt)
+        self.mmap_cache.write().unwrap().with_advice(madvice_opt)
     }
 
     fn watch(&self, callback: WatchCallback) -> WatchHandle {

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -245,6 +245,8 @@ impl MmapDirectory {
 
     #[cfg(unix)]
     /// Opens a MmapDirectory in a directory, with a given access pattern.
+    ///
+    /// This is only supported on unix platforms.
     pub fn open_with_madvice<P: AsRef<Path>>(
         directory_path: P,
         madvice: Advice,

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock, Weak};
 use std::{fmt, result};
 
-use aho_corasick::Anchored::No;
 use common::StableDeref;
 use fs4::FileExt;
 use memmap2::Mmap;

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock, Weak};
 use std::{fmt, result};
 
+use aho_corasick::Anchored::No;
 use common::StableDeref;
 use fs4::FileExt;
 use memmap2::Mmap;
@@ -217,16 +218,11 @@ impl MmapDirectory {
     }
 
     #[cfg(unix)]
-    fn with_advice(
-        root_path: PathBuf,
-        temp_directory: Option<TempDir>,
-        madvice_opt: Option<Advice>,
-    ) {
-        let mut inner = MmapDirectoryInner::new(root_path, temp_directory);
-        inner.with_advice(madvice_opt);
-        MmapDirectory {
-            inner: Arc::new(inner),
-        }
+    /// Pass specific madvice flags when opening a new mmap file.
+    ///
+    /// This is only supported on unix platforms.
+    pub fn with_advice(&mut self, madvice_opt: Option<Advice>) {
+        self.inner.with_advice(madvice_opt)
     }
 
     /// Creates a new MmapDirectory in a temporary directory.
@@ -247,8 +243,7 @@ impl MmapDirectory {
     /// Returns an error if the `directory_path` does not
     /// exist or if it is not a directory.
     pub fn open<P: AsRef<Path>>(directory_path: P) -> Result<MmapDirectory, OpenDirectoryError> {
-        let canonical_path = Self::resolve_directory_path(directory_path.as_ref())?;
-        Ok(MmapDirectory::new(canonical_path, None))
+        Self::open_with_access_pattern_impl(directory_path.as_ref())
     }
 
     #[cfg(unix)]
@@ -259,15 +254,14 @@ impl MmapDirectory {
         directory_path: P,
         madvice: Advice,
     ) -> Result<MmapDirectory, OpenDirectoryError> {
-        let canonical_path = Self::resolve_directory_path(directory_path.as_ref())?;
-        Ok(MmapDirectory::with_advice(
-            canonical_path,
-            None,
-            madvice_opt,
-        ))
+        let dir = Self::open_with_access_pattern_impl(directory_path.as_ref())?;
+        dir.with_advice(Some(madvice));
+        Ok(dir)
     }
 
-    fn resolve_directory_path(directory_path: &Path) -> Result<PathBuf, OpenDirectoryError> {
+    fn open_with_access_pattern_impl(
+        directory_path: &Path,
+    ) -> Result<MmapDirectory, OpenDirectoryError> {
         if !directory_path.exists() {
             return Err(OpenDirectoryError::DoesNotExist(PathBuf::from(
                 directory_path,
@@ -294,7 +288,7 @@ impl MmapDirectory {
                 directory_path,
             )));
         }
-        Ok(canonical_path)
+        Ok(MmapDirectory::new(canonical_path, None))
     }
 
     /// Joins a relative_path to the directory `root_path`

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -101,16 +101,16 @@ struct MmapCache {
 }
 
 impl MmapCache {
-    #[cfg(unix)]
-    fn with_advice(&mut self, madvice_opt: Option<Advice>) {
-        self.madvice_opt = madvice_opt
-    }
-
     fn new() -> MmapCache {
         MmapCache {
             counters: CacheCounters::default(),
             cache: HashMap::default(),
         }
+    }
+
+    #[cfg(unix)]
+    fn with_advice(&mut self, madvice_opt: Option<Advice>) {
+        self.madvice_opt = madvice_opt
     }
 
     fn get_info(&self) -> CacheInfo {

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -194,7 +194,7 @@ impl MmapDirectoryInner {
     }
 
     #[cfg(unix)]
-    fn with_advice(&mut self, madvice_opt: Option<Advice>) {
+    fn with_advice(&self, madvice_opt: Option<Advice>) {
         self.mmap_cache.write().unwrap().with_advice(madvice_opt)
     }
 
@@ -221,7 +221,7 @@ impl MmapDirectory {
     /// Pass specific madvice flags when opening a new mmap file.
     ///
     /// This is only supported on unix platforms.
-    pub fn with_advice(&mut self, madvice_opt: Option<Advice>) {
+    pub fn with_advice(&self, madvice_opt: Option<Advice>) {
         self.inner.with_advice(madvice_opt)
     }
 

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -218,7 +218,7 @@ impl MmapDirectory {
     /// Pass specific madvice flags when opening a new mmap file.
     ///
     /// This is only supported on unix platforms.
-    fn with_advice(&mut self, madvice_opt: Option<Advice>) {
+    pub fn with_advice(&mut self, madvice_opt: Option<Advice>) {
         self.inner.with_advice(madvice_opt)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ pub use crate::schema::{DateOptions, DateTimePrecision, Document, Term};
 /// Index format version.
 const INDEX_FORMAT_VERSION: u32 = 5;
 
+#[cfg(unix)]
 pub use memmap2::Advice;
 
 /// Structure version for the index.


### PR DESCRIPTION
Hides the ability to customise the madvice mmap flags to UNIX only. Allowing you to build tantivy successfully on Windows with the mmap directory.

Originally this was going to be an empty enum or an enum with only the `Normal` variant, but that would have been more confusing IMO. 