### PR TITLE
replace BinaryHeap for TopN

### DIFF
--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -97,7 +97,7 @@ pub use self::multi_collector::{FruitHandle, MultiCollector, MultiFruit};
 mod top_collector;
 
 mod top_score_collector;
-pub use self::top_score_collector::TopDocs;
+pub use self::top_score_collector::{TopDocs, TopNComputer};
 
 mod custom_score_top_collector;
 pub use self::custom_score_top_collector::{CustomScorer, CustomSegmentScorer};

--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -20,6 +20,14 @@ pub(crate) struct ComparableDoc<T, D> {
     pub feature: T,
     pub doc: D,
 }
+impl<T: std::fmt::Debug, D: std::fmt::Debug> std::fmt::Debug for ComparableDoc<T, D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ComparableDoc")
+            .field("feature", &self.feature)
+            .field("doc", &self.doc)
+            .finish()
+    }
+}
 
 impl<T: PartialOrd, D: PartialOrd> PartialOrd for ComparableDoc<T, D> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -99,7 +107,8 @@ where T: PartialOrd + Clone
         }
 
         Ok(top_collector
-            .into_iter_sorted()
+            .into_sorted_vec()
+            .into_iter()
             .skip(self.offset)
             .map(|cdoc| (cdoc.feature, cdoc.doc))
             .collect())
