### PR TITLE
add missing parameter to term agg

### DIFF
--- a/columnar/src/block_accessor.rs
+++ b/columnar/src/block_accessor.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use crate::{Column, DocId, RowId};
 
 #[derive(Debug, Default, Clone)]
@@ -61,14 +63,18 @@ where F: FnMut(u32) {
     let mut hit = hits_iter.next();
 
     while let (Some(&current_doc), Some(&current_hit)) = (doc, hit) {
-        if current_doc < current_hit {
-            callback(current_doc);
-            doc = docs_iter.next();
-        } else if current_doc == current_hit {
-            doc = docs_iter.next();
-            hit = hits_iter.next();
-        } else {
-            hit = hits_iter.next();
+        match current_doc.cmp(&current_hit) {
+            Ordering::Less => {
+                callback(current_doc);
+                doc = docs_iter.next();
+            }
+            Ordering::Equal => {
+                doc = docs_iter.next();
+                hit = hits_iter.next();
+            }
+            Ordering::Greater => {
+                hit = hits_iter.next();
+            }
         }
     }
 

--- a/columnar/src/block_accessor.rs
+++ b/columnar/src/block_accessor.rs
@@ -4,6 +4,7 @@ use crate::{Column, DocId, RowId};
 pub struct ColumnBlockAccessor<T> {
     val_cache: Vec<T>,
     docid_cache: Vec<DocId>,
+    missing_docids_cache: Vec<DocId>,
     row_id_cache: Vec<RowId>,
 }
 
@@ -20,6 +21,20 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
             .values
             .get_vals(&self.row_id_cache, &mut self.val_cache);
     }
+    #[inline]
+    pub fn fetch_block_with_missing(&mut self, docs: &[u32], accessor: &Column<T>, missing: T) {
+        self.fetch_block(docs, accessor);
+        // We can compare docid_cache with docs to find missing docs
+        if docs.len() != self.docid_cache.len() {
+            self.missing_docids_cache.clear();
+            find_missing_docs(docs, &self.docid_cache, |doc| {
+                self.missing_docids_cache.push(doc);
+                self.val_cache.push(missing);
+            });
+            self.docid_cache
+                .extend_from_slice(&self.missing_docids_cache);
+        }
+    }
 
     #[inline]
     pub fn iter_vals(&self) -> impl Iterator<Item = T> + '_ {
@@ -32,5 +47,78 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
             .iter()
             .cloned()
             .zip(self.val_cache.iter().cloned())
+    }
+}
+
+fn find_missing_docs<F>(docs: &[u32], hits: &[u32], mut callback: F)
+where F: FnMut(u32) {
+    let mut docs_iter = docs.iter();
+    let mut hits_iter = hits.iter();
+
+    let mut doc = docs_iter.next();
+    let mut hit = hits_iter.next();
+
+    while let (Some(&current_doc), Some(&current_hit)) = (doc, hit) {
+        if current_doc < current_hit {
+            callback(current_doc);
+            doc = docs_iter.next();
+        } else if current_doc == current_hit {
+            doc = docs_iter.next();
+            hit = hits_iter.next();
+        } else {
+            hit = hits_iter.next();
+        }
+    }
+
+    while let Some(&current_doc) = doc {
+        callback(current_doc);
+        doc = docs_iter.next();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_missing_docs() {
+        let docs: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let hits: Vec<u32> = vec![2, 4, 6, 8, 10];
+
+        let mut missing_docs: Vec<u32> = Vec::new();
+
+        find_missing_docs(&docs, &hits, |missing_doc| {
+            missing_docs.push(missing_doc);
+        });
+
+        assert_eq!(missing_docs, vec![1, 3, 5, 7, 9]);
+    }
+
+    #[test]
+    fn test_find_missing_docs_empty() {
+        let docs: Vec<u32> = Vec::new();
+        let hits: Vec<u32> = vec![2, 4, 6, 8, 10];
+
+        let mut missing_docs: Vec<u32> = Vec::new();
+
+        find_missing_docs(&docs, &hits, |missing_doc| {
+            missing_docs.push(missing_doc);
+        });
+
+        assert_eq!(missing_docs, vec![]);
+    }
+
+    #[test]
+    fn test_find_missing_docs_all_missing() {
+        let docs: Vec<u32> = vec![1, 2, 3, 4, 5];
+        let hits: Vec<u32> = Vec::new();
+
+        let mut missing_docs: Vec<u32> = Vec::new();
+
+        find_missing_docs(&docs, &hits, |missing_doc| {
+            missing_docs.push(missing_doc);
+        });
+
+        assert_eq!(missing_docs, vec![1, 2, 3, 4, 5]);
     }
 }

--- a/columnar/src/block_accessor.rs
+++ b/columnar/src/block_accessor.rs
@@ -25,7 +25,7 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     pub fn fetch_block_with_missing(&mut self, docs: &[u32], accessor: &Column<T>, missing: T) {
         self.fetch_block(docs, accessor);
         // We can compare docid_cache with docs to find missing docs
-        if docs.len() != self.docid_cache.len() {
+        if docs.len() != self.docid_cache.len() || accessor.index.is_multivalue() {
             self.missing_docids_cache.clear();
             find_missing_docs(docs, &self.docid_cache, |doc| {
                 self.missing_docids_cache.push(doc);
@@ -50,6 +50,8 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     }
 }
 
+/// Given two sorted lists of docids `docs` and `hits`, hits is a subset of `docs`.
+/// Return all docs that are not in `hits`.
 fn find_missing_docs<F>(docs: &[u32], hits: &[u32], mut callback: F)
 where F: FnMut(u32) {
     let mut docs_iter = docs.iter();

--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -130,7 +130,7 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
             .select_batch_in_place(selected_docid_range.start, doc_ids);
     }
 
-    /// Fils the output vector with the (possibly multiple values that are associated_with
+    /// Fills the output vector with the (possibly multiple values that are associated_with
     /// `row_id`.
     ///
     /// This method clears the `output` vector.

--- a/columnar/src/column_index/mod.rs
+++ b/columnar/src/column_index/mod.rs
@@ -37,6 +37,10 @@ impl From<MultiValueIndex> for ColumnIndex {
 }
 
 impl ColumnIndex {
+    #[inline]
+    pub fn is_multivalue(&self) -> bool {
+        matches!(self, ColumnIndex::Multivalued(_))
+    }
     // Returns the cardinality of the column index.
     //
     // By convention, if the column contains no docs, we consider that it is

--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -123,7 +123,8 @@ pub enum AggregationVariants {
 }
 
 impl AggregationVariants {
-    fn get_fast_field_name(&self) -> &str {
+    /// Returns the name of the field used by the aggregation.
+    pub fn get_fast_field_name(&self) -> &str {
         match self {
             AggregationVariants::Terms(terms) => terms.field.as_str(),
             AggregationVariants::Range(range) => range.field.as_str(),

--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -36,6 +36,9 @@ pub struct AggregationWithAccessor {
     /// based on search terms. That is not that case currently, but eventually this needs to be
     /// Option or moved.
     pub(crate) accessor: Column<u64>,
+    /// Load insert u64 for missing use case
+    pub(crate) missing_accessor1: Option<u64>,
+    pub(crate) missing_accessor2: Option<u64>,
     pub(crate) str_dict_column: Option<StrColumn>,
     pub(crate) field_type: ColumnType,
     pub(crate) sub_aggregation: AggregationsWithAccessor,
@@ -51,6 +54,8 @@ impl AggregationWithAccessor {
         reader: &SegmentReader,
         limits: AggregationLimits,
     ) -> crate::Result<Vec<AggregationWithAccessor>> {
+        let mut missing_accessor1 = None;
+        let mut missing_accessor2 = None;
         let mut str_dict_column = None;
         use AggregationVariants::*;
         let acc_field_types: Vec<(Column, ColumnType)> = match &agg.agg {

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -284,9 +284,16 @@ impl SegmentAggregationCollector for SegmentTermCollector {
 
         let mem_pre = self.get_memory_consumption();
 
-        bucket_agg_accessor
-            .column_block_accessor
-            .fetch_block(docs, &bucket_agg_accessor.accessor);
+        if let Some(missing) = bucket_agg_accessor.missing_accessor1 {
+            bucket_agg_accessor
+                .column_block_accessor
+                .fetch_block_with_missing(docs, &bucket_agg_accessor.accessor, missing);
+        } else {
+            bucket_agg_accessor
+                .column_block_accessor
+                .fetch_block(docs, &bucket_agg_accessor.accessor);
+        }
+
         for term_id in bucket_agg_accessor.column_block_accessor.iter_vals() {
             let entry = self.term_buckets.entries.entry(term_id).or_default();
             *entry += 1;

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -166,8 +166,6 @@ pub struct TermsAggregation {
     /// Special Case 2: if the key is of type text and the column is numerical, we also need to use
     /// the special missing aggregation, since there is no mechanism in the numerical column to
     /// add text.
-    ///
-    ///
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub missing: Option<Key>,
 }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -299,7 +299,7 @@ impl SegmentAggregationCollector for SegmentTermCollector {
 
         let mem_pre = self.get_memory_consumption();
 
-        if let Some(missing) = bucket_agg_accessor.missing_value_for_accessor1 {
+        if let Some(missing) = bucket_agg_accessor.missing_value_for_accessor {
             bucket_agg_accessor
                 .column_block_accessor
                 .fetch_block_with_missing(docs, &bucket_agg_accessor.accessor, missing);


### PR DESCRIPTION
missing parameter on term aggregation

Limitations:
Mixed types columns are not supported.
Missing key of type string is not supported on numerical fields 

It requires a special missing aggregation to address those limitations

https://github.com/quickwit-oss/tantivy/issues/1913
https://github.com/quickwit-oss/tantivy/issues/1789