### PR TITLE
Change TokenFilter trait to simplify (a bit) the boxing of filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ oneshot = "0.1.5"
 base64 = "0.21.0"
 byteorder = "1.4.3"
 crc32fast = "1.3.2"
+dyn-clone = "1.0.11"
 once_cell = "1.10.0"
 regex = { version = "1.5.5", default-features = false, features = ["std", "unicode"] }
 aho-corasick = "1.0"

--- a/benches/analyzer.rs
+++ b/benches/analyzer.rs
@@ -1,5 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use tantivy::tokenizer::TokenizerManager;
+use tantivy::tokenizer::{
+    BoxTokenFilter, LowerCaser, RemoveLongFilter, SimpleTokenizer, TextAnalyzer, TokenizerManager,
+};
 
 const ALICE_TXT: &str = include_str!("alice.txt");
 
@@ -16,7 +18,26 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             assert_eq!(word_count, 30_731);
         })
     });
+    let token_filters = vec![
+        BoxTokenFilter::from(RemoveLongFilter::limit(40)),
+        BoxTokenFilter::from(LowerCaser),
+    ];
+    let mut dynamic_analyzer = TextAnalyzer::new(SimpleTokenizer::default(), token_filters);
+    c.bench_function("default-dynamic-tokenize-alice", |b| {
+        b.iter(|| {
+            let mut word_count = 0;
+            let mut token_stream = dynamic_analyzer.token_stream(ALICE_TXT);
+            while token_stream.advance() {
+                word_count += 1;
+            }
+            assert_eq!(word_count, 30_731);
+        })
+    });
 }
 
-criterion_group!(benches, criterion_benchmark);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(200);
+    targets = criterion_benchmark
+}
 criterion_main!(benches);

