### PR TITLE
Ngram tokenizer now returns an error with invalid arguments.

### DIFF
--- a/examples/custom_tokenizer.rs
+++ b/examples/custom_tokenizer.rs
@@ -53,7 +53,7 @@ fn main() -> tantivy::Result<()> {
     // this will store tokens of 3 characters each
     index
         .tokenizers()
-        .register("ngram3", NgramTokenizer::new(3, 3, false));
+        .register("ngram3", NgramTokenizer::new(3, 3, false).unwrap());
 
     // To insert document we need an index writer.
     // There must be only one writer at a time.

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -693,7 +693,7 @@ Survey in 2016, 2017, and 2018."#;
         terms.insert(String::from("bc"), 1.0);
 
         let fragments = search_fragments(
-            &mut From::from(NgramTokenizer::all_ngrams(2, 2)),
+            &mut From::from(NgramTokenizer::all_ngrams(2, 2).unwrap()),
             text,
             &terms,
             3,


### PR DESCRIPTION
Fixes #2100 