@@ -151,7 +160,8 @@ impl<T: PartialOrd + Clone> TopSegmentCollector<T> {
     pub fn harvest(self) -> Vec<(T, DocAddress)> {
         let segment_ord = self.segment_ord;
         self.topn_computer
-            .into_iter_sorted()
+            .into_sorted_vec()
+            .into_iter()
             .map(|comparable_doc| {
                 (
                     comparable_doc.feature,

--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -107,9 +107,7 @@ where T: PartialOrd + Clone
                     .take(self.limit)
                     .collect());
             }
-            if child.len() > self.limit {
-                child.truncate(self.limit);
-            }
+            child.truncate(self.limit);
 
             return Ok(child);
         }

--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -60,8 +60,7 @@ pub(crate) struct TopCollector<T> {
 }
 
 impl<T> TopCollector<T>
-where
-    T: PartialOrd + Clone,
+where T: PartialOrd + Clone
 {
     /// Creates a top collector, with a number of documents equal to "limit".
     ///

--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -60,7 +60,8 @@ pub(crate) struct TopCollector<T> {
 }
 
 impl<T> TopCollector<T>
-where T: PartialOrd + Clone
+where
+    T: PartialOrd + Clone,
 {
     /// Creates a top collector, with a number of documents equal to "limit".
     ///
@@ -86,30 +87,10 @@ where T: PartialOrd + Clone
 
     pub fn merge_fruits(
         &self,
-        mut children: Vec<Vec<(T, DocAddress)>>,
+        children: Vec<Vec<(T, DocAddress)>>,
     ) -> crate::Result<Vec<(T, DocAddress)>> {
         if self.limit == 0 {
             return Ok(Vec::new());
-        }
-        if children.len() == 1 {
-            let mut child = children.pop().unwrap();
-            child.sort_by(|a, b| {
-                if a.0 == b.0 {
-                    a.1.cmp(&b.1)
-                } else {
-                    b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
-                }
-            });
-            if self.offset != 0 {
-                return Ok(child
-                    .into_iter()
-                    .skip(self.offset)
-                    .take(self.limit)
-                    .collect());
-            }
-            child.truncate(self.limit);
-
-            return Ok(child);
         }
         let mut top_collector = TopNComputer::new(self.limit + self.offset);
         for child_fruit in children {
@@ -150,9 +131,9 @@ where T: PartialOrd + Clone
 /// The Top Collector keeps track of the K documents
 /// sorted by type `T`.
 ///
-/// The implementation is based on a `BinaryHeap`.
+/// The implementation is based on a repeatedly truncating on the median after K * 2 documents
 /// The theoretical complexity for collecting the top `K` out of `n` documents
-/// is `O(n log K)`.
+/// is `O(n + K)`.
 pub(crate) struct TopSegmentCollector<T> {
     topn_computer: TopNComputer<T, DocId>,
     segment_ord: u32,

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -896,20 +896,25 @@ mod tests {
         // using AllQuery to get a constant score
         let searcher = index.reader().unwrap().searcher();
 
+        let page_0 = searcher.search(&AllQuery, &TopDocs::with_limit(1)).unwrap();
+
         let page_1 = searcher.search(&AllQuery, &TopDocs::with_limit(2)).unwrap();
 
         let page_2 = searcher.search(&AllQuery, &TopDocs::with_limit(3)).unwrap();
 
         // precondition for the test to be meaningful: we did get documents
         // with the same score
+        assert!(page_0.iter().all(|result| result.0 == page_1[0].0));
         assert!(page_1.iter().all(|result| result.0 == page_1[0].0));
         assert!(page_2.iter().all(|result| result.0 == page_2[0].0));
 
         // sanity check since we're relying on make_index()
+        assert_eq!(page_0.len(), 1);
         assert_eq!(page_1.len(), 2);
         assert_eq!(page_2.len(), 3);
 
         assert_eq!(page_1, &page_2[..page_1.len()]);
+        assert_eq!(page_0, &page_2[..page_0.len()]);
     }
 
     #[test]

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -775,9 +775,8 @@ where
 
     #[inline(never)]
     fn truncate_top_n(&mut self) -> Score {
-        let truncate_pos = self.top_n.min(self.buffer.len().saturating_sub(1));
         // Use select_nth_unstable to find the top nth score
-        let (_, median_el, _) = self.buffer.select_nth_unstable(truncate_pos);
+        let (_, median_el, _) = self.buffer.select_nth_unstable(self.top_n);
 
         let median_score = median_el.feature.clone();
         // Remove all elements below the top_n
@@ -787,9 +786,7 @@ where
     }
 
     pub(crate) fn into_sorted_vec(mut self) -> Vec<ComparableDoc<Score, DocId>> {
-        if self.buffer.len() == 0 {
-            self.buffer.clear();
-        } else {
+        if self.buffer.len() > self.top_n {
             self.truncate_top_n();
         }
         self.buffer.sort_unstable();

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -761,6 +761,7 @@ where
 
         // This is faster since it avoids the buffer resizing to be inlined from vec.push()
         // (this is in the hot path)
+        // TODO: Replace with `push_within_capacity` when it's stabilized
         let uninit = self.buffer.spare_capacity_mut();
         // This cannot panic, because we truncate_median will at least remove one element, since
         // the min capacity is 2.


### PR DESCRIPTION
replace BinaryHeap for TopN with variant that selects the median with QuickSort,
which runs in O(n) time.

### Variant with `spare_capacity_mut` 

#### Top 10
Query | tantivy-0.20 | tantivy-0.21 | tantivy-topn
-- | -- | -- | --
AVERAGE | 2,882 μs | 2,844 μs | 2,469 μs

#### Top 100
Query | tantivy-0.20 | tantivy-0.21 | tantivy-topn
-- | -- | -- | --
AVERAGE | 2,846 μs | 2,902 μs | 2,504 μs

#### Top 1000
Query | tantivy-0.20 | tantivy-0.21 | tantivy-topn
-- | -- | -- | --
AVERAGE | 2,848 μs | 3,169 μs | 2,518 μs

### Variant with `push` 



![topn_1](https://github.com/quickwit-oss/tantivy/assets/1109503/8d1af4f6-3dcb-4804-a3d6-d66c5f1c1945)
![topn_2](https://github.com/quickwit-oss/tantivy/assets/1109503/189950e6-a38e-4f28-a887-371ed54aa28b)
![topn_3](https://github.com/quickwit-oss/tantivy/assets/1109503/c260d7ad-133a-4a68-8630-974bbb953879)
