### PR TITLE
Fixes the new deny-by-default incorrect_partial_ord_impl_on_ord_type Clippy lint

### DIFF
--- a/columnar/src/column_values/u128_based/compact_space/blank_range.rs
+++ b/columnar/src/column_values/u128_based/compact_space/blank_range.rs
@@ -38,6 +38,6 @@ impl Ord for BlankRange {
 }
 impl PartialOrd for BlankRange {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.blank_size().cmp(&other.blank_size()))
+        Some(self.cmp(other))
     }
 }

--- a/src/query/more_like_this/more_like_this.rs
+++ b/src/query/more_like_this/more_like_this.rs
@@ -23,13 +23,15 @@ impl Eq for ScoreTerm {}
 
 impl PartialOrd for ScoreTerm {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.score.partial_cmp(&other.score)
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for ScoreTerm {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap_or(std::cmp::Ordering::Equal)
+        self.score
+            .partial_cmp(&other.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
     }
 }
 

--- a/sstable/src/merge/heap_merge.rs
+++ b/sstable/src/merge/heap_merge.rs
@@ -15,7 +15,7 @@ impl<B: AsRef<[u8]>> Ord for HeapItem<B> {
 }
 impl<B: AsRef<[u8]>> PartialOrd for HeapItem<B> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(other.0.as_ref().cmp(self.0.as_ref()))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_partial_ord_impl_on_ord_type