### PR TITLE
implement lenient parser

### DIFF
--- a/query-grammar/Cargo.toml
+++ b/query-grammar/Cargo.toml
@@ -12,6 +12,4 @@ keywords = ["search", "information", "retrieval"]
 edition = "2021"
 
 [dependencies]
-combine = {version="4", default-features=false, features=[] }
-once_cell = "1.7.2"
-regex ={ version = "1.5.4", default-features = false, features = ["std", "unicode"] }
+nom = "7"

--- a/query-grammar/src/infallible.rs
+++ b/query-grammar/src/infallible.rs
@@ -1,0 +1,291 @@
+//! nom combinators for infallible operations
+
+use nom::{IResult, InputLength};
+pub type ErrorList = Vec<(usize, String)>;
+pub type JResult<I,O> = IResult<I, (O, ErrorList), std::convert::Infallible>;
+
+// when rfcs#1733 get stabilized, this can make things clearer
+// trait InfallibleParser<I, O> = nom::Parser<I, (O, ErrorList), std::convert::Infallible>;
+
+// TODO space0 and space1: space0 can't fail, space1 can parse nothing but reports missing space
+
+
+/// A variant of the classical `opt` parser, except it returns an infallible error type.
+///
+/// It's less generic than the original to ease type resolution in the rest of the code.
+pub fn opt_i<I: Clone, O, F>(mut f: F) -> impl FnMut(I) -> JResult<I, Option<O>> where
+  F: nom::Parser<I, O, nom::error::Error<I>>,
+{
+  move |input: I| {
+    let i = input.clone();
+    match f.parse(input) {
+      Ok((i, o)) => Ok((i, (Some(o), Vec::new()))),
+      Err(_) => Ok((i, (None, Vec::new()))),
+    }
+  } 
+}
+
+pub fn fallible<I, O, E: nom::error::ParseError<I>, F>(mut f: F) -> impl FnMut(I) -> IResult<I, O, E>
+where F: nom::Parser<I, (O, ErrorList), std::convert::Infallible>
+{   
+    use nom::Err;
+    move |input: I|
+    match f.parse(input) {
+        Ok((input, (output, _err))) => Ok((input, output)),
+        Err(Err::Incomplete(needed)) => Err(Err::Incomplete(needed)),
+        Err(Err::Error(val)) | Err(Err::Failure(val)) => match val {},
+    }
+}
+
+pub fn delimited_infallible<I, O1, O2, O3, F, G, H>(
+  mut first: F,
+  mut second: G,
+  mut third: H,
+) -> impl FnMut(I) -> JResult<I, O2>
+where
+  F: nom::Parser<I, (O1, ErrorList), std::convert::Infallible>,
+  G: nom::Parser<I, (O2, ErrorList), std::convert::Infallible>,
+  H: nom::Parser<I, (O3, ErrorList), std::convert::Infallible>,
+{
+  move |input: I| {
+    let (input, (_, mut err)) = first.parse(input)?;
+    let (input, (o2, mut err2)) = second.parse(input)?;
+    err.append(&mut err2);
+    let (input, (_, mut err3)) = third.parse(input)?;
+    err.append(&mut err3);
+    Ok((input, (o2, err)))
+  }
+}
+
+// Parse nothing. Just a lazy way to not implement terminated/preceded and use delimited instead
+pub fn nothing(i: &str) -> JResult<&str, ()> {
+    Ok((i, ((), Vec::new())))
+}
+
+pub trait TupleInfallible<I, O> {
+  /// Parses the input and returns a tuple of results of each parser.
+  fn parse(&mut self, input: I) -> JResult<I, O>;
+}
+
+impl<Input, Output, F: nom::Parser<Input, (Output, ErrorList), std::convert::Infallible>>
+  TupleInfallible<Input, (Output,)> for (F,)
+{
+  fn parse(&mut self, input: Input) -> JResult<Input, (Output,)> {
+    self.0.parse(input).map(|(i, (o,e))| (i, ((o,),e)))
+  }
+}
+
+
+// these macros are heavily copied from nom, with some minor adaptations for our type
+macro_rules! tuple_trait(
+  ($name1:ident $ty1:ident, $name2: ident $ty2:ident, $($name:ident $ty:ident),*) => (
+    tuple_trait!(__impl $name1 $ty1, $name2 $ty2; $($name $ty),*);
+  );
+  (__impl $($name:ident $ty: ident),+; $name1:ident $ty1:ident, $($name2:ident $ty2:ident),*) => (
+    tuple_trait_impl!($($name $ty),+);
+    tuple_trait!(__impl $($name $ty),+ , $name1 $ty1; $($name2 $ty2),*);
+  );
+  (__impl $($name:ident $ty: ident),+; $name1:ident $ty1:ident) => (
+    tuple_trait_impl!($($name $ty),+);
+    tuple_trait_impl!($($name $ty),+, $name1 $ty1);
+  );
+);
+
+macro_rules! tuple_trait_impl(
+  ($($name:ident $ty: ident),+) => (
+    impl<
+      Input: Clone, $($ty),+ ,
+      $($name: nom::Parser<Input, ($ty, ErrorList), std::convert::Infallible>),+
+    > TupleInfallible<Input, ( $($ty),+ )> for ( $($name),+ ) {
+
+      fn parse(&mut self, input: Input) -> JResult<Input, ( $($ty),+ )> {
+        let mut error_list = Vec::new();
+        tuple_trait_inner!(0, self, input, (), error_list, $($name)+)
+      }
+    }
+  );
+);
+
+macro_rules! tuple_trait_inner(
+  ($it:tt, $self:expr, $input:expr, (), $error_list:expr, $head:ident $($id:ident)+) => ({
+    let (i, (o, mut err)) = $self.$it.parse($input.clone())?;
+    $error_list.append(&mut err);
+
+    succ!($it, tuple_trait_inner!($self, i, ( o ), $error_list, $($id)+))
+  });
+  ($it:tt, $self:expr, $input:expr, ($($parsed:tt)*), $error_list:expr, $head:ident $($id:ident)+) => ({
+    let (i, (o, mut err)) = $self.$it.parse($input.clone())?;
+    $error_list.append(&mut err);
+
+    succ!($it, tuple_trait_inner!($self, i, ($($parsed)* , o), $error_list, $($id)+))
+  });
+  ($it:tt, $self:expr, $input:expr, ($($parsed:tt)*), $error_list:expr, $head:ident) => ({
+    let (i, (o, mut err)) = $self.$it.parse($input.clone())?;
+    $error_list.append(&mut err);
+
+    Ok((i, (($($parsed)* , o), $error_list)))
+  });
+);
+
+macro_rules! succ (
+  (0, $submac:ident ! ($($rest:tt)*)) => ($submac!(1, $($rest)*));
+  (1, $submac:ident ! ($($rest:tt)*)) => ($submac!(2, $($rest)*));
+  (2, $submac:ident ! ($($rest:tt)*)) => ($submac!(3, $($rest)*));
+  (3, $submac:ident ! ($($rest:tt)*)) => ($submac!(4, $($rest)*));
+  (4, $submac:ident ! ($($rest:tt)*)) => ($submac!(5, $($rest)*));
+  (5, $submac:ident ! ($($rest:tt)*)) => ($submac!(6, $($rest)*));
+  (6, $submac:ident ! ($($rest:tt)*)) => ($submac!(7, $($rest)*));
+  (7, $submac:ident ! ($($rest:tt)*)) => ($submac!(8, $($rest)*));
+  (8, $submac:ident ! ($($rest:tt)*)) => ($submac!(9, $($rest)*));
+  (9, $submac:ident ! ($($rest:tt)*)) => ($submac!(10, $($rest)*));
+  (10, $submac:ident ! ($($rest:tt)*)) => ($submac!(11, $($rest)*));
+  (11, $submac:ident ! ($($rest:tt)*)) => ($submac!(12, $($rest)*));
+  (12, $submac:ident ! ($($rest:tt)*)) => ($submac!(13, $($rest)*));
+  (13, $submac:ident ! ($($rest:tt)*)) => ($submac!(14, $($rest)*));
+  (14, $submac:ident ! ($($rest:tt)*)) => ($submac!(15, $($rest)*));
+  (15, $submac:ident ! ($($rest:tt)*)) => ($submac!(16, $($rest)*));
+  (16, $submac:ident ! ($($rest:tt)*)) => ($submac!(17, $($rest)*));
+  (17, $submac:ident ! ($($rest:tt)*)) => ($submac!(18, $($rest)*));
+  (18, $submac:ident ! ($($rest:tt)*)) => ($submac!(19, $($rest)*));
+  (19, $submac:ident ! ($($rest:tt)*)) => ($submac!(20, $($rest)*));
+  (20, $submac:ident ! ($($rest:tt)*)) => ($submac!(21, $($rest)*));
+);
+
+tuple_trait!(FnA A, FnB B, FnC C, FnD D, FnE E, FnF F, FnG G, FnH H, FnI I, FnJ J, FnK K, FnL L,
+  FnM M, FnN N, FnO O, FnP P, FnQ Q, FnR R, FnS S, FnT T, FnU U);
+
+
+// Special case: implement `TupleInfallible` for `()`, the unit type.
+// This can come up in macros which accept a variable number of arguments.
+// Literally, `()` is an empty tuple, so it should simply parse nothing.
+impl<I> TupleInfallible<I, ()> for () {
+  fn parse(&mut self, input: I) -> JResult<I, ()> {
+    Ok((input, ((), Vec::new())))
+  }
+}
+
+pub fn tuple_infallible<I, O, List: TupleInfallible<I, O>>(
+  mut l: List,
+) -> impl FnMut(I) -> JResult<I, O> {
+  move |i: I| l.parse(i)
+}
+
+pub fn separated_list_infallible<I, O, O2, F, G>(
+  mut sep: G,
+  mut f: F,
+) -> impl FnMut(I) -> JResult<I, Vec<O>>
+where
+  I: Clone + InputLength,
+  F: nom::Parser<I, (O, ErrorList), std::convert::Infallible>,
+  G: nom::Parser<I, (O2, ErrorList), std::convert::Infallible>,
+{
+  move |mut i: I| {
+    let mut res = Vec::new();
+    let mut errors = Vec::new();
+
+    match f.parse(i.clone()) {
+      Err(_) => unreachable!(),
+      Ok((i1, (o, mut err))) => {
+        errors.append(&mut err);
+        res.push(o);
+        i = i1;
+      }
+    }
+
+    loop {
+      let len = i.input_len();
+      match sep.parse(i.clone()) {
+        Err(_) => unreachable!(),
+        Ok((i1, (_, mut err))) => {
+          errors.append(&mut err);
+
+          match f.parse(i1.clone()) {
+            Err(_) => unreachable!(),
+            Ok((i2, (o, mut err))) => {
+              // infinite loop check: the parser must always consume
+              // if we consumed nothing here, don't produce an element.
+              if i2.input_len() == len {
+                return Ok((i1, (res, errors))); 
+              }
+              res.push(o);
+              errors.append(&mut err);
+               i = i2;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+pub trait Alt<I, O> {
+  /// Tests each parser in the tuple and returns the result of the first one that succeeds
+  fn choice(&mut self, input: I) -> Option<JResult<I, O>>;
+}
+
+macro_rules! alt_trait(
+  ($first_cond:ident $first:ident, $($id_cond:ident $id: ident),+) => (
+    alt_trait!(__impl $first_cond $first; $($id_cond $id),+);
+  );
+  (__impl $($current_cond:ident $current:ident),*; $head_cond:ident $head:ident, $($id_cond:ident $id:ident),+) => (
+    alt_trait_impl!($($current_cond $current),*);
+
+    alt_trait!(__impl $($current_cond $current,)* $head_cond $head; $($id_cond $id),+);
+  );
+  (__impl $($current_cond:ident $current:ident),*; $head_cond:ident $head:ident) => (
+    alt_trait_impl!($($current_cond $current),*);
+    alt_trait_impl!($($current_cond $current,)* $head_cond $head);
+  );
+);
+
+macro_rules! alt_trait_impl(
+  ($($id_cond:ident $id:ident),+) => (
+    impl<
+      Input: Clone, Output,
+      $(
+          // () are to make things easier on me, but I'm not entirely sure whether we can do better
+          // with rule E0207
+          $id_cond: nom::Parser<Input, (), ()>,
+          $id: nom::Parser<Input, (Output, ErrorList), std::convert::Infallible>
+      ),+
+    > Alt<Input, Output> for ( $(($id_cond, $id),)+ ) {
+
+      fn choice(&mut self, input: Input) -> Option<JResult<Input, Output>> {
+        match self.0.0.parse(input.clone()) {
+          Err(_) => alt_trait_inner!(1, self, input, $($id_cond $id),+),
+          Ok((i1, _)) => Some(self.0.1.parse(i1)),
+        }
+      }
+    }
+  );
+);
+
+macro_rules! alt_trait_inner(
+  ($it:tt, $self:expr, $input:expr, $head_cond:ident $head:ident, $($id_cond:ident $id:ident),+) => (
+    match $self.$it.0.parse($input.clone()) {
+      Err(_) => succ!($it, alt_trait_inner!($self, $input, $($id_cond $id),+)),
+      Ok((i1, _)) => Some($self.$it.1.parse(i1)),
+    }
+  );
+  ($it:tt, $self:expr, $input:expr, $head_cond:ident $head:ident) => (
+    None
+  );
+);
+
+alt_trait!(A1 A, B1 B, C1 C, D1 D, E1 E, F1 F, G1 G, H1 H, I1 I, J1 J, K1 K,
+           L1 L, M1 M, N1 N, O1 O, P1 P, Q1 Q, R1 R, S1 S, T1 T, U1 U);
+
+/// An alt() like combinator. For each branch, it first tries a fallible parser, which commits to
+/// this branch, or tells to check next branch, and the execute the infallible parser which follow.
+///
+/// In case no branch match, the default (fallible) parser is executed.
+pub fn alt_infallible<I: Clone, O, F, List: Alt<I, O>>(
+  mut l: List,
+  mut default: F,
+) -> impl FnMut(I) -> JResult<I, O> where
+  F: nom::Parser<I, (O, ErrorList), std::convert::Infallible>,
+{
+  move |i: I| {
+      l.choice(i.clone()).unwrap_or_else(|| default.parse(i))
+  }
+}

--- a/query-grammar/src/lib.rs
+++ b/query-grammar/src/lib.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+mod infallible;
 mod occur;
 mod query_grammar;
 mod user_input_ast;
-mod infallible;
 
 pub use crate::occur::Occur;
 use crate::query_grammar::{parse_to_ast, parse_to_ast_lenient};

--- a/query-grammar/src/lib.rs
+++ b/query-grammar/src/lib.rs
@@ -5,6 +5,7 @@ mod occur;
 mod query_grammar;
 mod user_input_ast;
 
+pub use crate::infallible::LenientError;
 pub use crate::occur::Occur;
 use crate::query_grammar::{parse_to_ast, parse_to_ast_lenient};
 pub use crate::user_input_ast::{
@@ -20,6 +21,6 @@ pub fn parse_query(query: &str) -> Result<UserInputAst, Error> {
 }
 
 /// Parse a query, trying to recover from syntax errors, and giving hints toward fixing errors.
-pub fn parse_query_leniet(query: &str) -> (UserInputAst, Vec<(usize, String)>) {
+pub fn parse_query_lenient(query: &str) -> (UserInputAst, Vec<LenientError>) {
     parse_to_ast_lenient(query)
 }

--- a/query-grammar/src/lib.rs
+++ b/query-grammar/src/lib.rs
@@ -3,7 +3,6 @@
 mod occur;
 mod query_grammar;
 mod user_input_ast;
-use combine::parser::Parser;
 
 pub use crate::occur::Occur;
 use crate::query_grammar::parse_to_ast;
@@ -14,6 +13,6 @@ pub use crate::user_input_ast::{
 pub struct Error;
 
 pub fn parse_query(query: &str) -> Result<UserInputAst, Error> {
-    let (user_input_ast, _remaining) = parse_to_ast().parse(query).map_err(|_| Error)?;
+    let (_remaining, user_input_ast) = parse_to_ast(query).map_err(|_| Error)?;
     Ok(user_input_ast)
 }

--- a/query-grammar/src/lib.rs
+++ b/query-grammar/src/lib.rs
@@ -3,16 +3,23 @@
 mod occur;
 mod query_grammar;
 mod user_input_ast;
+mod infallible;
 
 pub use crate::occur::Occur;
-use crate::query_grammar::parse_to_ast;
+use crate::query_grammar::{parse_to_ast, parse_to_ast_lenient};
 pub use crate::user_input_ast::{
     Delimiter, UserInputAst, UserInputBound, UserInputLeaf, UserInputLiteral,
 };
 
 pub struct Error;
 
+/// Parse a query
 pub fn parse_query(query: &str) -> Result<UserInputAst, Error> {
     let (_remaining, user_input_ast) = parse_to_ast(query).map_err(|_| Error)?;
     Ok(user_input_ast)
+}
+
+/// Parse a query, trying to recover from syntax errors, and giving hints toward fixing errors.
+pub fn parse_query_leniet(query: &str) -> (UserInputAst, Vec<(usize, String)>) {
+    parse_to_ast_lenient(query)
 }

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -264,12 +264,12 @@ fn term_group_infallible(i: &str) -> JResult<&str, UserInputAst> {
     let mut errs = Vec::new();
 
     loop {
-        if i.len() == 0 {
+        if i.is_empty() {
             // TODO push error about missing )
             break Ok((i, (UserInputAst::Clause(terms), errs)));
         }
-        if i.starts_with(')') {
-            break Ok((&i[1..], (UserInputAst::Clause(terms), errs)));
+        if let Some(i) = i.strip_prefix(')') {
+            break Ok((i, (UserInputAst::Clause(terms), errs)));
         }
         // here we do the assumption term_or_phrase_infallible always consume something if the
         // first byte is not `)` or ' '. If it did not, we would end up looping.
@@ -554,7 +554,7 @@ fn set_infallible(mut i: &str) -> JResult<&str, UserInputLeaf> {
     let mut elements = Vec::new();
     let mut errs = Vec::new();
     loop {
-        if i.len() == 0 {
+        if i.is_empty() {
             // TODO push error about missing ]
             break Ok((
                 i,
@@ -567,9 +567,9 @@ fn set_infallible(mut i: &str) -> JResult<&str, UserInputLeaf> {
                 ),
             ));
         }
-        if i.starts_with(']') {
+        if let Some(i) = i.strip_prefix(']') {
             break Ok((
-                &i[1..],
+                i,
                 (
                     UserInputLeaf::Set {
                         field: None,
@@ -686,6 +686,7 @@ fn occur_leaf(i: &str) -> IResult<&str, (Option<Occur>, UserInputAst)> {
     tuple((fallible(occur_symbol), boosted_leaf))(i)
 }
 
+#[allow(clippy::type_complexity)]
 fn operand_occur_leaf_infallible(
     i: &str,
 ) -> JResult<&str, (Option<BinaryOperand>, Option<Occur>, Option<UserInputAst>)> {

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -1,15 +1,13 @@
-use combine::error::StringStreamError;
-use combine::parser::char::{char, digit, space, spaces, string};
-use combine::parser::combinator::recognize;
-use combine::parser::range::{take_while, take_while1};
-use combine::parser::repeat::escaped;
-use combine::parser::Parser;
-use combine::{
-    any, attempt, between, choice, eof, many, many1, one_of, optional, parser, satisfy, sep_by,
-    skip_many1, value,
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::character::complete::{
+    anychar, char, digit1, none_of, one_of, satisfy, space0, space1, u32,
 };
-use once_cell::sync::Lazy;
-use regex::Regex;
+use nom::combinator::{eof, map, map_res, opt, recognize, value, verify};
+use nom::error::{Error, ErrorKind};
+use nom::multi::{many0, many1, separated_list0, separated_list1};
+use nom::sequence::{delimited, preceded, separated_pair, terminated, tuple};
+use nom::IResult;
 
 use super::user_input_ast::{UserInputAst, UserInputBound, UserInputLeaf, UserInputLiteral};
 use crate::user_input_ast::Delimiter;
@@ -20,181 +18,108 @@ use crate::Occur;
 const SPECIAL_CHARS: &[char] = &[
     '+', '^', '`', ':', '{', '}', '"', '[', ']', '(', ')', '!', '\\', '*', ' ',
 ];
-const ESCAPED_SPECIAL_CHARS_PATTERN: &str = r#"\\(\+|\^|`|:|\{|\}|"|\[|\]|\(|\)|!|\\|\*|\s)"#;
 
-/// Parses a field_name
-/// A field name must have at least one character and be followed by a colon.
-/// All characters are allowed including special characters `SPECIAL_CHARS`, but these
-/// need to be escaped with a backslash character '\'.
-fn field_name<'a>() -> impl Parser<&'a str, Output = String> {
-    static ESCAPED_SPECIAL_CHARS_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(ESCAPED_SPECIAL_CHARS_PATTERN).unwrap());
+/// consume a field name followed by collon. Return the field name with escape sequence
+/// already interpreted
+fn field_name(i: &str) -> IResult<&str, String> {
+    let simple_char = none_of(SPECIAL_CHARS);
+    let first_char = verify(none_of(SPECIAL_CHARS), |c| *c != '-');
+    let escape_sequence = || preceded(char('\\'), one_of(SPECIAL_CHARS));
 
-    recognize::<String, _, _>(escaped(
-        (
-            take_while1(|c| !SPECIAL_CHARS.contains(&c) && c != '-'),
-            take_while(|c| !SPECIAL_CHARS.contains(&c)),
+    map(
+        terminated(
+            tuple((
+                alt((first_char, escape_sequence())),
+                many0(alt((simple_char, escape_sequence(), char('\\')))),
+            )),
+            char(':'),
         ),
-        '\\',
-        satisfy(|_| true), /* if the next character is not a special char, the \ will be treated
-                            * as the \ character. */
-    ))
-    .skip(char(':'))
-    .map(|s| ESCAPED_SPECIAL_CHARS_RE.replace_all(&s, "$1").to_string())
-    .and_then(|s: String| match s.is_empty() {
-        true => Err(StringStreamError::UnexpectedParse),
-        _ => Ok(s),
-    })
+        |(first_char, next)| {
+            std::iter::once(first_char)
+                .chain(next.into_iter())
+                .collect()
+        },
+    )(i)
 }
 
-fn word<'a>() -> impl Parser<&'a str, Output = String> {
-    (
-        satisfy(|c: char| {
-            !c.is_whitespace()
-                && !['-', '^', '`', ':', '{', '}', '"', '[', ']', '(', ')'].contains(&c)
-        }),
-        many(satisfy(|c: char| {
-            !c.is_whitespace() && ![':', '^', '{', '}', '"', '[', ']', '(', ')'].contains(&c)
-        })),
-    )
-        .map(|(s1, s2): (char, String)| format!("{s1}{s2}"))
-        .and_then(|s: String| match s.as_str() {
-            "OR" | "AND " | "NOT" => Err(StringStreamError::UnexpectedParse),
+/// Consume a word outside of any context.
+// TODO should support escape sequences
+fn word(i: &str) -> IResult<&str, &str> {
+    map_res(
+        recognize(tuple((
+            satisfy(|c| {
+                !c.is_whitespace()
+                    && !['-', '^', '`', ':', '{', '}', '"', '[', ']', '(', ')'].contains(&c)
+            }),
+            many0(satisfy(|c: char| {
+                !c.is_whitespace() && ![':', '^', '{', '}', '"', '[', ']', '(', ')'].contains(&c)
+            })),
+        ))),
+        |s| match s {
+            "OR" | "AND" | "NOT" | "IN" => Err(Error::new(i, ErrorKind::Tag)),
             _ => Ok(s),
-        })
+        },
+    )(i)
 }
 
-// word variant that allows more characters, e.g. for range queries that don't allow field
-// specifier
-fn relaxed_word<'a>() -> impl Parser<&'a str, Output = String> {
-    (
-        satisfy(|c: char| {
-            !c.is_whitespace() && !['`', '{', '}', '"', '[', ']', '(', ')'].contains(&c)
-        }),
-        many(satisfy(|c: char| {
+/// Consume a word inside a Range context. More values are allowed as they are
+/// not ambiguous in this context.
+// TODO support escape sequences
+fn relaxed_word(i: &str) -> IResult<&str, &str> {
+    recognize(tuple((
+        satisfy(|c| !c.is_whitespace() && !['`', '{', '}', '"', '[', ']', '(', ')'].contains(&c)),
+        many0(satisfy(|c: char| {
             !c.is_whitespace() && !['{', '}', '"', '[', ']', '(', ')'].contains(&c)
         })),
-    )
-        .map(|(s1, s2): (char, String)| format!("{s1}{s2}"))
+    )))(i)
 }
 
-/// Parses a date time according to rfc3339
-/// 2015-08-02T18:54:42+02
-/// 2021-04-13T19:46:26.266051969+00:00
-///
-/// NOTE: also accepts 999999-99-99T99:99:99.266051969+99:99
-/// We delegate rejecting such invalid dates to the logical AST computation code
-/// which invokes `time::OffsetDateTime::parse(..., &Rfc3339)` on the value to actually parse
-/// it (instead of merely extracting the datetime value as string as done here).
-fn date_time<'a>() -> impl Parser<&'a str, Output = String> {
-    let two_digits = || recognize::<String, _, _>((digit(), digit()));
+fn negative_number(i: &str) -> IResult<&str, &str> {
+    recognize(preceded(
+        char('-'),
+        tuple((digit1, opt(tuple((char('.'), digit1))))),
+    ))(i)
+}
 
-    // Parses a time zone
-    // -06:30
-    // Z
-    let time_zone = {
-        let utc = recognize::<String, _, _>(char('Z'));
-        let offset = recognize((
-            choice([char('-'), char('+')]),
-            two_digits(),
-            char(':'),
-            two_digits(),
-        ));
-
-        utc.or(offset)
+fn simple_term(i: &str) -> IResult<&str, (Delimiter, String)> {
+    // TODO lenient: if unfinished, assume it end at end of buffer or next `term_name:`.
+    // emit message about unfinished delimiter
+    let escaped_string = |delimiter| {
+        // we need this because none_of can't accept an owned array of char.
+        let not_delimiter = verify(anychar, move |parsed| *parsed != delimiter);
+        map(
+            delimited(
+                char(delimiter),
+                many0(alt((preceded(char('\\'), anychar), not_delimiter))),
+                char(delimiter),
+            ),
+            |res| res.into_iter().collect::<String>(),
+        )
     };
 
-    // Parses a date
-    // 2010-01-30
-    let date = {
-        recognize::<String, _, _>((
-            many1::<String, _, _>(digit()),
-            char('-'),
-            two_digits(),
-            char('-'),
-            two_digits(),
-        ))
-    };
+    let negative_number = map(negative_number, |number| {
+        (Delimiter::None, number.to_string())
+    });
+    let double_quotes = map(escaped_string('"'), |phrase| {
+        (Delimiter::DoubleQuotes, phrase)
+    });
+    let simple_quotes = map(escaped_string('\''), |phrase| {
+        (Delimiter::SingleQuotes, phrase)
+    });
+    let text_no_delimiter = map(word, |text| (Delimiter::None, text.to_string()));
 
-    // Parses a time
-    // 12:30:02
-    // 19:46:26.266051969
-    let time = {
-        recognize::<String, _, _>((
-            two_digits(),
-            char(':'),
-            two_digits(),
-            char(':'),
-            two_digits(),
-            optional((char('.'), many1::<String, _, _>(digit()))),
-            time_zone,
-        ))
-    };
-
-    recognize((date, char('T'), time))
+    alt((
+        negative_number,
+        simple_quotes,
+        double_quotes,
+        text_no_delimiter,
+    ))(i)
 }
 
-fn escaped_character<'a>() -> impl Parser<&'a str, Output = char> {
-    (char('\\'), any()).map(|(_, x)| x)
-}
-
-fn escaped_string<'a>(delimiter: char) -> impl Parser<&'a str, Output = String> {
-    (
-        char(delimiter),
-        many(choice((
-            escaped_character(),
-            satisfy(move |c: char| c != delimiter),
-        ))),
-        char(delimiter),
-    )
-        .map(|(_, s, _)| s)
-}
-
-fn term_val<'a>() -> impl Parser<&'a str, Output = (Delimiter, String)> {
-    let double_quotes = escaped_string('"').map(|phrase| (Delimiter::DoubleQuotes, phrase));
-    let single_quotes = escaped_string('\'').map(|phrase| (Delimiter::SingleQuotes, phrase));
-    let text_no_delimiter = word().map(|text| (Delimiter::None, text));
-    negative_number()
-        .map(|negative_number_str| (Delimiter::None, negative_number_str))
-        .or(double_quotes)
-        .or(single_quotes)
-        .or(text_no_delimiter)
-}
-
-fn term_query<'a>() -> impl Parser<&'a str, Output = UserInputLiteral> {
-    (field_name(), term_val(), slop_or_prefix_val()).map(
-        |(field_name, (delimiter, phrase), (slop, prefix))| UserInputLiteral {
-            field_name: Some(field_name),
-            phrase,
-            delimiter,
-            slop,
-            prefix,
-        },
-    )
-}
-
-fn slop_or_prefix_val<'a>() -> impl Parser<&'a str, Output = (u32, bool)> {
-    let prefix_val = char('*').map(|_ast| (0, true));
-    let slop_val = slop_val().map(|slop| (slop, false));
-
-    prefix_val.or(slop_val)
-}
-
-fn slop_val<'a>() -> impl Parser<&'a str, Output = u32> {
-    let slop =
-        (char('~'), many1(digit())).and_then(|(_, slop): (_, String)| match slop.parse::<u32>() {
-            Ok(d) => Ok(d),
-            _ => Err(StringStreamError::UnexpectedParse),
-        });
-    optional(slop).map(|slop| match slop {
-        Some(d) => d,
-        _ => 0,
-    })
-}
-
-fn literal<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
-    let term_default_field =
-        (term_val(), slop_or_prefix_val()).map(|((delimiter, phrase), (slop, prefix))| {
+fn literal(i: &str) -> IResult<&str, UserInputLeaf> {
+    let term_or_phrase = map(
+        tuple((simple_term, slop_or_prefix_val)),
+        |((delimiter, phrase), (slop, prefix))| {
             UserInputLiteral {
                 field_name: None,
                 phrase,
@@ -202,67 +127,68 @@ fn literal<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
                 slop,
                 prefix,
             }
-        });
+            .into()
+        },
+    );
 
-    attempt(term_query())
-        .or(term_default_field)
-        .map(UserInputLeaf::from)
+    alt((
+        map(char('*'), |_| UserInputLeaf::All),
+        map(
+            tuple((
+                opt(field_name),
+                alt((
+                    range,
+                    set,
+                    term_or_phrase,
+                    // TODO term grouping should go here (ie `my_field:(+a +"bc d")`)
+                )),
+            )),
+            |(field_name, leaf): (Option<String>, UserInputLeaf)| leaf.set_field(field_name),
+        ),
+    ))(i)
 }
 
-fn negative_number<'a>() -> impl Parser<&'a str, Output = String> {
-    (
-        char('-'),
-        many1(digit()),
-        optional((char('.'), many1(digit()))),
-    )
-        .map(|(s1, s2, s3): (char, String, Option<(char, String)>)| {
-            if let Some(('.', s3)) = s3 {
-                format!("{s1}{s2}.{s3}")
-            } else {
-                format!("{s1}{s2}")
-            }
-        })
-}
-
-fn spaces1<'a>() -> impl Parser<&'a str, Output = ()> {
-    skip_many1(space())
+fn slop_or_prefix_val(i: &str) -> IResult<&str, (u32, bool)> {
+    map(
+        opt(alt((
+            value((0, true), char('*')),
+            map(preceded(char('~'), u32), |slop| (slop, false)),
+        ))),
+        |slop_or_prefix_opt| slop_or_prefix_opt.unwrap_or_default(),
+    )(i)
 }
 
 /// Function that parses a range out of a Stream
 /// Supports ranges like:
 /// [5 TO 10], {5 TO 10}, [* TO 10], [10 TO *], {10 TO *], >5, <=10
 /// [a TO *], [a TO c], [abc TO bcd}
-fn range<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
+fn range(i: &str) -> IResult<&str, UserInputLeaf> {
     let range_term_val = || {
-        attempt(date_time())
-            .or(negative_number())
-            .or(relaxed_word())
-            .or(char('*').with(value("*".to_string())))
+        map(
+            alt((negative_number, relaxed_word, tag("*"))),
+            ToString::to_string,
+        )
     };
 
     // check for unbounded range in the form of <5, <=10, >5, >=5
-    let elastic_unbounded_range = (
-        choice([
-            attempt(string(">=")),
-            attempt(string("<=")),
-            attempt(string("<")),
-            attempt(string(">")),
-        ])
-        .skip(spaces()),
-        range_term_val(),
-    )
-        .map(
-            |(comparison_sign, bound): (&str, String)| match comparison_sign {
-                ">=" => (UserInputBound::Inclusive(bound), UserInputBound::Unbounded),
-                "<=" => (UserInputBound::Unbounded, UserInputBound::Inclusive(bound)),
-                "<" => (UserInputBound::Unbounded, UserInputBound::Exclusive(bound)),
-                ">" => (UserInputBound::Exclusive(bound), UserInputBound::Unbounded),
-                // default case
-                _ => (UserInputBound::Unbounded, UserInputBound::Unbounded),
-            },
-        );
-    let lower_bound = (one_of("{[".chars()), range_term_val()).map(
-        |(boundary_char, lower_bound): (char, String)| {
+    let elastic_unbounded_range = map(
+        tuple((
+            preceded(space0, alt((tag(">="), tag("<="), tag("<"), tag(">")))),
+            preceded(space0, range_term_val()),
+        )),
+        |(comparison_sign, bound)| match comparison_sign {
+            ">=" => (UserInputBound::Inclusive(bound), UserInputBound::Unbounded),
+            "<=" => (UserInputBound::Unbounded, UserInputBound::Inclusive(bound)),
+            "<" => (UserInputBound::Unbounded, UserInputBound::Exclusive(bound)),
+            ">" => (UserInputBound::Exclusive(bound), UserInputBound::Unbounded),
+            // unreachable case
+            _ => (UserInputBound::Unbounded, UserInputBound::Unbounded),
+        },
+    );
+
+    let lower_bound = map(
+        separated_pair(one_of("{["), space0, range_term_val()),
+        |(boundary_char, lower_bound)| {
             if lower_bound == "*" {
                 UserInputBound::Unbounded
             } else if boundary_char == '{' {
@@ -272,108 +198,95 @@ fn range<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
             }
         },
     );
-    let upper_bound = (range_term_val(), one_of("}]".chars())).map(
-        |(higher_bound, boundary_char): (String, char)| {
-            if higher_bound == "*" {
+
+    let upper_bound = map(
+        separated_pair(range_term_val(), space0, one_of("}]")),
+        |(upper_bound, boundary_char)| {
+            if upper_bound == "*" {
                 UserInputBound::Unbounded
             } else if boundary_char == '}' {
-                UserInputBound::Exclusive(higher_bound)
+                UserInputBound::Exclusive(upper_bound)
             } else {
-                UserInputBound::Inclusive(higher_bound)
+                UserInputBound::Inclusive(upper_bound)
             }
         },
     );
-    // return only lower and upper
-    let lower_to_upper = (
-        lower_bound.skip((spaces(), string("TO"), spaces())),
-        upper_bound,
-    );
 
-    (
-        optional(field_name()).skip(spaces()),
-        // try elastic first, if it matches, the range is unbounded
-        attempt(elastic_unbounded_range).or(lower_to_upper),
-    )
-        .map(|(field, (lower, upper))|
-             // Construct the leaf from extracted field (optional)
-             // and bounds
-             UserInputLeaf::Range {
-                 field,
-                 lower,
-                 upper
-    })
+    let lower_to_upper =
+        separated_pair(lower_bound, tuple((space1, tag("TO"), space1)), upper_bound);
+
+    map(
+        alt((elastic_unbounded_range, lower_to_upper)),
+        |(lower, upper)| UserInputLeaf::Range {
+            field: None,
+            lower,
+            upper,
+        },
+    )(i)
 }
 
-/// Function that parses a set out of a Stream
-/// Supports ranges like: `IN [val1 val2 val3]`
-fn set<'a>() -> impl Parser<&'a str, Output = UserInputLeaf> {
-    let term_list = between(
-        char('['),
-        char(']'),
-        sep_by(term_val().map(|(_delimiter, text)| text), spaces()),
-    );
-
-    let set_content = ((string("IN"), spaces()), term_list).map(|(_, elements)| elements);
-
-    (optional(attempt(field_name().skip(spaces()))), set_content)
-        .map(|(field, elements)| UserInputLeaf::Set { field, elements })
+fn set(i: &str) -> IResult<&str, UserInputLeaf> {
+    map(
+        preceded(
+            tuple((space0, tag("IN"), space1)),
+            delimited(
+                tuple((char('['), space0)),
+                separated_list0(space1, map(simple_term, |(_, term)| term)),
+                char(']'),
+            ),
+        ),
+        |elements| UserInputLeaf::Set {
+            field: None,
+            elements,
+        },
+    )(i)
 }
 
 fn negate(expr: UserInputAst) -> UserInputAst {
     expr.unary(Occur::MustNot)
 }
 
-fn leaf<'a>() -> impl Parser<&'a str, Output = UserInputAst> {
-    parser(|input| {
-        char('(')
-            .with(ast())
-            .skip(char(')'))
-            .or(char('*').map(|_| UserInputAst::from(UserInputLeaf::All)))
-            .or(attempt(
-                string("NOT").skip(spaces1()).with(leaf()).map(negate),
-            ))
-            .or(attempt(range().map(UserInputAst::from)))
-            .or(attempt(set().map(UserInputAst::from)))
-            .or(literal().map(UserInputAst::from))
-            .parse_stream(input)
-            .into_result()
-    })
+fn leaf(i: &str) -> IResult<&str, UserInputAst> {
+    alt((
+        delimited(char('('), ast, char(')')),
+        map(char('*'), |_| UserInputAst::from(UserInputLeaf::All)),
+        map(preceded(tuple((tag("NOT"), space1)), leaf), negate),
+        map(literal, UserInputAst::from),
+    ))(i)
 }
 
-fn occur_symbol<'a>() -> impl Parser<&'a str, Output = Occur> {
-    char('-')
-        .map(|_| Occur::MustNot)
-        .or(char('+').map(|_| Occur::Must))
+fn occur_leaf(i: &str) -> IResult<&str, (Option<Occur>, UserInputAst)> {
+    let occur_symbol = alt((
+        value(Occur::MustNot, char('-')),
+        value(Occur::Must, char('+')),
+    ));
+
+    tuple((opt(occur_symbol), boosted_leaf))(i)
 }
 
-fn occur_leaf<'a>() -> impl Parser<&'a str, Output = (Option<Occur>, UserInputAst)> {
-    (optional(occur_symbol()), boosted_leaf())
+fn positive_float_number(i: &str) -> IResult<&str, f64> {
+    map(
+        recognize(tuple((digit1, opt(tuple((char('.'), digit1)))))),
+        // TODO this is actually dangerous if the number is actually not representable as a f64
+        // (too big for instance)
+        |float_str: &str| float_str.parse::<f64>().unwrap(),
+    )(i)
 }
 
-fn positive_float_number<'a>() -> impl Parser<&'a str, Output = f64> {
-    (many1(digit()), optional((char('.'), many1(digit())))).map(
-        |(int_part, decimal_part_opt): (String, Option<(char, String)>)| {
-            let mut float_str = int_part;
-            if let Some((chr, decimal_str)) = decimal_part_opt {
-                float_str.push(chr);
-                float_str.push_str(&decimal_str);
+fn boost(i: &str) -> IResult<&str, f64> {
+    preceded(char('^'), positive_float_number)(i)
+}
+
+fn boosted_leaf(i: &str) -> IResult<&str, UserInputAst> {
+    map(
+        tuple((leaf, opt(boost))),
+        |(leaf, boost_opt)| match boost_opt {
+            Some(boost) if (boost - 1.0).abs() > f64::EPSILON => {
+                UserInputAst::Boost(Box::new(leaf), boost)
             }
-            float_str.parse::<f64>().unwrap()
+            _ => leaf,
         },
-    )
-}
-
-fn boost<'a>() -> impl Parser<&'a str, Output = f64> {
-    (char('^'), positive_float_number()).map(|(_, boost)| boost)
-}
-
-fn boosted_leaf<'a>() -> impl Parser<&'a str, Output = UserInputAst> {
-    (leaf(), optional(boost())).map(|(leaf, boost_opt)| match boost_opt {
-        Some(boost) if (boost - 1.0).abs() > f64::EPSILON => {
-            UserInputAst::Boost(Box::new(leaf), boost)
-        }
-        _ => leaf,
-    })
+    )(i)
 }
 
 #[derive(Clone, Copy)]
@@ -382,10 +295,11 @@ enum BinaryOperand {
     And,
 }
 
-fn binary_operand<'a>() -> impl Parser<&'a str, Output = BinaryOperand> {
-    string("AND")
-        .with(value(BinaryOperand::And))
-        .or(string("OR").with(value(BinaryOperand::Or)))
+fn binary_operand(i: &str) -> IResult<&str, BinaryOperand> {
+    alt((
+        value(BinaryOperand::And, tag("AND")),
+        value(BinaryOperand::Or, tag("OR")),
+    ))(i)
 }
 
 fn aggregate_binary_expressions(
@@ -413,38 +327,41 @@ fn aggregate_binary_expressions(
     }
 }
 
-fn operand_leaf<'a>() -> impl Parser<&'a str, Output = (BinaryOperand, UserInputAst)> {
-    (
-        binary_operand().skip(spaces()),
-        boosted_leaf().skip(spaces()),
-    )
+fn operand_leaf(i: &str) -> IResult<&str, (BinaryOperand, UserInputAst)> {
+    tuple((
+        terminated(binary_operand, space1),
+        terminated(boosted_leaf, space0),
+    ))(i)
 }
 
-pub fn ast<'a>() -> impl Parser<&'a str, Output = UserInputAst> {
-    let boolean_expr = (boosted_leaf().skip(spaces()), many1(operand_leaf()))
-        .map(|(left, right)| aggregate_binary_expressions(left, right));
-    let whitespace_separated_leaves = many1(occur_leaf().skip(spaces().silent())).map(
-        |subqueries: Vec<(Option<Occur>, UserInputAst)>| {
-            if subqueries.len() == 1 {
-                let (occur_opt, ast) = subqueries.into_iter().next().unwrap();
-                match occur_opt.unwrap_or(Occur::Should) {
-                    Occur::Must | Occur::Should => ast,
-                    Occur::MustNot => UserInputAst::Clause(vec![(Some(Occur::MustNot), ast)]),
-                }
-            } else {
-                UserInputAst::Clause(subqueries.into_iter().collect())
-            }
-        },
+pub fn ast(i: &str) -> IResult<&str, UserInputAst> {
+    let boolean_expr = map(
+        separated_pair(boosted_leaf, space1, many1(operand_leaf)),
+        |(left, right)| aggregate_binary_expressions(left, right),
     );
-    let expr = attempt(boolean_expr).or(whitespace_separated_leaves);
-    spaces().with(expr).skip(spaces())
+    let whitespace_separated_leaves = map(separated_list1(space1, occur_leaf), |subqueries| {
+        if subqueries.len() == 1 {
+            let (occur_opt, ast) = subqueries.into_iter().next().unwrap();
+            match occur_opt.unwrap_or(Occur::Should) {
+                Occur::Must | Occur::Should => ast,
+                Occur::MustNot => UserInputAst::Clause(vec![(Some(Occur::MustNot), ast)]),
+            }
+        } else {
+            UserInputAst::Clause(subqueries.into_iter().collect())
+        }
+    });
+
+    delimited(
+        space0,
+        alt((boolean_expr, whitespace_separated_leaves)),
+        space0,
+    )(i)
 }
 
-pub fn parse_to_ast<'a>() -> impl Parser<&'a str, Output = UserInputAst> {
-    spaces()
-        .with(optional(ast()).skip(eof()))
-        .map(|opt_ast| opt_ast.unwrap_or_else(UserInputAst::empty_query))
-        .map(rewrite_ast)
+pub fn parse_to_ast(i: &str) -> IResult<&str, UserInputAst> {
+    map(delimited(space0, opt(ast), eof), |opt_ast| {
+        rewrite_ast(opt_ast.unwrap_or_else(UserInputAst::empty_query))
+    })(i)
 }
 
 /// Removes unnecessary children clauses in AST
@@ -470,11 +387,6 @@ fn rewrite_ast_clause(input: &mut (Option<Occur>, UserInputAst)) {
 
 #[cfg(test)]
 mod test {
-
-    type TestParseResult = Result<(), StringStreamError>;
-
-    use combine::parser::Parser;
-
     use super::*;
 
     pub fn nearly_equals(a: f64, b: f64) -> bool {
@@ -488,42 +400,44 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_occur_symbol() -> TestParseResult {
-        assert_eq!(super::occur_symbol().parse("-")?, (Occur::MustNot, ""));
-        assert_eq!(super::occur_symbol().parse("+")?, (Occur::Must, ""));
-        Ok(())
-    }
+    // TODO test as part of occur_leaf
+    // #[test]
+    // fn test_occur_symbol() -> TestParseResult {
+    // assert_eq!(super::occur_symbol("-")?, ("", Occur::MustNot));
+    // assert_eq!(super::occur_symbol("+")?, ("", Occur::Must));
+    // Ok(())
+    // }
 
     #[test]
     fn test_positive_float_number() {
         fn valid_parse(float_str: &str, expected_val: f64, expected_remaining: &str) {
-            let (val, remaining) = positive_float_number().parse(float_str).unwrap();
+            let (remaining, val) = positive_float_number(float_str).unwrap();
             assert_eq!(remaining, expected_remaining);
             assert_nearly_equals(val, expected_val);
         }
         fn error_parse(float_str: &str) {
-            assert!(positive_float_number().parse(float_str).is_err());
+            assert!(positive_float_number(float_str).is_err());
         }
         valid_parse("1.0", 1.0, "");
         valid_parse("1", 1.0, "");
         valid_parse("0.234234 aaa", 0.234234f64, " aaa");
         error_parse(".3332");
-        error_parse("1.");
+        // TODO trinity-1686a: I disagree that it should fail, I think it should succeeed,
+        // consuming only "1", and leave "." for the next thing (which will likely fail then)
+        // error_parse("1.");
         error_parse("-1.");
     }
 
     #[test]
     fn test_date_time() {
-        let (val, remaining) = date_time()
-            .parse("2015-08-02T18:54:42+02:30")
-            .expect("cannot parse date");
+        let (remaining, val) =
+            relaxed_word("2015-08-02T18:54:42+02:30").expect("cannot parse date");
         assert_eq!(val, "2015-08-02T18:54:42+02:30");
         assert_eq!(remaining, "");
-        assert!(date_time().parse("2015-08-02T18:54:42+02").is_err());
+        // this isn't a valid date, but relaxed_word allows it.
+        // assert!(date_time().parse("2015-08-02T18:54:42+02").is_err());
 
-        let (val, remaining) = date_time()
-            .parse("2021-04-13T19:46:26.266051969+00:00")
+        let (remaining, val) = relaxed_word("2021-04-13T19:46:26.266051969+00:00")
             .expect("cannot parse fractional date");
         assert_eq!(val, "2021-04-13T19:46:26.266051969+00:00");
         assert_eq!(remaining, "");
@@ -531,13 +445,13 @@ mod test {
 
     #[track_caller]
     fn test_parse_query_to_ast_helper(query: &str, expected: &str) {
-        let query = parse_to_ast().parse(query).unwrap().0;
+        let query = parse_to_ast(query).unwrap().1;
         let query_str = format!("{query:?}");
         assert_eq!(query_str, expected);
     }
 
     fn test_is_parse_err(query: &str) {
-        assert!(parse_to_ast().parse(query).is_err());
+        assert!(parse_to_ast(query).is_err());
     }
 
     #[test]
@@ -555,18 +469,15 @@ mod test {
 
     #[test]
     fn test_parse_query_to_ast_not_op() {
-        assert_eq!(
-            format!("{:?}", parse_to_ast().parse("NOT")),
-            "Err(UnexpectedParse)"
-        );
+        assert!(parse_to_ast("NOT").is_err(),);
         test_parse_query_to_ast_helper("NOTa", "NOTa");
         test_parse_query_to_ast_helper("NOT a", "(-a)");
     }
 
     #[test]
     fn test_boosting() {
-        assert!(parse_to_ast().parse("a^2^3").is_err());
-        assert!(parse_to_ast().parse("a^2^").is_err());
+        assert!(parse_to_ast("a^2^3").is_err());
+        assert!(parse_to_ast("a^2^").is_err());
         test_parse_query_to_ast_helper("a^3", "(a)^3");
         test_parse_query_to_ast_helper("a^3 b^2", "(*(a)^3 *(b)^2)");
         test_parse_query_to_ast_helper("a^1", "a");
@@ -578,22 +489,10 @@ mod test {
         test_parse_query_to_ast_helper("a OR b", "(?a ?b)");
         test_parse_query_to_ast_helper("a OR b AND c", "(?a ?(+b +c))");
         test_parse_query_to_ast_helper("a AND b         AND c", "(+a +b +c)");
-        assert_eq!(
-            format!("{:?}", parse_to_ast().parse("a OR b aaa")),
-            "Err(UnexpectedParse)"
-        );
-        assert_eq!(
-            format!("{:?}", parse_to_ast().parse("a AND b aaa")),
-            "Err(UnexpectedParse)"
-        );
-        assert_eq!(
-            format!("{:?}", parse_to_ast().parse("aaa a OR b ")),
-            "Err(UnexpectedParse)"
-        );
-        assert_eq!(
-            format!("{:?}", parse_to_ast().parse("aaa ccc a OR b ")),
-            "Err(UnexpectedParse)"
-        );
+        assert!(parse_to_ast("a OR b aaa").is_err());
+        assert!(parse_to_ast("a AND b aaa").is_err());
+        assert!(parse_to_ast("aaa a OR b ").is_err());
+        assert!(parse_to_ast("aaa ccc a OR b ").is_err());
     }
 
     #[test]
@@ -617,7 +516,7 @@ mod test {
 
     #[test]
     fn test_occur_leaf() {
-        let ((occur, ast), _) = super::occur_leaf().parse("+abc").unwrap();
+        let (_, (occur, ast)) = super::occur_leaf("+abc").unwrap();
         assert_eq!(occur, Some(Occur::Must));
         assert_eq!(format!("{ast:?}"), "abc");
     }
@@ -625,61 +524,54 @@ mod test {
     #[test]
     fn test_field_name() {
         assert_eq!(
-            super::field_name().parse(".my.field.name:a"),
-            Ok((".my.field.name".to_string(), "a"))
+            super::field_name(".my.field.name:a"),
+            Ok(("a", ".my.field.name".to_string()))
         );
         assert_eq!(
-            super::field_name().parse(r#"にんじん:a"#),
-            Ok(("にんじん".to_string(), "a"))
+            super::field_name(r#"にんじん:a"#),
+            Ok(("a", "にんじん".to_string()))
         );
         assert_eq!(
-            super::field_name().parse(r#"my\field:a"#),
-            Ok((r#"my\field"#.to_string(), "a"))
-        );
-        assert!(super::field_name().parse("my field:a").is_err());
-        assert_eq!(
-            super::field_name().parse("\\(1\\+1\\):2"),
-            Ok(("(1+1)".to_string(), "2"))
+            super::field_name(r#"my\field:a"#),
+            Ok(("a", r#"my\field"#.to_string()))
         );
         assert_eq!(
-            super::field_name().parse("my_field_name:a"),
-            Ok(("my_field_name".to_string(), "a"))
+            super::field_name(r#"my\\field:a"#),
+            Ok(("a", r#"my\field"#.to_string()))
+        );
+        assert!(super::field_name("my field:a").is_err());
+        assert_eq!(
+            super::field_name("\\(1\\+1\\):2"),
+            Ok(("2", "(1+1)".to_string()))
         );
         assert_eq!(
-            super::field_name().parse("myfield.b:hello").unwrap(),
-            ("myfield.b".to_string(), "hello")
+            super::field_name("my_field_name:a"),
+            Ok(("a", "my_field_name".to_string()))
         );
         assert_eq!(
-            super::field_name().parse(r#"myfield\.b:hello"#).unwrap(),
-            (r#"myfield\.b"#.to_string(), "hello")
-        );
-        assert!(super::field_name().parse("my_field_name").is_err());
-        assert!(super::field_name().parse(":a").is_err());
-        assert!(super::field_name().parse("-my_field:a").is_err());
-        assert_eq!(
-            super::field_name().parse("_my_field:a"),
-            Ok(("_my_field".to_string(), "a"))
+            super::field_name("myfield.b:hello").unwrap(),
+            ("hello", "myfield.b".to_string())
         );
         assert_eq!(
-            super::field_name().parse("~my~field:a"),
-            Ok(("~my~field".to_string(), "a"))
+            super::field_name(r#"myfield\.b:hello"#).unwrap(),
+            ("hello", r#"myfield\.b"#.to_string())
+        );
+        assert!(super::field_name("my_field_name").is_err());
+        assert!(super::field_name(":a").is_err());
+        assert!(super::field_name("-my_field:a").is_err());
+        assert_eq!(
+            super::field_name("_my_field:a"),
+            Ok(("a", "_my_field".to_string()))
+        );
+        assert_eq!(
+            super::field_name("~my~field:a"),
+            Ok(("a", "~my~field".to_string()))
         );
         for special_char in SPECIAL_CHARS.iter() {
             let query = &format!("\\{special_char}my\\{special_char}field:a");
             assert_eq!(
-                super::field_name().parse(query),
-                Ok((format!("{special_char}my{special_char}field"), "a"))
-            );
-        }
-    }
-
-    #[test]
-    fn test_field_name_re() {
-        let escaped_special_chars_re = Regex::new(ESCAPED_SPECIAL_CHARS_PATTERN).unwrap();
-        for special_char in SPECIAL_CHARS.iter() {
-            assert_eq!(
-                escaped_special_chars_re.replace_all(&format!("\\{special_char}"), "$1"),
-                special_char.to_string()
+                super::field_name(query),
+                Ok(("a", format!("{special_char}my{special_char}field")))
             );
         }
     }
@@ -687,19 +579,17 @@ mod test {
     #[test]
     fn test_range_parser() {
         // testing the range() parser separately
-        let res = range()
-            .parse("title: <hello")
+        let res = literal("title: <hello")
             .expect("Cannot parse felxible bound word")
-            .0;
+            .1;
         let expected = UserInputLeaf::Range {
             field: Some("title".to_string()),
             lower: UserInputBound::Unbounded,
             upper: UserInputBound::Exclusive("hello".to_string()),
         };
-        let res2 = range()
-            .parse("title:{* TO hello}")
+        let res2 = literal("title:{* TO hello}")
             .expect("Cannot parse ununbounded to word")
-            .0;
+            .1;
         assert_eq!(res, expected);
         assert_eq!(res2, expected);
 
@@ -708,14 +598,12 @@ mod test {
             lower: UserInputBound::Inclusive("71.2".to_string()),
             upper: UserInputBound::Unbounded,
         };
-        let res3 = range()
-            .parse("weight: >=71.2")
+        let res3 = literal("weight: >=71.2")
             .expect("Cannot parse flexible bound float")
-            .0;
-        let res4 = range()
-            .parse("weight:[71.2 TO *}")
+            .1;
+        let res4 = literal("weight:[71.2 TO *}")
             .expect("Cannot parse float to unbounded")
-            .0;
+            .1;
         assert_eq!(res3, expected_weight);
         assert_eq!(res4, expected_weight);
 
@@ -724,10 +612,9 @@ mod test {
             lower: UserInputBound::Exclusive("2015-08-02T18:54:42Z".to_string()),
             upper: UserInputBound::Inclusive("2021-08-02T18:54:42+02:30".to_string()),
         };
-        let res5 = range()
-            .parse("date_field:{2015-08-02T18:54:42Z TO 2021-08-02T18:54:42+02:30]")
+        let res5 = literal("date_field:{2015-08-02T18:54:42Z TO 2021-08-02T18:54:42+02:30]")
             .expect("Cannot parse date range")
-            .0;
+            .1;
         assert_eq!(res5, expected_dates);
 
         let expected_flexible_dates = UserInputLeaf::Range {
@@ -736,10 +623,9 @@ mod test {
             upper: UserInputBound::Inclusive("2021-08-02T18:54:42.12345+02:30".to_string()),
         };
 
-        let res6 = range()
-            .parse("date_field: <=2021-08-02T18:54:42.12345+02:30")
+        let res6 = literal("date_field: <=2021-08-02T18:54:42.12345+02:30")
             .expect("Cannot parse date range")
-            .0;
+            .1;
         assert_eq!(res6, expected_flexible_dates);
         // IP Range Unbounded
         let expected_weight = UserInputLeaf::Range {
@@ -747,14 +633,10 @@ mod test {
             lower: UserInputBound::Inclusive("::1".to_string()),
             upper: UserInputBound::Unbounded,
         };
-        let res1 = range()
-            .parse("ip: >=::1")
+        let res1 = literal("ip: >=::1").expect("Cannot parse ip v6 format").1;
+        let res2 = literal("ip:[::1 TO *}")
             .expect("Cannot parse ip v6 format")
-            .0;
-        let res2 = range()
-            .parse("ip:[::1 TO *}")
-            .expect("Cannot parse ip v6 format")
-            .0;
+            .1;
         assert_eq!(res1, expected_weight);
         assert_eq!(res2, expected_weight);
 
@@ -764,10 +646,9 @@ mod test {
             lower: UserInputBound::Inclusive("::0.0.0.50".to_string()),
             upper: UserInputBound::Exclusive("::0.0.0.52".to_string()),
         };
-        let res1 = range()
-            .parse("ip:[::0.0.0.50 TO ::0.0.0.52}")
+        let res1 = literal("ip:[::0.0.0.50 TO ::0.0.0.52}")
             .expect("Cannot parse ip v6 format")
-            .0;
+            .1;
         assert_eq!(res1, expected_weight);
     }
 
@@ -868,11 +749,12 @@ mod test {
 
     #[test]
     fn test_slop() {
-        assert!(parse_to_ast().parse("\"a b\"~").is_err());
-        assert!(parse_to_ast().parse("foo:\"a b\"~").is_err());
-        assert!(parse_to_ast().parse("\"a b\"~a").is_err());
-        assert!(parse_to_ast().parse("\"a b\"~100000000000000000").is_err());
-        test_parse_query_to_ast_helper("\"a b\"^2~4", "(*(\"a b\")^2 *~4)");
+        assert!(parse_to_ast("\"a b\"~").is_err());
+        assert!(parse_to_ast("foo:\"a b\"~").is_err());
+        assert!(parse_to_ast("\"a b\"~a").is_err());
+        assert!(parse_to_ast("\"a b\"~100000000000000000").is_err());
+        test_parse_query_to_ast_helper("\"a b\"^2 ~4", "(*(\"a b\")^2 *~4)");
+        test_parse_query_to_ast_helper("\"a b\"~4^2", "(\"a b\"~4)^2");
         test_parse_query_to_ast_helper("\"~Document\"", "\"~Document\"");
         test_parse_query_to_ast_helper("~Document", "~Document");
         test_parse_query_to_ast_helper("a~2", "a~2");

--- a/query-grammar/src/user_input_ast.rs
+++ b/query-grammar/src/user_input_ast.rs
@@ -158,6 +158,7 @@ impl UserInputBound {
     }
 }
 
+#[derive(PartialEq)]
 pub enum UserInputAst {
     Clause(Vec<(Option<Occur>, UserInputAst)>),
     Leaf(Box<UserInputLeaf>),

--- a/query-grammar/src/user_input_ast.rs
+++ b/query-grammar/src/user_input_ast.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Formatter};
 
 use crate::Occur;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub enum UserInputLeaf {
     Literal(UserInputLiteral),
     All,
@@ -85,7 +85,7 @@ pub enum Delimiter {
     None,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub struct UserInputLiteral {
     pub field_name: Option<String>,
     pub phrase: String,
@@ -123,7 +123,7 @@ impl fmt::Debug for UserInputLiteral {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum UserInputBound {
     Inclusive(String),
     Exclusive(String),
@@ -158,7 +158,7 @@ impl UserInputBound {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone)]
 pub enum UserInputAst {
     Clause(Vec<(Option<Occur>, UserInputAst)>),
     Leaf(Box<UserInputLeaf>),

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -390,8 +390,14 @@ impl QueryParser {
         query: &str,
     ) -> (LogicalAst, Vec<QueryParserError>) {
         let (user_input_ast, errors) = query_grammar::parse_query_lenient(query);
-        let mut errors: Vec<_> = errors.into_iter()
-            .map(|error| QueryParserError::SyntaxError(format!("{} at position {}", error.message, error.pos)))
+        let mut errors: Vec<_> = errors
+            .into_iter()
+            .map(|error| {
+                QueryParserError::SyntaxError(format!(
+                    "{} at position {}",
+                    error.message, error.pos
+                ))
+            })
             .collect();
         let (ast, mut ast_errors) = self.compute_logical_ast_lenient(user_input_ast);
         errors.append(&mut ast_errors);

--- a/src/schema/json_object_options.rs
+++ b/src/schema/json_object_options.rs
@@ -80,12 +80,12 @@ impl JsonObjectOptions {
     /// When expand_dots is enabled, json object like
     /// `{"k8s.node.id": 5}` is processed as if it was
     /// `{"k8s": {"node": {"id": 5}}}`.
-    /// It option has the merit of allowing users to
+    /// This option has the merit of allowing users to
     /// write queries  like `k8s.node.id:5`.
     /// On the other, enabling that feature can lead to
     /// ambiguity.
     ///
-    /// If disabled, the "." need to be escaped:
+    /// If disabled, the "." needs to be escaped:
     /// `k8s\.node\.id:5`.
     pub fn is_expand_dots_enabled(&self) -> bool {
         self.expand_dots_enabled

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -5,8 +5,10 @@
 //! Tantivy has a very strict schema.
 //! The schema defines information about the fields your index contains, that is, for each field:
 //!
-//! - the field name (may only contain letters `[a-zA-Z]`, number `[0-9]`, and `_`)
-//! - the type of the field (currently only  `text` and `u64` are supported)
+//! - the field name (may contain any characted, can't start with a `-` and can't be empty. Some
+//!   characters may require escaping when using the query parser).
+//! - the type of the field (currently `text`, `u64`, `i64`, `f64`, `bool`, `date`, `IpAddr`,
+//!   facets, bytes and json are supported)
 //! - how the field should be indexed / stored.
 //!
 //! This very last point is critical as it will enable / disable some of the functionality


### PR DESCRIPTION
fix #5 

Most of the grammar part is done, however it's not reporting hints just yet (this isn't really required, but would be a nice addition, to help someone understand how their query was understood, and why the parser think it's somewhat wrong).

At the moment, only the part in query-grammar is done. More work is required to convert the AST to a query without failing. This part hasn't been explored yet, but should be before the ticket is considered fixed.

I'm sending this as a draft to get initial comments on the parser part