### PR TITLE
encode some part of posting list as -1 instead of direct values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ uuid = { version = "1.0.0", features = ["v4", "serde"] }
 crossbeam-channel = "0.5.4"
 rust-stemmers = "1.2.0"
 downcast-rs = "1.2.0"
-bitpacking = { version = "0.8.4", default-features = false, features = ["bitpacker4x"] }
+bitpacking = { git = "https://github.com/quickwit-oss/bitpacking", branch = "trinity--delta-minus-one", default-features = false, features = ["bitpacker4x"] }
 census = "0.4.0"
 rustc-hash = "1.1.0"
 thiserror = "1.0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ uuid = { version = "1.0.0", features = ["v4", "serde"] }
 crossbeam-channel = "0.5.4"
 rust-stemmers = "1.2.0"
 downcast-rs = "1.2.0"
-bitpacking = { git = "https://github.com/quickwit-oss/bitpacking", branch = "trinity--delta-minus-one", default-features = false, features = ["bitpacker4x"] }
+bitpacking = { git = "https://github.com/quickwit-oss/bitpacking", rev = "f730b75", default-features = false, features = ["bitpacker4x"] }
 census = "0.4.0"
 rustc-hash = "1.1.0"
 thiserror = "1.0.30"

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -126,9 +126,7 @@ mod tests_mmap {
         assert_eq!(searcher.num_docs(), 512);
         let parse_query = QueryParser::for_index(&index, Vec::new());
         {
-            let query = parse_query
-                .parse_query(r"json.somekey:1")
-                .unwrap();
+            let query = parse_query.parse_query(r"json.somekey:1").unwrap();
             let num_docs = searcher.search(&query, &Count).unwrap();
             assert_eq!(num_docs, 256);
         }

--- a/src/positions/reader.rs
+++ b/src/positions/reader.rs
@@ -92,7 +92,7 @@ impl PositionReader {
             // that block is bitpacked.
             let bit_width = bit_widths[block_rel_id];
             self.block_decoder
-                .uncompress_block_unsorted(compressed_data, bit_width);
+                .uncompress_block_unsorted(compressed_data, bit_width, false);
         } else {
             // that block is vint encoded.
             self.block_decoder

--- a/src/positions/serializer.rs
+++ b/src/positions/serializer.rs
@@ -62,8 +62,9 @@ impl<W: io::Write> PositionSerializer<W> {
             return;
         }
         if self.block.len() == COMPRESSION_BLOCK_SIZE {
-            let (bit_width, block_encoded): (u8, &[u8]) =
-                self.block_encoder.compress_block_unsorted(&self.block[..], false);
+            let (bit_width, block_encoded): (u8, &[u8]) = self
+                .block_encoder
+                .compress_block_unsorted(&self.block[..], false);
             self.bit_widths.push(bit_width);
             self.positions_buffer.extend(block_encoded);
         } else {

--- a/src/positions/serializer.rs
+++ b/src/positions/serializer.rs
@@ -63,7 +63,7 @@ impl<W: io::Write> PositionSerializer<W> {
         }
         if self.block.len() == COMPRESSION_BLOCK_SIZE {
             let (bit_width, block_encoded): (u8, &[u8]) =
-                self.block_encoder.compress_block_unsorted(&self.block[..]);
+                self.block_encoder.compress_block_unsorted(&self.block[..], false);
             self.bit_widths.push(bit_width);
             self.positions_buffer.extend(block_encoded);
         } else {

--- a/src/postings/block_segment_postings.rs
+++ b/src/postings/block_segment_postings.rs
@@ -30,7 +30,7 @@ pub struct BlockSegmentPostings {
     block_max_score_cache: Option<Score>,
     doc_freq: u32,
     data: OwnedBytes,
-    pub(crate) skip_reader: SkipReader,
+    skip_reader: SkipReader,
 }
 
 fn decode_bitpacked_block(
@@ -303,7 +303,6 @@ impl BlockSegmentPostings {
 
     pub(crate) fn load_block(&mut self) {
         let offset = self.skip_reader.byte_offset();
-        // I'm not sure why it's there, but it breaks with blocks that can be encoded on zero byte.
         if self.block_is_loaded() {
             return;
         }
@@ -372,6 +371,10 @@ impl BlockSegmentPostings {
             data: OwnedBytes::empty(),
             skip_reader: SkipReader::new(OwnedBytes::empty(), 0, IndexRecordOption::Basic),
         }
+    }
+
+    pub(crate) fn skip_reader(&self) -> &SkipReader {
+        &self.skip_reader
     }
 }
 

--- a/src/postings/block_segment_postings.rs
+++ b/src/postings/block_segment_postings.rs
@@ -45,7 +45,7 @@ fn decode_bitpacked_block(
     let num_consumed_bytes =
         doc_decoder.uncompress_block_sorted(data, doc_offset, doc_num_bits, strict_delta);
     if let Some(freq_decoder) = freq_decoder_opt {
-        freq_decoder.uncompress_block_unsorted(&data[num_consumed_bytes..], tf_num_bits);
+        freq_decoder.uncompress_block_unsorted(&data[num_consumed_bytes..], tf_num_bits, strict_delta);
     }
 }
 

--- a/src/postings/block_segment_postings.rs
+++ b/src/postings/block_segment_postings.rs
@@ -45,7 +45,11 @@ fn decode_bitpacked_block(
     let num_consumed_bytes =
         doc_decoder.uncompress_block_sorted(data, doc_offset, doc_num_bits, strict_delta);
     if let Some(freq_decoder) = freq_decoder_opt {
-        freq_decoder.uncompress_block_unsorted(&data[num_consumed_bytes..], tf_num_bits, strict_delta);
+        freq_decoder.uncompress_block_unsorted(
+            &data[num_consumed_bytes..],
+            tf_num_bits,
+            strict_delta,
+        );
     }
 }
 

--- a/src/postings/compression/mod.rs
+++ b/src/postings/compression/mod.rs
@@ -44,7 +44,11 @@ impl BlockEncoder {
         (num_bits, &self.output[..written_size])
     }
 
-    pub fn compress_block_unsorted(&mut self, block: &[u32], minus_one_encoded: bool) -> (u8, &[u8]) {
+    pub fn compress_block_unsorted(
+        &mut self,
+        block: &[u32],
+        minus_one_encoded: bool,
+    ) -> (u8, &[u8]) {
         debug_assert!(!minus_one_encoded || !block.contains(&0));
 
         let mut block_minus_one = [0; COMPRESSION_BLOCK_SIZE];
@@ -106,18 +110,20 @@ impl BlockDecoder {
             )
         } else {
             self.output_len = COMPRESSION_BLOCK_SIZE;
-            self.bitpacker.decompress_sorted(
-                offset,
-                compressed_data,
-                &mut self.output,
-                num_bits,
-            )
+            self.bitpacker
+                .decompress_sorted(offset, compressed_data, &mut self.output, num_bits)
         }
     }
 
-    pub fn uncompress_block_unsorted(&mut self, compressed_data: &[u8], num_bits: u8, minus_one_encoded: bool) -> usize {
+    pub fn uncompress_block_unsorted(
+        &mut self,
+        compressed_data: &[u8],
+        num_bits: u8,
+        minus_one_encoded: bool,
+    ) -> usize {
         self.output_len = COMPRESSION_BLOCK_SIZE;
-        let res = self.bitpacker
+        let res = self
+            .bitpacker
             .decompress(compressed_data, &mut self.output, num_bits);
         if minus_one_encoded {
             for val in &mut self.output {
@@ -310,12 +316,14 @@ pub mod tests {
             let n = 128;
             let vals: Vec<u32> = (0..n).map(|i| 11u32 + (i as u32) * 7u32 % 12).collect();
             let mut encoder = BlockEncoder::default();
-            let (num_bits, compressed_data) = encoder.compress_block_unsorted(&vals, minus_one_encode);
+            let (num_bits, compressed_data) =
+                encoder.compress_block_unsorted(&vals, minus_one_encode);
             compressed.extend_from_slice(compressed_data);
             compressed.push(173u8);
             let mut decoder = BlockDecoder::default();
             {
-                let consumed_num_bytes = decoder.uncompress_block_unsorted(&compressed, num_bits, minus_one_encode);
+                let consumed_num_bytes =
+                    decoder.uncompress_block_unsorted(&compressed, num_bits, minus_one_encode);
                 assert_eq!(consumed_num_bytes + 1, compressed.len());
                 assert_eq!(compressed[consumed_num_bytes], 173u8);
             }

--- a/src/postings/compression/mod.rs
+++ b/src/postings/compression/mod.rs
@@ -53,7 +53,7 @@ impl BlockEncoder {
 
         let mut block_minus_one = [0; COMPRESSION_BLOCK_SIZE];
         let block = if minus_one_encoded {
-            for (elem_min_one, elem) in (&mut block_minus_one).into_iter().zip(block) {
+            for (elem_min_one, elem) in block_minus_one.iter_mut().zip(block) {
                 *elem_min_one = elem - 1;
             }
             &block_minus_one
@@ -61,10 +61,10 @@ impl BlockEncoder {
             block
         };
 
-        let num_bits = self.bitpacker.num_bits(&block);
+        let num_bits = self.bitpacker.num_bits(block);
         let written_size = self
             .bitpacker
-            .compress(&block, &mut self.output[..], num_bits);
+            .compress(block, &mut self.output[..], num_bits);
         (num_bits, &self.output[..written_size])
     }
 }

--- a/src/postings/compression/mod.rs
+++ b/src/postings/compression/mod.rs
@@ -396,7 +396,7 @@ mod bench {
         let (num_bits, compressed) = encoder.compress_block_sorted(&data, 0u32);
         let mut decoder = BlockDecoder::default();
         b.iter(|| {
-            decoder.uncompress_block_sorted(compressed, 0u32, num_bits);
+            decoder.uncompress_block_sorted(compressed, 0u32, num_bits, true);
         });
     }
 

--- a/src/postings/compression/mod.rs
+++ b/src/postings/compression/mod.rs
@@ -45,6 +45,8 @@ impl BlockEncoder {
     }
 
     pub fn compress_block_unsorted(&mut self, block: &[u32], minus_one_encoded: bool) -> (u8, &[u8]) {
+        debug_assert!(!minus_one_encoded || !block.contains(&0));
+
         let mut block_minus_one = [0; COMPRESSION_BLOCK_SIZE];
         let block = if minus_one_encoded {
             for (elem_min_one, elem) in (&mut block_minus_one).into_iter().zip(block) {

--- a/src/postings/recorder.rs
+++ b/src/postings/recorder.rs
@@ -133,11 +133,11 @@ impl Recorder for DocIdRecorder {
             doc_ids.sort_unstable();
 
             for doc in doc_ids {
-                serializer.write_doc(*doc, 1u32, &[0][..]);
+                serializer.write_doc(*doc, 0u32, &[][..]);
             }
         } else {
             for doc in VInt32Reader::new(&buffer[..]) {
-                serializer.write_doc(doc, 1u32, &[0][..]);
+                serializer.write_doc(doc, 0u32, &[][..]);
             }
         }
     }

--- a/src/postings/recorder.rs
+++ b/src/postings/recorder.rs
@@ -133,11 +133,11 @@ impl Recorder for DocIdRecorder {
             doc_ids.sort_unstable();
 
             for doc in doc_ids {
-                serializer.write_doc(*doc, 0u32, &[][..]);
+                serializer.write_doc(*doc, 1u32, &[0][..]);
             }
         } else {
             for doc in VInt32Reader::new(&buffer[..]) {
-                serializer.write_doc(doc, 0u32, &[][..]);
+                serializer.write_doc(doc, 1u32, &[0][..]);
             }
         }
     }

--- a/src/postings/serializer.rs
+++ b/src/postings/serializer.rs
@@ -301,6 +301,7 @@ pub struct PostingsSerializer<W: Write> {
     bm25_weight: Option<Bm25Weight>,
     avg_fieldnorm: Score, /* Average number of term in the field for that segment.
                            * this value is used to compute the block wand information. */
+    term_has_freq: bool,
 }
 
 impl<W: Write> PostingsSerializer<W> {
@@ -325,13 +326,15 @@ impl<W: Write> PostingsSerializer<W> {
             fieldnorm_reader,
             bm25_weight: None,
             avg_fieldnorm,
+            term_has_freq: false,
         }
     }
 
     pub fn new_term(&mut self, term_doc_freq: u32) {
         self.bm25_weight = None;
 
-        if !self.mode.has_freq() {
+        self.term_has_freq = self.mode.has_freq() && term_doc_freq != 0;
+        if !self.term_has_freq {
             return;
         }
 
@@ -365,7 +368,7 @@ impl<W: Write> PostingsSerializer<W> {
             // last el block 0, offset block 1,
             self.postings_write.extend(block_encoded);
         }
-        if self.mode.has_freq() {
+        if self.term_has_freq {
             let (num_bits, block_encoded): (u8, &[u8]) = self
                 .block_encoder
                 .compress_block_unsorted(self.block.term_freqs(), true);
@@ -432,7 +435,7 @@ impl<W: Write> PostingsSerializer<W> {
                 self.postings_write.write_all(block_encoded)?;
             }
             // ... Idem for term frequencies
-            if self.mode.has_freq() {
+            if self.term_has_freq {
                 let block_encoded = self
                     .block_encoder
                     .compress_vint_unsorted(self.block.term_freqs());

--- a/src/postings/serializer.rs
+++ b/src/postings/serializer.rs
@@ -368,7 +368,7 @@ impl<W: Write> PostingsSerializer<W> {
         if self.mode.has_freq() {
             let (num_bits, block_encoded): (u8, &[u8]) = self
                 .block_encoder
-                .compress_block_unsorted(self.block.term_freqs());
+                .compress_block_unsorted(self.block.term_freqs(), true);
             self.postings_write.extend(block_encoded);
             self.skip_write.write_term_freq(num_bits);
             if self.mode.has_positions() {

--- a/src/postings/skip.rs
+++ b/src/postings/skip.rs
@@ -9,6 +9,8 @@ use crate::{DocId, Score, TERMINATED};
 // doc num bits between 0..=32 are used for legacy, delta without -1 encoding
 // 33..=65 are used for current delta-1 encoding
 // 66..=255 is currently unused
+//
+// when ysing strict delta, we also encode term frequency as value-1 instead of value.
 const STRICT_DELTA_OFFSET: u8 = 33;
 
 #[inline]

--- a/src/query/term_query/term_scorer.rs
+++ b/src/query/term_query/term_scorer.rs
@@ -93,7 +93,7 @@ impl TermScorer {
     }
 
     pub fn last_doc_in_block(&self) -> DocId {
-        self.postings.block_cursor.skip_reader.last_doc_in_block()
+        self.postings.block_cursor.skip_reader().last_doc_in_block()
     }
 }
 


### PR DESCRIPTION
fix https://github.com/quickwit-oss/quickwit/issues/3740 on next tantivy pull
fix #2180 

tested with quickwit on 100k documents from github-archive, using a json term covering everything, indexed+stored+record-position+fast, all put in a single split.
Here are the size of the different sections of the split, at each step of the changes:

![image](https://github.com/quickwit-oss/tantivy/assets/35889323/d3c4efb3-00a7-4948-8471-046a7dce409c)



the code should be compatible with old indexes, however it generate posting lists that can't be read by old version.
Not emitting TF cause the decoding to become somewhat of a guesswork, we know this field has frequency, but does it really has frequency for *this* term? We now decide that based on whether the section is lengthily enough to contain those. As far as I can tell it's correct, but not beautiful, and rather fragile. I think I prefer encoding dummy TF/position than actually not emitting those