### PR TITLE
Fix testing on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,14 +73,16 @@ maplit = "1.0.2"
 matches = "0.1.9"
 pretty_assertions = "1.2.1"
 proptest = "1.0.0"
-criterion = "0.5"
 test-log = "0.2.10"
 env_logger = "0.10.0"
-pprof = { git = "https://github.com/PSeitz/pprof-rs/", rev = "53af24b", features = ["flamegraph", "criterion"] } # temp fork that works with criterion 0.5
 futures = "0.3.21"
 paste = "1.0.11"
 more-asserts = "0.3.1"
 rand_distr = "0.4.3"
+
+[target.'cfg(not(windows))'.dev-dependencies]
+criterion = "0.5"
+pprof = { git = "https://github.com/PSeitz/pprof-rs/", rev = "53af24b", features = ["flamegraph", "criterion"] } # temp fork that works with criterion 0.5
 
 [dev-dependencies.fail]
 version = "0.5.0"

--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -71,6 +71,7 @@ impl FileHandle for WrapFile {
 
         #[cfg(not(unix))]
         {
+            use std::io::{Read, Seek};
             let mut file = self.file.try_clone()?; // Clone the file to read from it separately
                                                    // Seek to the start position in the file
             file.seek(io::SeekFrom::Start(start as u64))?;

--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -71,7 +71,6 @@ impl FileHandle for WrapFile {
 
         #[cfg(not(unix))]
         {
-            use std::io::{Read, Seek};
             let mut file = self.file.try_clone()?; // Clone the file to read from it separately
                                                    // Seek to the start position in the file
             file.seek(io::SeekFrom::Start(start as u64))?;


### PR DESCRIPTION
After manually doing this fix on several local instances when doing a fix or change, I finally broke and have just made this PR to fix testing tantivy on Windows.

The error is because of the deps used in the `bench` directory aren't supported on Windows. 
