### PR TITLE
Change in the default fast field tokenizer manager.

### DIFF
--- a/examples/aggregation.rs
+++ b/examples/aggregation.rs
@@ -37,7 +37,7 @@ fn main() -> tantivy::Result<()> {
                 .set_index_option(IndexRecordOption::WithFreqs)
                 .set_tokenizer("raw"),
         )
-        .set_fast(None)
+        .set_fast("default")
         .set_stored();
     schema_builder.add_text_field("category", text_fieldtype);
     schema_builder.add_f64_field("stock", FAST);

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -1293,13 +1293,13 @@ mod tests {
         // searching for terma, but min_doc_count will return all terms
         let res = exec_request_with_query(agg_req, &index, Some(("string2", "hit")))?;
 
-        assert_eq!(res["my_texts"]["buckets"][0]["key"], "A");
+        assert_eq!(res["my_texts"]["buckets"][0]["key"], "a");
         assert_eq!(res["my_texts"]["buckets"][0]["doc_count"], 2);
         assert_eq!(
             res["my_texts"]["buckets"][0]["elhistogram"]["buckets"],
             json!([{ "doc_count": 1, "key": 1.0 }, { "doc_count": 1, "key": 2.0 } ])
         );
-        assert_eq!(res["my_texts"]["buckets"][1]["key"], "B");
+        assert_eq!(res["my_texts"]["buckets"][1]["key"], "b");
         assert_eq!(res["my_texts"]["buckets"][1]["doc_count"], 1);
         assert_eq!(
             res["my_texts"]["buckets"][1]["elhistogram"]["buckets"],
@@ -1421,10 +1421,10 @@ mod tests {
         let res = exec_request_with_query(agg_req, &index, None).unwrap();
         println!("{}", serde_json::to_string_pretty(&res).unwrap());
 
-        assert_eq!(res["my_texts"]["buckets"][0]["key"], "Hallo Hallo");
+        assert_eq!(res["my_texts"]["buckets"][0]["key"], "hallo hallo");
         assert_eq!(res["my_texts"]["buckets"][0]["doc_count"], 1);
 
-        assert_eq!(res["my_texts"]["buckets"][1]["key"], "Hello Hello");
+        assert_eq!(res["my_texts"]["buckets"][1]["key"], "hello hello");
         assert_eq!(res["my_texts"]["buckets"][1]["doc_count"], 1);
 
         Ok(())

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -411,7 +411,7 @@ mod tests {
                     .set_index_option(IndexRecordOption::Basic)
                     .set_fieldnorms(false),
             )
-            .set_fast(None)
+            .set_fast("default")
             .set_stored();
         let text_field = schema_builder.add_text_field("text", text_fieldtype.clone());
         let text_field_id = schema_builder.add_text_field("text_id", text_fieldtype);
@@ -466,7 +466,7 @@ mod tests {
             .set_indexing_options(
                 TextFieldIndexing::default().set_index_option(IndexRecordOption::WithFreqs),
             )
-            .set_fast(None)
+            .set_fast("default")
             .set_stored();
         let text_field = schema_builder.add_text_field("text", text_fieldtype);
         let date_field = schema_builder.add_date_field("date", FAST);

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -120,8 +120,8 @@ impl IndexBuilder {
         Self {
             schema: None,
             index_settings: IndexSettings::default(),
-            tokenizer_manager: TokenizerManager::default(),
-            fast_field_tokenizer_manager: TokenizerManager::default(),
+            tokenizer_manager: TokenizerManager::default_for_indexing(),
+            fast_field_tokenizer_manager: TokenizerManager::default_for_fast_fields(),
         }
     }
 
@@ -400,8 +400,8 @@ impl Index {
             settings: metas.index_settings.clone(),
             directory,
             schema,
-            tokenizers: TokenizerManager::default(),
-            fast_field_tokenizers: TokenizerManager::default(),
+            tokenizers: TokenizerManager::default_for_indexing(),
+            fast_field_tokenizers: TokenizerManager::default_for_fast_fields(),
             executor: Arc::new(Executor::single_thread()),
             inventory,
         }

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -446,7 +446,8 @@ mod tests {
     #[test]
     fn test_text_fastfield() {
         let mut schema_builder = Schema::builder();
-        let text_field = schema_builder.add_text_field("text", TEXT | FAST);
+        let text_options: TextOptions = TextOptions::from(TEXT).set_fast("raw");
+        let text_field = schema_builder.add_text_field("text", text_options);
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
 
@@ -1082,7 +1083,7 @@ mod tests {
     #[test]
     fn test_fast_field_in_json_field_expand_dots_disabled() {
         let mut schema_builder = Schema::builder();
-        let json_option = JsonObjectOptions::default().set_fast(None);
+        let json_option = JsonObjectOptions::default().set_fast("default");
         let json = schema_builder.add_json_field("json", json_option);
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
@@ -1108,7 +1109,7 @@ mod tests {
     #[test]
     fn test_fast_field_in_json_field_with_tokenizer() {
         let mut schema_builder = Schema::builder();
-        let json_option = JsonObjectOptions::default().set_fast(Some("default"));
+        let json_option = JsonObjectOptions::default().set_fast("default");
         let json = schema_builder.add_json_field("json", json_option);
         let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
@@ -1134,7 +1135,7 @@ mod tests {
     fn test_fast_field_in_json_field_expand_dots_enabled() {
         let mut schema_builder = Schema::builder();
         let json_option = JsonObjectOptions::default()
-            .set_fast(None)
+            .set_fast("default")
             .set_expand_dots_enabled();
         let json = schema_builder.add_json_field("json", json_option);
         let schema = schema_builder.build();
@@ -1202,10 +1203,10 @@ mod tests {
     #[test]
     fn test_fast_field_tokenizer() {
         let mut schema_builder = Schema::builder();
-        let opt = TextOptions::default().set_fast(Some("custom_lowercase"));
+        let opt = TextOptions::default().set_fast("custom_lowercase");
         let text_field = schema_builder.add_text_field("text", opt);
         let schema = schema_builder.build();
-        let ff_tokenizer_manager = TokenizerManager::default();
+        let ff_tokenizer_manager = TokenizerManager::default_for_fast_fields();
         ff_tokenizer_manager.register(
             "custom_lowercase",
             TextAnalyzer::builder(RawTokenizer::default())
@@ -1238,7 +1239,7 @@ mod tests {
                     .set_index_option(crate::schema::IndexRecordOption::WithFreqs)
                     .set_tokenizer("raw"),
             )
-            .set_fast(Some("default"))
+            .set_fast("default")
             .set_stored();
 
         let log_field = schema_builder.add_text_field("log_level", text_fieldtype);
@@ -1271,7 +1272,7 @@ mod tests {
     fn test_shadowing_fast_field_with_expand_dots() {
         let mut schema_builder = Schema::builder();
         let json_option = JsonObjectOptions::default()
-            .set_fast(None)
+            .set_fast("default")
             .set_expand_dots_enabled();
         let json_field = schema_builder.add_json_field("jsonfield", json_option.clone());
         let shadowing_json_field = schema_builder.add_json_field("jsonfield.attr", json_option);

--- a/src/fastfield/readers.rs
+++ b/src/fastfield/readers.rs
@@ -349,7 +349,7 @@ mod tests {
         schema_builder.add_json_field(
             "json_expand_dots_enabled",
             JsonObjectOptions::default()
-                .set_fast(None)
+                .set_fast("default")
                 .set_expand_dots_enabled(),
         );
         let dynamic_field = schema_builder.add_json_field("_dyna", FAST);

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -956,7 +956,7 @@ mod test {
             .iter()
             .flat_map(|field_name| schema.get_field(field_name))
             .collect();
-        let tokenizer_manager = TokenizerManager::default();
+        let tokenizer_manager = TokenizerManager::default_for_indexing();
         tokenizer_manager.register(
             "en_with_stop_words",
             TextAnalyzer::builder(SimpleTokenizer::default())
@@ -1447,7 +1447,7 @@ mod test {
         let title = schema_builder.add_text_field("title", text_options);
         let schema = schema_builder.build();
         let default_fields = vec![title];
-        let tokenizer_manager = TokenizerManager::default();
+        let tokenizer_manager = TokenizerManager::default_for_indexing();
         let query_parser = QueryParser::new(schema, default_fields, tokenizer_manager);
 
         assert_matches!(
@@ -1622,7 +1622,8 @@ mod test {
         let mut schema_builder = Schema::builder();
         schema_builder.add_text_field(r#"a\.b"#, STRING);
         let schema = schema_builder.build();
-        let query_parser = QueryParser::new(schema, Vec::new(), TokenizerManager::default());
+        let query_parser =
+            QueryParser::new(schema, Vec::new(), TokenizerManager::default_for_indexing());
         let query = query_parser.parse_query(r#"a\.b:hello"#).unwrap();
         assert_eq!(
             format!("{query:?}"),
@@ -1639,8 +1640,11 @@ mod test {
         schema_builder.add_text_field("first.toto.titi", STRING);
         schema_builder.add_text_field("third.a.b.c", STRING);
         let schema = schema_builder.build();
-        let query_parser =
-            QueryParser::new(schema.clone(), Vec::new(), TokenizerManager::default());
+        let query_parser = QueryParser::new(
+            schema.clone(),
+            Vec::new(),
+            TokenizerManager::default_for_indexing(),
+        );
         assert_eq!(
             query_parser.split_full_path("first.toto"),
             Some((schema.get_field("first.toto").unwrap(), ""))

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,6 +1,6 @@
 //! Schema definition for tantivy's indices.
-//!
 //! # Setting your schema in Tantivy
+//!
 //!
 //! Tantivy has a very strict schema.
 //! The schema defines information about the fields your index contains, that is, for each field:
@@ -152,6 +152,8 @@ pub use self::schema::{DocParsingError, Schema, SchemaBuilder};
 pub use self::term::{Term, ValueBytes, JSON_END_OF_PATH};
 pub use self::text_options::{TextFieldIndexing, TextOptions, STRING, TEXT};
 pub use self::value::Value;
+
+pub(crate) const DEFAULT_FAST_FIELD_TOKENIZER: &str = "default";
 
 /// Validator for a potential `field_name`.
 /// Returns true if the name can be use for a field name.

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -189,7 +189,7 @@ pub mod tests {
 
     #[test]
     fn test_raw_tokenizer2() {
-        let tokenizer_manager = TokenizerManager::default();
+        let tokenizer_manager = TokenizerManager::default_for_indexing();
         let mut en_tokenizer = tokenizer_manager.get("raw").unwrap();
         let mut tokens: Vec<Token> = vec![];
         {
@@ -206,7 +206,7 @@ pub mod tests {
 
     #[test]
     fn test_en_tokenizer() {
-        let tokenizer_manager = TokenizerManager::default();
+        let tokenizer_manager = TokenizerManager::default_for_indexing();
         assert!(tokenizer_manager.get("en_doesnotexist").is_none());
         let mut en_tokenizer = tokenizer_manager.get("en_stem").unwrap();
         let mut tokens: Vec<Token> = vec![];
@@ -228,7 +228,7 @@ pub mod tests {
 
     #[test]
     fn test_non_en_tokenizer() {
-        let tokenizer_manager = TokenizerManager::default();
+        let tokenizer_manager = TokenizerManager::default_for_indexing();
         tokenizer_manager.register(
             "el_stem",
             TextAnalyzer::builder(SimpleTokenizer::default())
@@ -256,7 +256,7 @@ pub mod tests {
 
     #[test]
     fn test_tokenizer_empty() {
-        let tokenizer_manager = TokenizerManager::default();
+        let tokenizer_manager = TokenizerManager::default_for_indexing();
         let mut en_tokenizer = tokenizer_manager.get("en_stem").unwrap();
         {
             let mut tokens: Vec<Token> = vec![];
@@ -282,7 +282,7 @@ pub mod tests {
 
     #[test]
     fn test_whitespace_tokenizer() {
-        let tokenizer_manager = TokenizerManager::default();
+        let tokenizer_manager = TokenizerManager::default_for_indexing();
         let mut ws_tokenizer = tokenizer_manager.get("whitespace").unwrap();
         let mut tokens: Vec<Token> = vec![];
         {


### PR DESCRIPTION
`{ fast: true }` now results in the use of a the default fast field tokenizer. (instead of no tokenizer) The default tokenizer lowercases.

Fast field gets a different default tokenizer manager than the normal tokenizer.

The serialization of the fast field options is unchanged.