### PR TITLE
Make TextAnalyzerBuilder publically accessible

### DIFF
--- a/src/collector/filter_collector_wrapper.rs
+++ b/src/collector/filter_collector_wrapper.rs
@@ -64,9 +64,9 @@ use crate::{DocId, Score, SegmentReader, TantivyError};
 /// # }
 /// ```
 ///
-/// Note that this is limited to fast fields which implement the [`FastValue`] trait,
-/// e.g. `u64` but not `&[u8]`. To filter based on a bytes fast field,
-/// use a [`BytesFilterCollector`] instead.
+/// Note that this is limited to fast fields which implement the
+/// [`FastValue`][crate::fastfield::FastValue] trait, e.g. `u64` but not `&[u8]`.
+/// To filter based on a bytes fast field, use a [`BytesFilterCollector`] instead.
 pub struct FilterCollector<TCollector, TPredicate, TPredicateValue>
 where TPredicate: 'static + Clone
 {

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -154,7 +154,7 @@ pub use self::split_compound_words::SplitCompoundWords;
 pub use self::stemmer::{Language, Stemmer};
 pub use self::stop_word_filter::StopWordFilter;
 pub use self::tokenized_string::{PreTokenizedStream, PreTokenizedString};
-pub use self::tokenizer::TextAnalyzer;
+pub use self::tokenizer::{TextAnalyzer, TextAnalyzerBuilder};
 pub use self::tokenizer_manager::TokenizerManager;
 pub use self::whitespace_tokenizer::WhitespaceTokenizer;
 


### PR DESCRIPTION
This way, client code can name the type to e.g. store it inside structs without resorting to generics and it means that its documentation is part of the crate documentation generated by `cargo doc`.