### PR TITLE
delayed column opening during merge

### DIFF
--- a/columnar/src/dynamic_column.rs
+++ b/columnar/src/dynamic_column.rs
@@ -228,7 +228,7 @@ static_dynamic_conversions!(StrColumn, Str);
 static_dynamic_conversions!(BytesColumn, Bytes);
 static_dynamic_conversions!(Column<Ipv6Addr>, IpAddr);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DynamicColumnHandle {
     pub(crate) file_slice: FileSlice,
     pub(crate) column_type: ColumnType,

--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -1,3 +1,4 @@
+use std::fs::File;
 use std::ops::{Deref, Range, RangeBounds};
 use std::sync::Arc;
 use std::{fmt, io};
@@ -29,6 +30,59 @@ pub trait FileHandle: 'static + Send + Sync + HasLen + fmt::Debug {
             io::ErrorKind::Unsupported,
             "Async read is not supported.",
         ))
+    }
+}
+
+#[derive(Debug)]
+pub struct WrapFile {
+    file: File,
+    len: usize,
+}
+impl WrapFile {
+    pub fn new(file: File) -> io::Result<Self> {
+        let len = file.metadata()?.len() as usize;
+        Ok(WrapFile { file, len })
+    }
+}
+
+#[async_trait]
+impl FileHandle for WrapFile {
+    fn read_bytes(&self, range: Range<usize>) -> io::Result<OwnedBytes> {
+        let file_len = self.len();
+
+        // Calculate the actual range to read, ensuring it stays within file boundaries
+        let start = range.start;
+        let end = range.end.min(file_len);
+
+        // Ensure the start is before the end of the range
+        if start >= end {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "Invalid range"));
+        }
+
+        let mut buffer = vec![0; end - start];
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::prelude::FileExt;
+            self.file.read_exact_at(&mut buffer, start as u64)?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mut file = self.file.try_clone()?; // Clone the file to read from it separately
+                                                   // Seek to the start position in the file
+            file.seek(io::SeekFrom::Start(start as u64))?;
+            // Read the data into the buffer
+            file.read_exact(&mut buffer)?;
+        }
+
+        Ok(OwnedBytes::new(buffer))
+    }
+    // todo implement async
+}
+impl HasLen for WrapFile {
+    fn len(&self) -> usize {
+        self.len
     }
 }
 
@@ -64,6 +118,30 @@ pub struct FileSlice {
 impl fmt::Debug for FileSlice {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "FileSlice({:?}, {:?})", &self.data, self.range)
+    }
+}
+
+impl FileSlice {
+    pub fn stream_file_chunks(&self) -> impl Iterator<Item = io::Result<OwnedBytes>> + '_ {
+        let len = self.range.end;
+        let mut start = self.range.start;
+        std::iter::from_fn(move || {
+            /// Returns chunks of 1MB of data from the FileHandle.
+            const CHUNK_SIZE: usize = 1024 * 1024; // 1MB
+
+            if start < len {
+                let end = (start + CHUNK_SIZE).min(len);
+                let range = start..end;
+                let chunk = self.data.read_bytes(range);
+                start += CHUNK_SIZE;
+                match chunk {
+                    Ok(chunk) => Some(Ok(chunk)),
+                    Err(e) => Some(Err(e)),
+                }
+            } else {
+                None
+            }
+        })
     }
 }
 

--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -34,11 +34,13 @@ pub trait FileHandle: 'static + Send + Sync + HasLen + fmt::Debug {
 }
 
 #[derive(Debug)]
+/// A File with it's length included.
 pub struct WrapFile {
     file: File,
     len: usize,
 }
 impl WrapFile {
+    /// Creates a new WrapFile and stores its length.
     pub fn new(file: File) -> io::Result<Self> {
         let len = file.metadata()?.len() as usize;
         Ok(WrapFile { file, len })

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -2427,6 +2427,13 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_regression_1() {
+        use IndexingOp::*;
+        let ops = &[AddDoc { id: 15 }, Commit, AddDoc { id: 9 }, Commit, Merge];
+        test_operation_strategy(&ops[..], false, true).unwrap();
+    }
+
+    #[test]
     fn test_range_query_bug_1() {
         use IndexingOp::*;
         let ops = &[


### PR DESCRIPTION
This is the first part of addressing https://github.com/quickwit-oss/quickwit/issues/3633
Instead of loading all Column into memory for the merge, only the current `column_name, column_category` group is loaded. 

Second part would be to replace mmap calls with file reads, for better control on releasing memory
