### PR TITLE
DOC: show the escape backslash

### DIFF
--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -167,7 +167,7 @@ fn trim_ast(logical_ast: LogicalAst) -> Option<LogicalAst> {
 /// * phrase terms: Quoted terms become phrase searches on fields that have positions indexed. e.g.,
 ///   `title:"Barack Obama"` will only find documents that have "barack" immediately followed by
 ///   "obama". Single quotes can also be used. If the text to be searched contains quotation mark,
-///   it is possible to escape them with a \.
+///   it is possible to escape them with a `\`.
 ///
 /// * range terms: Range searches can be done by specifying the start and end bound. These can be
 ///   inclusive or exclusive. e.g., `title:[a TO c}` will find all documents whose title contains a


### PR DESCRIPTION
Before this PR, the char doesn't render:

![image](https://github.com/quickwit-oss/tantivy/assets/480395/cf675387-ab6d-42fb-a2f2-9e0323a9e904)

I tested that there are no further shenanigans with backquotes:

![image](https://github.com/quickwit-oss/tantivy/assets/480395/6a0eb964-f37f-48e8-8c39-2f0e6d32c97a)