--- a/examples/stop_words.rs
+++ b/examples/stop_words.rs
@@ -51,7 +51,7 @@ fn main() -> tantivy::Result<()> {
     // This tokenizer lowers all of the text (to help with stop word matching)
     // then removes all instances of `the` and `and` from the corpus
     let tokenizer = TextAnalyzer::builder(SimpleTokenizer::default())
-        .filter(LowerCaser)
+        .filter(LowerCaser::default())
         .filter(StopWordFilter::remove(vec![
             "the".to_string(),
             "and".to_string(),

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -1209,7 +1209,7 @@ mod tests {
         ff_tokenizer_manager.register(
             "custom_lowercase",
             TextAnalyzer::builder(RawTokenizer::default())
-                .filter(LowerCaser)
+                .filter(LowerCaser::default())
                 .build(),
         );
 

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -209,7 +209,7 @@ impl SegmentWriter {
                     for value in values {
                         let mut token_stream = match value {
                             Value::PreTokStr(tok_str) => {
-                                PreTokenizedStream::from(tok_str.clone()).into()
+                                Box::new(PreTokenizedStream::from(tok_str.clone()))
                             }
                             Value::Str(ref text) => {
                                 let text_analyzer =

--- a/src/query/more_like_this/more_like_this.rs
+++ b/src/query/more_like_this/more_like_this.rs
@@ -4,9 +4,7 @@ use std::collections::{BinaryHeap, HashMap};
 use crate::query::bm25::idf;
 use crate::query::{BooleanQuery, BoostQuery, Occur, Query, TermQuery};
 use crate::schema::{Field, FieldType, IndexRecordOption, Term, Value};
-use crate::tokenizer::{
-    BoxTokenStream, FacetTokenizer, PreTokenizedStream, TokenStream, Tokenizer,
-};
+use crate::tokenizer::{FacetTokenizer, PreTokenizedStream, TokenStream, Tokenizer};
 use crate::{DocAddress, Result, Searcher, TantivyError};
 
 #[derive(Debug, PartialEq)]
@@ -206,8 +204,7 @@ impl MoreLikeThis {
                 for value in values {
                     match value {
                         Value::PreTokStr(tok_str) => {
-                            let mut token_stream: BoxTokenStream =
-                                PreTokenizedStream::from(tok_str.clone()).into();
+                            let mut token_stream = PreTokenizedStream::from(tok_str.clone());
                             token_stream.process(&mut |token| {
                                 if !self.is_noise_word(token.text.clone()) {
                                     let term = Term::from_field_text(field, &token.text);

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -960,7 +960,8 @@ mod test {
         tokenizer_manager.register(
             "en_with_stop_words",
             TextAnalyzer::builder(SimpleTokenizer::default())
-                .filter(LowerCaser)
+                .filter(LowerCaser::default())
+                .filter(LowerCaser::default())
                 .filter(StopWordFilter::remove(vec!["the".to_string()]))
                 .build(),
         );

--- a/src/tokenizer/alphanum_only.rs
+++ b/src/tokenizer/alphanum_only.rs
@@ -39,9 +39,9 @@ impl<T> AlphaNumOnlyFilterStream<T> {
 }
 
 impl TokenFilter for AlphaNumOnlyFilter {
-    type OutputTokenStream<T: TokenStream> = AlphaNumOnlyFilterStream<T>;
+    type OutputTokenStream<'a, T: TokenStream> = AlphaNumOnlyFilterStream<T>;
 
-    fn filter<T: TokenStream>(&self, token_stream: T) -> Self::OutputTokenStream<T> {
+    fn filter<'a, T: TokenStream>(&'a mut self, token_stream: T) -> Self::OutputTokenStream<'a, T> {
         AlphaNumOnlyFilterStream { tail: token_stream }
     }
 }

--- a/src/tokenizer/alphanum_only.rs
+++ b/src/tokenizer/alphanum_only.rs
@@ -21,7 +21,7 @@
 //! // the "emoji" is dropped because its not an alphanum
 //! assert!(stream.next().is_none());
 //! ```
-use super::{Token, TokenFilter, TokenStream, Tokenizer};
+use super::{Token, TokenFilter, TokenStream};
 
 /// `TokenFilter` that removes all tokens that contain non
 /// ascii alphanumeric characters.
@@ -39,23 +39,10 @@ impl<T> AlphaNumOnlyFilterStream<T> {
 }
 
 impl TokenFilter for AlphaNumOnlyFilter {
-    type Tokenizer<T: Tokenizer> = AlphaNumOnlyFilterWrapper<T>;
+    type OutputTokenStream<T: TokenStream> = AlphaNumOnlyFilterStream<T>;
 
-    fn transform<T: Tokenizer>(self, tokenizer: T) -> AlphaNumOnlyFilterWrapper<T> {
-        AlphaNumOnlyFilterWrapper(tokenizer)
-    }
-}
-
-#[derive(Clone)]
-pub struct AlphaNumOnlyFilterWrapper<T>(T);
-
-impl<T: Tokenizer> Tokenizer for AlphaNumOnlyFilterWrapper<T> {
-    type TokenStream<'a> = AlphaNumOnlyFilterStream<T::TokenStream<'a>>;
-
-    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
-        AlphaNumOnlyFilterStream {
-            tail: self.0.token_stream(text),
-        }
+    fn filter<T: TokenStream>(&self, token_stream: T) -> Self::OutputTokenStream<T> {
+        AlphaNumOnlyFilterStream { tail: token_stream }
     }
 }
 

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -139,7 +139,7 @@ mod tokenizer;
 mod tokenizer_manager;
 mod whitespace_tokenizer;
 
-pub use tokenizer_api::{BoxTokenStream, Token, TokenFilter, TokenStream, Tokenizer};
+pub use tokenizer_api::{Token, TokenFilter, TokenStream, Tokenizer};
 
 pub use self::alphanum_only::AlphaNumOnlyFilter;
 pub use self::ascii_folding_filter::AsciiFoldingFilter;

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -154,7 +154,7 @@ pub use self::split_compound_words::SplitCompoundWords;
 pub use self::stemmer::{Language, Stemmer};
 pub use self::stop_word_filter::StopWordFilter;
 pub use self::tokenized_string::{PreTokenizedStream, PreTokenizedString};
-pub use self::tokenizer::{TextAnalyzer, TextAnalyzerBuilder};
+pub use self::tokenizer::{BoxTokenFilter, TextAnalyzer, TextAnalyzerBuilder};
 pub use self::tokenizer_manager::TokenizerManager;
 pub use self::whitespace_tokenizer::WhitespaceTokenizer;
 

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -68,7 +68,7 @@
 //!
 //! let en_stem = TextAnalyzer::builder(SimpleTokenizer::default())
 //!     .filter(RemoveLongFilter::limit(40))
-//!     .filter(LowerCaser)
+//!     .filter(LowerCaser::default())
 //!     .filter(Stemmer::new(Language::English))
 //!     .build();
 //! ```
@@ -115,7 +115,7 @@
 //! // We need to register our tokenizer :
 //! let custom_en_tokenizer = TextAnalyzer::builder(SimpleTokenizer::default())
 //!     .filter(RemoveLongFilter::limit(40))
-//!     .filter(LowerCaser)
+//!     .filter(LowerCaser::default())
 //!     .build();
 //! index
 //!     .tokenizers()
@@ -233,7 +233,7 @@ pub mod tests {
             "el_stem",
             TextAnalyzer::builder(SimpleTokenizer::default())
                 .filter(RemoveLongFilter::limit(40))
-                .filter(LowerCaser)
+                .filter(LowerCaser::default())
                 .filter(Stemmer::new(Language::Greek))
                 .build(),
         );

--- a/src/tokenizer/remove_long.rs
+++ b/src/tokenizer/remove_long.rs
@@ -12,7 +12,7 @@
 //! assert_eq!(stream.next().unwrap().text, "nice");
 //! assert!(stream.next().is_none());
 //! ```
-use super::{Token, TokenFilter, TokenStream, Tokenizer};
+use super::{Token, TokenFilter, TokenStream};
 
 /// `RemoveLongFilter` removes tokens that are longer
 /// than a given number of bytes (in UTF-8 representation).
@@ -38,29 +38,12 @@ impl<T> RemoveLongFilterStream<T> {
 }
 
 impl TokenFilter for RemoveLongFilter {
-    type Tokenizer<T: Tokenizer> = RemoveLongFilterWrapper<T>;
+    type OutputTokenStream<T: TokenStream> = RemoveLongFilterStream<T>;
 
-    fn transform<T: Tokenizer>(self, tokenizer: T) -> RemoveLongFilterWrapper<T> {
-        RemoveLongFilterWrapper {
-            length_limit: self.length_limit,
-            inner: tokenizer,
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct RemoveLongFilterWrapper<T: Tokenizer> {
-    length_limit: usize,
-    inner: T,
-}
-
-impl<T: Tokenizer> Tokenizer for RemoveLongFilterWrapper<T> {
-    type TokenStream<'a> = RemoveLongFilterStream<T::TokenStream<'a>>;
-
-    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+    fn filter<T: TokenStream>(&self, token_stream: T) -> Self::OutputTokenStream<T> {
         RemoveLongFilterStream {
             token_length_limit: self.length_limit,
-            tail: self.inner.token_stream(text),
+            tail: token_stream,
         }
     }
 }

--- a/src/tokenizer/remove_long.rs
+++ b/src/tokenizer/remove_long.rs
@@ -38,9 +38,9 @@ impl<T> RemoveLongFilterStream<T> {
 }
 
 impl TokenFilter for RemoveLongFilter {
-    type OutputTokenStream<T: TokenStream> = RemoveLongFilterStream<T>;
+    type OutputTokenStream<'a, T: TokenStream> = RemoveLongFilterStream<T>;
 
-    fn filter<T: TokenStream>(&self, token_stream: T) -> Self::OutputTokenStream<T> {
+    fn filter<'a, T: TokenStream>(&'a mut self, token_stream: T) -> Self::OutputTokenStream<'a, T> {
         RemoveLongFilterStream {
             token_length_limit: self.length_limit,
             tail: token_stream,

--- a/src/tokenizer/split_compound_words.rs
+++ b/src/tokenizer/split_compound_words.rs
@@ -1,6 +1,6 @@
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, MatchKind};
 
-use super::{Token, TokenFilter, TokenStream, Tokenizer};
+use super::{Token, TokenFilter, TokenStream};
 
 /// A [`TokenFilter`] which splits compound words into their parts
 /// based on a given dictionary.
@@ -80,29 +80,12 @@ impl SplitCompoundWords {
 }
 
 impl TokenFilter for SplitCompoundWords {
-    type Tokenizer<T: Tokenizer> = SplitCompoundWordsFilter<T>;
+    type OutputTokenStream<T: TokenStream> = SplitCompoundWordsTokenStream<T>;
 
-    fn transform<T: Tokenizer>(self, tokenizer: T) -> SplitCompoundWordsFilter<T> {
-        SplitCompoundWordsFilter {
-            dict: self.dict,
-            inner: tokenizer,
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct SplitCompoundWordsFilter<T> {
-    dict: AhoCorasick,
-    inner: T,
-}
-
-impl<T: Tokenizer> Tokenizer for SplitCompoundWordsFilter<T> {
-    type TokenStream<'a> = SplitCompoundWordsTokenStream<T::TokenStream<'a>>;
-
-    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+    fn filter<T: TokenStream>(&self, token_stream: T) -> Self::OutputTokenStream<T> {
         SplitCompoundWordsTokenStream {
             dict: self.dict.clone(),
-            tail: self.inner.token_stream(text),
+            tail: token_stream,
             cuts: Vec::new(),
             parts: Vec::new(),
         }

--- a/src/tokenizer/split_compound_words.rs
+++ b/src/tokenizer/split_compound_words.rs
@@ -80,9 +80,9 @@ impl SplitCompoundWords {
 }
 
 impl TokenFilter for SplitCompoundWords {
-    type OutputTokenStream<T: TokenStream> = SplitCompoundWordsTokenStream<T>;
+    type OutputTokenStream<'a, T: TokenStream> = SplitCompoundWordsTokenStream<T>;
 
-    fn filter<T: TokenStream>(&self, token_stream: T) -> Self::OutputTokenStream<T> {
+    fn filter<'a, T: TokenStream>(&'a mut self, token_stream: T) -> Self::OutputTokenStream<'a, T> {
         SplitCompoundWordsTokenStream {
             dict: self.dict.clone(),
             tail: token_stream,

--- a/src/tokenizer/stemmer.rs
+++ b/src/tokenizer/stemmer.rs
@@ -81,9 +81,9 @@ impl Default for Stemmer {
 }
 
 impl TokenFilter for Stemmer {
-    type OutputTokenStream<T: TokenStream> = StemmerTokenStream<T>;
+    type OutputTokenStream<'a, T: TokenStream> = StemmerTokenStream<T>;
 
-    fn filter<T: TokenStream>(&self, token_stream: T) -> Self::OutputTokenStream<T> {
+    fn filter<'a, T: TokenStream>(&'a mut self, token_stream: T) -> Self::OutputTokenStream<'a, T> {
         let stemmer = rust_stemmers::Stemmer::create(self.stemmer_algorithm);
         StemmerTokenStream {
             tail: token_stream,

--- a/src/tokenizer/stop_word_filter/mod.rs
+++ b/src/tokenizer/stop_word_filter/mod.rs
@@ -72,9 +72,9 @@ impl StopWordFilter {
 }
 
 impl TokenFilter for StopWordFilter {
-    type OutputTokenStream<T: TokenStream> = StopWordFilterStream<T>;
+    type OutputTokenStream<'a, T: TokenStream> = StopWordFilterStream<T>;
 
-    fn filter<T: TokenStream>(&self, token_stream: T) -> Self::OutputTokenStream<T> {
+    fn filter<'a, T: TokenStream>(&'a mut self, token_stream: T) -> Self::OutputTokenStream<'a, T> {
         StopWordFilterStream {
             words: self.words.clone(),
             tail: token_stream,

--- a/src/tokenizer/stop_word_filter/mod.rs
+++ b/src/tokenizer/stop_word_filter/mod.rs
@@ -21,7 +21,7 @@ use rustc_hash::FxHashSet;
 
 #[cfg(feature = "stopwords")]
 use super::Language;
-use super::{Token, TokenFilter, TokenStream, Tokenizer};
+use super::{Token, TokenFilter, TokenStream};
 
 /// `TokenFilter` that removes stop words from a token stream
 #[derive(Clone)]
@@ -72,29 +72,12 @@ impl StopWordFilter {
 }
 
 impl TokenFilter for StopWordFilter {
-    type Tokenizer<T: Tokenizer> = StopWordFilterWrapper<T>;
+    type OutputTokenStream<T: TokenStream> = StopWordFilterStream<T>;
 
-    fn transform<T: Tokenizer>(self, tokenizer: T) -> StopWordFilterWrapper<T> {
-        StopWordFilterWrapper {
-            words: self.words,
-            inner: tokenizer,
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct StopWordFilterWrapper<T> {
-    words: Arc<FxHashSet<String>>,
-    inner: T,
-}
-
-impl<T: Tokenizer> Tokenizer for StopWordFilterWrapper<T> {
-    type TokenStream<'a> = StopWordFilterStream<T::TokenStream<'a>>;
-
-    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+    fn filter<T: TokenStream>(&self, token_stream: T) -> Self::OutputTokenStream<T> {
         StopWordFilterStream {
             words: self.words.clone(),
-            tail: self.inner.token_stream(text),
+            tail: token_stream,
         }
     }
 }

--- a/src/tokenizer/tokenizer.rs
+++ b/src/tokenizer/tokenizer.rs
@@ -64,8 +64,7 @@ impl TextAnalyzer {
     ///
     /// When creating a `TextAnalyzer` from a `Tokenizer` and a static set of `TokenFilter`,
     /// prefer using `TextAnalyzer::builder(tokenizer).filter(token_filter).build()` as it
-    /// will be more performant and only create one `Box<dyn BoxableTokenizer>` instead of
-    /// one per `TokenFilter`.
+    /// will be more performant and create less boxes.
     ///
     /// # Example
     ///

--- a/src/tokenizer/tokenizer.rs
+++ b/src/tokenizer/tokenizer.rs
@@ -1,6 +1,8 @@
+use std::ops::Deref;
+
 /// The tokenizer module contains all of the tools used to process
 /// text in `tantivy`.
-use tokenizer_api::{BoxTokenStream, TokenFilter, Tokenizer};
+use tokenizer_api::{BoxTokenStream, TokenFilter, TokenStream, Tokenizer};
 
 use crate::tokenizer::empty_tokenizer::EmptyTokenizer;
 
@@ -10,7 +12,7 @@ pub struct TextAnalyzer {
 }
 
 /// A boxable `Tokenizer`, with its `TokenStream` type erased.
-trait BoxableTokenizer: 'static + Send + Sync {
+pub trait BoxableTokenizer: 'static + Send + Sync {
     /// Creates a boxed token stream for a given `str`.
     fn box_token_stream<'a>(&'a mut self, text: &'a str) -> BoxTokenStream<'a>;
     /// Clone this tokenizer.
@@ -23,6 +25,83 @@ impl<T: Tokenizer> BoxableTokenizer for T {
     }
     fn box_clone(&self) -> Box<dyn BoxableTokenizer> {
         Box::new(self.clone())
+    }
+}
+
+pub struct BoxedTokenizer(Box<dyn BoxableTokenizer>);
+
+impl Clone for BoxedTokenizer {
+    fn clone(&self) -> BoxedTokenizer {
+        Self(self.0.box_clone())
+    }
+}
+
+impl Tokenizer for BoxedTokenizer {
+    type TokenStream<'a> = Box<dyn TokenStream + 'a>;
+
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+        self.0.box_token_stream(text).into()
+    }
+}
+
+/// Trait for the pluggable components of `Tokenizer`s.
+pub trait BoxableTokenFilter: 'static + Send + Sync {
+    /// Wraps a Tokenizer and returns a new one.
+    fn box_transform(&self, tokenizer: BoxedTokenizer) -> Box<dyn BoxableTokenizer>;
+}
+
+impl<T: TokenFilter> BoxableTokenFilter for T {
+    fn box_transform(&self, tokenizer: BoxedTokenizer) -> Box<dyn BoxableTokenizer> {
+        let tokenizer = self.clone().transform(tokenizer);
+        tokenizer.box_clone()
+    }
+}
+
+pub struct BoxTokenFilter(Box<dyn BoxableTokenFilter>);
+
+impl Deref for BoxTokenFilter {
+    type Target = dyn BoxableTokenFilter;
+
+    fn deref(&self) -> &dyn BoxableTokenFilter {
+        &*self.0
+    }
+}
+
+impl<T: TokenFilter> From<T> for BoxTokenFilter {
+    fn from(tokenizer: T) -> BoxTokenFilter {
+        BoxTokenFilter(Box::new(tokenizer))
+    }
+}
+
+impl TextAnalyzer {
+    /// Builds a new `TextAnalyzer` given a tokenizer and a vector of `BoxTokenFilter`.
+    ///
+    /// When creating a `TextAnalyzer` from a `Tokenizer` alone, prefer using
+    /// `TextAnalyzer::from(tokenizer)`.
+    /// When creating a `TextAnalyzer` from a `Tokenizer` and a static set of `TokenFilter`,
+    /// prefer using `TextAnalyzer::builder(tokenizer).filter(token_filter).build()`.
+    pub fn build<T: Tokenizer>(
+        tokenizer: T,
+        boxed_token_filters: Vec<BoxTokenFilter>,
+    ) -> TextAnalyzer {
+        let mut boxed_tokenizer = BoxedTokenizer(Box::new(tokenizer));
+        for filter in boxed_token_filters.into_iter() {
+            let filtered_boxed_tokenizer = filter.box_transform(boxed_tokenizer);
+            boxed_tokenizer = BoxedTokenizer(filtered_boxed_tokenizer);
+        }
+        TextAnalyzer {
+            tokenizer: boxed_tokenizer.0,
+        }
+    }
+
+    /// Create a new TextAnalyzerBuilder
+    pub fn builder<T: Tokenizer>(tokenizer: T) -> TextAnalyzerBuilder<T> {
+        TextAnalyzerBuilder { tokenizer }
+    }
+
+    /// Creates a token stream for a given `str`.
+    pub fn token_stream<'a>(&'a mut self, text: &'a str) -> BoxTokenStream<'a> {
+        self.tokenizer.box_token_stream(text)
     }
 }
 
@@ -46,20 +125,8 @@ impl<T: Tokenizer + Clone> From<T> for TextAnalyzer {
     }
 }
 
-impl TextAnalyzer {
-    /// Create a new TextAnalyzerBuilder
-    pub fn builder<T: Tokenizer>(tokenizer: T) -> TextAnalyzerBuilder<T> {
-        TextAnalyzerBuilder { tokenizer }
-    }
-
-    /// Creates a token stream for a given `str`.
-    pub fn token_stream<'a>(&'a mut self, text: &'a str) -> BoxTokenStream<'a> {
-        self.tokenizer.box_token_stream(text)
-    }
-}
-
 /// Builder helper for [`TextAnalyzer`]
-pub struct TextAnalyzerBuilder<T> {
+pub struct TextAnalyzerBuilder<T: Tokenizer> {
     tokenizer: T,
 }
 
@@ -88,5 +155,39 @@ impl<T: Tokenizer> TextAnalyzerBuilder<T> {
         TextAnalyzer {
             tokenizer: Box::new(self.tokenizer),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::tokenizer::{AlphaNumOnlyFilter, LowerCaser, RemoveLongFilter, WhitespaceTokenizer};
+
+    #[test]
+    fn test_text_analyzer_builder() {
+        let mut analyzer = TextAnalyzer::builder(WhitespaceTokenizer::default())
+            .filter(AlphaNumOnlyFilter)
+            .filter(RemoveLongFilter::limit(6))
+            .filter(LowerCaser)
+            .build();
+        let mut stream = analyzer.token_stream("- first bullet point");
+        assert_eq!(stream.next().unwrap().text, "first");
+        assert_eq!(stream.next().unwrap().text, "point");
+    }
+
+    #[test]
+    fn test_text_analyzer_with_filters_boxed() {
+        let mut analyzer = TextAnalyzer::build(
+            WhitespaceTokenizer::default(),
+            vec![
+                BoxTokenFilter::from(AlphaNumOnlyFilter),
+                BoxTokenFilter::from(LowerCaser),
+                BoxTokenFilter::from(RemoveLongFilter::limit(6)),
+            ],
+        );
+        let mut stream = analyzer.token_stream("- first bullet point");
+        assert_eq!(stream.next().unwrap().text, "first");
+        assert_eq!(stream.next().unwrap().text, "point");
     }
 }

--- a/src/tokenizer/tokenizer.rs
+++ b/src/tokenizer/tokenizer.rs
@@ -1,7 +1,7 @@
 use dyn_clone::DynClone;
 /// The tokenizer module contains all of the tools used to process
 /// text in `tantivy`.
-use tokenizer_api::{BoxTokenStream, TokenFilter, TokenStream, Tokenizer};
+use tokenizer_api::{TokenFilter, TokenStream, Tokenizer};
 
 use crate::tokenizer::empty_tokenizer::EmptyTokenizer;
 
@@ -14,12 +14,12 @@ pub struct TextAnalyzer {
 /// A boxable `Tokenizer`, with its `TokenStream` type erased.
 trait BoxableTokenizer: 'static + Send + Sync + DynClone {
     /// Creates a boxed token stream for a given `str`.
-    fn box_token_stream<'a>(&'a mut self, text: &'a str) -> BoxTokenStream<'a>;
+    fn box_token_stream<'a>(&'a mut self, text: &'a str) -> Box<dyn TokenStream + 'a>;
 }
 
 impl<T: Tokenizer> BoxableTokenizer for T {
-    fn box_token_stream<'a>(&'a mut self, text: &'a str) -> BoxTokenStream<'a> {
-        self.token_stream(text).into()
+    fn box_token_stream<'a>(&'a mut self, text: &'a str) -> Box<dyn TokenStream + 'a> {
+        Box::new(self.token_stream(text))
     }
 }
 
@@ -98,7 +98,7 @@ impl TextAnalyzer {
     }
 
     /// Creates a token stream for a given `str`.
-    pub fn token_stream<'a>(&'a mut self, text: &'a str) -> BoxTokenStream<'a> {
+    pub fn token_stream<'a>(&'a mut self, text: &'a str) -> Box<dyn TokenStream + 'a> {
         self.tokenizer.box_token_stream(text)
     }
 }

--- a/src/tokenizer/tokenizer_manager.rs
+++ b/src/tokenizer/tokenizer_manager.rs
@@ -63,14 +63,14 @@ impl Default for TokenizerManager {
             "default",
             TextAnalyzer::builder(SimpleTokenizer::default())
                 .filter(RemoveLongFilter::limit(40))
-                .filter(LowerCaser)
+                .filter(LowerCaser::default())
                 .build(),
         );
         manager.register(
             "en_stem",
             TextAnalyzer::builder(SimpleTokenizer::default())
                 .filter(RemoveLongFilter::limit(40))
-                .filter(LowerCaser)
+                .filter(LowerCaser::default())
                 .filter(Stemmer::new(Language::English))
                 .build(),
         );

--- a/tokenizer-api/src/lib.rs
+++ b/tokenizer-api/src/lib.rs
@@ -63,6 +63,12 @@ pub trait Tokenizer: 'static + Clone + Send + Sync {
 /// Simple wrapper of `Box<dyn TokenStream + 'a>`.
 pub struct BoxTokenStream<'a>(Box<dyn TokenStream + 'a>);
 
+impl<'a> From<BoxTokenStream<'a>> for Box<dyn TokenStream + 'a> {
+    fn from(token_stream: BoxTokenStream<'a>) -> Self {
+        token_stream.0
+    }
+}
+
 impl<'a, T> From<T> for BoxTokenStream<'a>
 where T: TokenStream + 'a
 {
@@ -78,6 +84,7 @@ impl<'a> Deref for BoxTokenStream<'a> {
         &*self.0
     }
 }
+
 impl<'a> DerefMut for BoxTokenStream<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut *self.0
@@ -137,11 +144,11 @@ pub trait TokenStream {
 }
 
 /// Trait for the pluggable components of `Tokenizer`s.
-pub trait TokenFilter: 'static + Send + Sync {
+pub trait TokenFilter: 'static + Send + Sync + Clone {
     /// The Tokenizer type returned by this filter, typically parametrized by the underlying
     /// Tokenizer.
     type Tokenizer<T: Tokenizer>: Tokenizer;
-    /// Wraps a Tokenizer and returns a new one.
+    /// Wraps a Tokenizer and returns a new onex .
     fn transform<T: Tokenizer>(self, tokenizer: T) -> Self::Tokenizer<T>;
 }
 

--- a/tokenizer-api/src/lib.rs
+++ b/tokenizer-api/src/lib.rs
@@ -115,9 +115,9 @@ pub trait TokenStream {
 pub trait TokenFilter: 'static + Send + Sync + Clone {
     /// The Tokenizer type returned by this filter, typically parametrized by the underlying
     /// Tokenizer.
-    type OutputTokenStream<T: TokenStream>: TokenStream;
+    type OutputTokenStream<'a, T: TokenStream>: TokenStream;
     /// Filter a token stream and returns a new one.
-    fn filter<T: TokenStream>(&self, token_stream: T) -> Self::OutputTokenStream<T>;
+    fn filter<'a, T: TokenStream>(&'a mut self, token_stream: T) -> Self::OutputTokenStream<'a, T>;
     /// Wraps a Tokenizer and returns a new one.
     fn transform<T: Tokenizer>(self, tokenizer: T) -> FilteredTokenizer<T, Self> {
         FilteredTokenizer {
@@ -134,7 +134,7 @@ pub struct FilteredTokenizer<T: Tokenizer, F: TokenFilter> {
 }
 
 impl<T: Tokenizer, F: TokenFilter> Tokenizer for FilteredTokenizer<T, F> {
-    type TokenStream<'a> = F::OutputTokenStream<T::TokenStream<'a>>;
+    type TokenStream<'a> = F::OutputTokenStream<'a, T::TokenStream<'a>>;
 
     fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
         let token_stream = self.tokenizer.token_stream(text);

--- a/tokenizer-api/src/lib.rs
+++ b/tokenizer-api/src/lib.rs
@@ -6,7 +6,6 @@
 //! Checkout the [tantivy repo](https://github.com/quickwit-oss/tantivy/tree/main/src/tokenizer) for some examples.
 
 use std::borrow::{Borrow, BorrowMut};
-use std::ops::{Deref, DerefMut};
 
 use serde::{Deserialize, Serialize};
 
@@ -58,37 +57,6 @@ pub trait Tokenizer: 'static + Clone + Send + Sync {
     type TokenStream<'a>: TokenStream;
     /// Creates a token stream for a given `str`.
     fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a>;
-}
-
-/// Simple wrapper of `Box<dyn TokenStream + 'a>`.
-pub struct BoxTokenStream<'a>(Box<dyn TokenStream + 'a>);
-
-impl<'a> From<BoxTokenStream<'a>> for Box<dyn TokenStream + 'a> {
-    fn from(token_stream: BoxTokenStream<'a>) -> Self {
-        token_stream.0
-    }
-}
-
-impl<'a, T> From<T> for BoxTokenStream<'a>
-where T: TokenStream + 'a
-{
-    fn from(token_stream: T) -> BoxTokenStream<'a> {
-        BoxTokenStream(Box::new(token_stream))
-    }
-}
-
-impl<'a> Deref for BoxTokenStream<'a> {
-    type Target = dyn TokenStream + 'a;
-
-    fn deref(&self) -> &Self::Target {
-        &*self.0
-    }
-}
-
-impl<'a> DerefMut for BoxTokenStream<'a> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut *self.0
-    }
 }
 
 impl<'a> TokenStream for Box<dyn TokenStream + 'a> {

--- a/tokenizer-api/src/lib.rs
+++ b/tokenizer-api/src/lib.rs
@@ -148,7 +148,7 @@ pub trait TokenFilter: 'static + Send + Sync + Clone {
     /// The Tokenizer type returned by this filter, typically parametrized by the underlying
     /// Tokenizer.
     type Tokenizer<T: Tokenizer>: Tokenizer;
-    /// Wraps a Tokenizer and returns a new onex .
+    /// Wraps a Tokenizer and returns a new one.
     fn transform<T: Tokenizer>(self, tokenizer: T) -> Self::Tokenizer<T>;
 }
 


### PR DESCRIPTION
I have a preference for this PR instead of this one: #2096

The main difference is that I changed the `TokenFilter` to make it independent of the `Tokenizer` trait as a `TokenFilter` should be defined only by the input token stream and its output token stream.

The main benefit compared to #2096 is that it avoids creating a `BoxTokenizer` and implementing the `Tokenizer` trait on it... it does not seem to be a substantial benefit but... except it is cleaner. For example in #2096, I tried to bypass `BoxTokenizer` and implemented the `Tokenizer` trait directly on `Box<dyn BoxableTokenizer>`, but I  got stack overflow as I was calling recursively the same method `box_token_stream` but the compiler did not tell me anything... 



Bench results:

```console
cargo bench --bench analyzer
    Finished bench [optimized + debuginfo] target(s) in 0.12s
warning: the following packages contain code that will be rejected by a future version of Rust: quick-xml v0.22.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running benches/analyzer.rs (target/release/deps/analyzer-2a32537b8a3b3efa)
Gnuplot not found, using plotters backend
default-tokenize-alice  time:   [874.40 µs 875.34 µs 876.63 µs]
                        change: [-2.0579% -1.8172% -1.5706%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 200 measurements (8.00%)
  8 (4.00%) high mild
  8 (4.00%) high severe

default-dynamic-tokenize-alice
                        time:   [1.1158 ms 1.1165 ms 1.1173 ms]
                        change: [-1.9267% -1.6803% -1.4354%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 200 measurements (4.00%)
  2 (1.00%) high mild
  6 (3.00%) high severe
```


I also ran the benchmark on tantivy `0.19` before the introduction of GATs, box token streams were used everywhere at that time.

```console
default-tokenize-alice  time:   [1.0371 ms 1.0376 ms 1.0383 ms]
```

So we have a performance regression on the box token filters, unfortunately. I tried to change the code to have something equivalent to what we had on 0.19 but... this bench results did not change.

