### PR TITLE
Fix missing trait imports on non-unix `read_bytes` implementation

### DIFF
--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -71,6 +71,7 @@ impl FileHandle for WrapFile {
 
         #[cfg(not(unix))]
         {
+            use std::io::{Read, Seek};
             let mut file = self.file.try_clone()?; // Clone the file to read from it separately
                                                    // Seek to the start position in the file
             file.seek(io::SeekFrom::Start(start as u64))?;


### PR DESCRIPTION
Closes #2153 

Adds the missing traits for non-unix systems in the `file_slice` file with the `WrapFile::read_bytes` method.