### PR TITLE
rename DocValue to Value

### DIFF
--- a/examples/date_time_field.rs
+++ b/examples/date_time_field.rs
@@ -4,7 +4,7 @@
 
 use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
-use tantivy::schema::{DateOptions, Schema, Value, INDEXED, STORED, STRING};
+use tantivy::schema::{DateOptions, OwnedValue, Schema, INDEXED, STORED, STRING};
 use tantivy::{Index, IndexWriter, TantivyDocument};
 
 fn main() -> tantivy::Result<()> {
@@ -63,7 +63,7 @@ fn main() -> tantivy::Result<()> {
             let retrieved_doc = searcher.doc::<TantivyDocument>(doc_address)?;
             assert!(matches!(
                 retrieved_doc.get_first(occurred_at),
-                Some(Value::Date(_))
+                Some(OwnedValue::Date(_))
             ));
             assert_eq!(
                 retrieved_doc.to_json(&schema),

--- a/src/core/json_utils.rs
+++ b/src/core/json_utils.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap;
 
 use crate::fastfield::FastValue;
 use crate::postings::{IndexingContext, IndexingPosition, PostingsWriter};
-use crate::schema::document::{DocValue, ReferenceValue};
+use crate::schema::document::{ReferenceValue, Value};
 use crate::schema::term::{JSON_PATH_SEGMENT_SEP, JSON_PATH_SEGMENT_SEP_STR};
 use crate::schema::{Field, Type, DATE_TIME_PRECISION_INDEXED};
 use crate::time::format_description::well_known::Rfc3339;
@@ -65,7 +65,7 @@ impl IndexingPositionsPerPath {
     }
 }
 
-pub(crate) fn index_json_values<'a, V: DocValue<'a>>(
+pub(crate) fn index_json_values<'a, V: Value<'a>>(
     doc: DocId,
     json_visitors: impl Iterator<Item = crate::Result<V::ObjectIter>>,
     text_analyzer: &mut TextAnalyzer,
@@ -91,7 +91,7 @@ pub(crate) fn index_json_values<'a, V: DocValue<'a>>(
     Ok(())
 }
 
-fn index_json_object<'a, V: DocValue<'a>>(
+fn index_json_object<'a, V: Value<'a>>(
     doc: DocId,
     json_visitor: V::ObjectIter,
     text_analyzer: &mut TextAnalyzer,
@@ -115,7 +115,7 @@ fn index_json_object<'a, V: DocValue<'a>>(
     }
 }
 
-fn index_json_value<'a, V: DocValue<'a>>(
+fn index_json_value<'a, V: Value<'a>>(
     doc: DocId,
     json_value: ReferenceValue<'a, V>,
     text_analyzer: &mut TextAnalyzer,

--- a/src/fastfield/facet_reader.rs
+++ b/src/fastfield/facet_reader.rs
@@ -62,7 +62,7 @@ impl FacetReader {
 
 #[cfg(test)]
 mod tests {
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::schema::{Facet, FacetOptions, SchemaBuilder, STORED};
     use crate::{DocAddress, Index, IndexWriter, TantivyDocument};
 

--- a/src/fastfield/writer.rs
+++ b/src/fastfield/writer.rs
@@ -5,7 +5,7 @@ use common::replace_in_place;
 use tokenizer_api::Token;
 
 use crate::indexer::doc_id_mapping::DocIdMapping;
-use crate::schema::document::{DocValue, Document, ReferenceValue};
+use crate::schema::document::{Document, ReferenceValue, Value};
 use crate::schema::term::{JSON_PATH_SEGMENT_SEP, JSON_PATH_SEGMENT_SEP_STR};
 use crate::schema::{value_type_to_column_type, Field, FieldType, Schema, Type};
 use crate::tokenizer::{TextAnalyzer, TokenizerManager};
@@ -129,7 +129,7 @@ impl FastFieldsWriter {
         Ok(())
     }
 
-    fn add_doc_value<'a, V: DocValue<'a>>(
+    fn add_doc_value<'a, V: Value<'a>>(
         &mut self,
         doc_id: DocId,
         field: Field,
@@ -243,7 +243,7 @@ impl FastFieldsWriter {
     }
 }
 
-fn record_json_obj_to_columnar_writer<'a, V: DocValue<'a>>(
+fn record_json_obj_to_columnar_writer<'a, V: Value<'a>>(
     doc: DocId,
     json_visitor: V::ObjectIter,
     expand_dots: bool,
@@ -282,7 +282,7 @@ fn record_json_obj_to_columnar_writer<'a, V: DocValue<'a>>(
     }
 }
 
-fn record_json_value_to_columnar_writer<'a, V: DocValue<'a>>(
+fn record_json_value_to_columnar_writer<'a, V: Value<'a>>(
     doc: DocId,
     json_val: ReferenceValue<'a, V>,
     expand_dots: bool,
@@ -382,7 +382,7 @@ mod tests {
 
     use super::record_json_value_to_columnar_writer;
     use crate::fastfield::writer::JSON_DEPTH_LIMIT;
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::DocId;
 
     fn test_columnar_from_jsons_aux(

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -158,7 +158,7 @@ mod tests_indexsorting {
     use crate::indexer::doc_id_mapping::DocIdMapping;
     use crate::indexer::NoMergePolicy;
     use crate::query::QueryParser;
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::schema::{Schema, *};
     use crate::{DocAddress, Index, IndexSettings, IndexSortByField, Order};
 

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -815,7 +815,7 @@ mod tests {
     use crate::indexer::index_writer::MEMORY_BUDGET_NUM_BYTES_MIN;
     use crate::indexer::NoMergePolicy;
     use crate::query::{BooleanQuery, Occur, Query, QueryParser, TermQuery};
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::schema::{
         self, Facet, FacetOptions, IndexRecordOption, IpAddrOptions, NumericOptions, Schema,
         TextFieldIndexing, TextOptions, FAST, INDEXED, STORED, STRING, TEXT,

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -753,7 +753,7 @@ mod tests {
     use crate::collector::{Count, FacetCollector};
     use crate::core::Index;
     use crate::query::{AllQuery, BooleanQuery, EnableScoring, Scorer, TermQuery};
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::schema::{
         Facet, FacetOptions, IndexRecordOption, NumericOptions, TantivyDocument, Term,
         TextFieldIndexing, INDEXED, TEXT,

--- a/src/indexer/merger_sorted_index_test.rs
+++ b/src/indexer/merger_sorted_index_test.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::core::Index;
     use crate::fastfield::AliveBitSet;
     use crate::query::QueryParser;
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::schema::{
         self, BytesOptions, Facet, FacetOptions, IndexRecordOption, NumericOptions,
         TextFieldIndexing, TextOptions,

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -13,7 +13,7 @@ use crate::postings::{
     compute_table_memory_size, serialize_postings, IndexingContext, IndexingPosition,
     PerFieldPostingsWriter, PostingsWriter,
 };
-use crate::schema::document::{DocValue, Document, ReferenceValue};
+use crate::schema::document::{Document, ReferenceValue, Value};
 use crate::schema::{FieldEntry, FieldType, Schema, Term, DATE_TIME_PRECISION_INDEXED};
 use crate::store::{StoreReader, StoreWriter};
 use crate::tokenizer::{FacetTokenizer, PreTokenizedStream, TextAnalyzer, Tokenizer};
@@ -492,7 +492,7 @@ mod tests {
     use crate::directory::RamDirectory;
     use crate::postings::TermInfo;
     use crate::query::PhraseQuery;
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::schema::{
         IndexRecordOption, Schema, TextFieldIndexing, TextOptions, Type, STORED, STRING, TEXT,
     };
@@ -715,7 +715,7 @@ mod tests {
         let json_field = schema_builder.add_json_field("json", STORED | TEXT);
         let schema = schema_builder.build();
         let mut doc = TantivyDocument::default();
-        let json_val: BTreeMap<String, crate::schema::Value> =
+        let json_val: BTreeMap<String, crate::schema::OwnedValue> =
             serde_json::from_str(r#"{"mykey": "repeated token token"}"#).unwrap();
         doc.add_object(json_field, json_val);
         let index = Index::create_in_ram(schema);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ pub mod tests {
     use crate::docset::{DocSet, TERMINATED};
     use crate::merge_policy::NoMergePolicy;
     use crate::query::BooleanQuery;
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::schema::*;
     use crate::{DateTime, DocAddress, Index, IndexWriter, Postings, ReloadPolicy};
 
@@ -986,11 +986,11 @@ pub mod tests {
                             text_field => "some other value",
                             other_text_field => "short");
         assert_eq!(document.len(), 3);
-        let values: Vec<&Value> = document.get_all(text_field).collect();
+        let values: Vec<&OwnedValue> = document.get_all(text_field).collect();
         assert_eq!(values.len(), 2);
         assert_eq!(values[0].as_str(), Some("tantivy"));
         assert_eq!(values[1].as_str(), Some("some other value"));
-        let values: Vec<&Value> = document.get_all(other_text_field).collect();
+        let values: Vec<&OwnedValue> = document.get_all(other_text_field).collect();
         assert_eq!(values.len(), 1);
         assert_eq!(values[0].as_str(), Some("short"));
     }

--- a/src/query/more_like_this/more_like_this.rs
+++ b/src/query/more_like_this/more_like_this.rs
@@ -5,7 +5,7 @@ use tokenizer_api::Token;
 
 use crate::query::bm25::idf;
 use crate::query::{BooleanQuery, BoostQuery, Occur, Query, TermQuery};
-use crate::schema::document::{DocValue, Document};
+use crate::schema::document::{Document, Value};
 use crate::schema::{Field, FieldType, IndexRecordOption, Term};
 use crate::tokenizer::{FacetTokenizer, PreTokenizedStream, TokenStream, Tokenizer};
 use crate::{DocAddress, Result, Searcher, TantivyDocument, TantivyError};
@@ -93,7 +93,7 @@ impl MoreLikeThis {
     }
 
     /// Creates a [`BooleanQuery`] using a set of field values.
-    pub fn query_with_document_fields<'a, V: DocValue<'a>>(
+    pub fn query_with_document_fields<'a, V: Value<'a>>(
         &self,
         searcher: &Searcher,
         doc_fields: &[(Field, Vec<V>)],
@@ -137,7 +137,7 @@ impl MoreLikeThis {
 
     /// Finds terms for a more-like-this query.
     /// field_to_field_values is a mapping from field to possible values of that field.
-    fn retrieve_terms_from_doc_fields<'a, V: DocValue<'a>>(
+    fn retrieve_terms_from_doc_fields<'a, V: Value<'a>>(
         &self,
         searcher: &Searcher,
         field_to_values: &[(Field, Vec<V>)],
@@ -159,7 +159,7 @@ impl MoreLikeThis {
     /// Computes the frequency of values for a field while updating the term frequencies
     /// Note: A FieldValue can be made up of multiple terms.
     /// We are interested in extracting terms within FieldValue
-    fn add_term_frequencies<'a, V: DocValue<'a>>(
+    fn add_term_frequencies<'a, V: Value<'a>>(
         &self,
         searcher: &Searcher,
         field: Field,

--- a/src/query/more_like_this/query.rs
+++ b/src/query/more_like_this/query.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use super::MoreLikeThis;
 use crate::query::{EnableScoring, Query, Weight};
-use crate::schema::{Field, Value};
+use crate::schema::{Field, OwnedValue};
 use crate::DocAddress;
 
 /// A query that matches all of the documents similar to a document
@@ -33,7 +33,7 @@ pub struct MoreLikeThisQuery {
 #[derive(Debug, Clone, PartialEq)]
 enum TargetDocument {
     DocumentAddress(DocAddress),
-    DocumentFields(Vec<(Field, Vec<Value>)>),
+    DocumentFields(Vec<(Field, Vec<OwnedValue>)>),
 }
 
 impl MoreLikeThisQuery {
@@ -60,7 +60,7 @@ impl Query for MoreLikeThisQuery {
             TargetDocument::DocumentFields(doc_fields) => {
                 let values = doc_fields
                     .iter()
-                    .map(|(field, values)| (*field, values.iter().collect::<Vec<&Value>>()))
+                    .map(|(field, values)| (*field, values.iter().collect::<Vec<&OwnedValue>>()))
                     .collect::<Vec<_>>();
 
                 self.mlt
@@ -175,7 +175,10 @@ impl MoreLikeThisQueryBuilder {
     /// that will be used to compose the resulting query.
     /// This interface is meant to be used when you want to provide your own set of fields
     /// not necessarily from a specific document.
-    pub fn with_document_fields(self, doc_fields: Vec<(Field, Vec<Value>)>) -> MoreLikeThisQuery {
+    pub fn with_document_fields(
+        self,
+        doc_fields: Vec<(Field, Vec<OwnedValue>)>,
+    ) -> MoreLikeThisQuery {
         MoreLikeThisQuery {
             mlt: self.mlt,
             target: TargetDocument::DocumentFields(doc_fields),

--- a/src/schema/document/de.rs
+++ b/src/schema/document/de.rs
@@ -802,52 +802,52 @@ mod tests {
         writer
     }
 
-    fn deserialize_value(buffer: Vec<u8>) -> crate::schema::Value {
+    fn deserialize_value(buffer: Vec<u8>) -> crate::schema::OwnedValue {
         let mut cursor = Cursor::new(buffer);
         let deserializer = BinaryValueDeserializer::from_reader(&mut cursor).unwrap();
-        crate::schema::Value::deserialize(deserializer).expect("Deserialize value")
+        crate::schema::OwnedValue::deserialize(deserializer).expect("Deserialize value")
     }
 
     #[test]
     fn test_simple_value_serialize() {
         let result = serialize_value(ReferenceValue::Null);
         let value = deserialize_value(result);
-        assert_eq!(value, crate::schema::Value::Null);
+        assert_eq!(value, crate::schema::OwnedValue::Null);
 
         let result = serialize_value(ReferenceValue::Str("hello, world"));
         let value = deserialize_value(result);
         assert_eq!(
             value,
-            crate::schema::Value::Str(String::from("hello, world"))
+            crate::schema::OwnedValue::Str(String::from("hello, world"))
         );
 
         let result = serialize_value(ReferenceValue::U64(123));
         let value = deserialize_value(result);
-        assert_eq!(value, crate::schema::Value::U64(123));
+        assert_eq!(value, crate::schema::OwnedValue::U64(123));
 
         let result = serialize_value(ReferenceValue::I64(-123));
         let value = deserialize_value(result);
-        assert_eq!(value, crate::schema::Value::I64(-123));
+        assert_eq!(value, crate::schema::OwnedValue::I64(-123));
 
         let result = serialize_value(ReferenceValue::F64(123.3845));
         let value = deserialize_value(result);
-        assert_eq!(value, crate::schema::Value::F64(123.3845));
+        assert_eq!(value, crate::schema::OwnedValue::F64(123.3845));
 
         let result = serialize_value(ReferenceValue::Bool(false));
         let value = deserialize_value(result);
-        assert_eq!(value, crate::schema::Value::Bool(false));
+        assert_eq!(value, crate::schema::OwnedValue::Bool(false));
 
         let result = serialize_value(ReferenceValue::Date(DateTime::from_timestamp_micros(100)));
         let value = deserialize_value(result);
         assert_eq!(
             value,
-            crate::schema::Value::Date(DateTime::from_timestamp_micros(100))
+            crate::schema::OwnedValue::Date(DateTime::from_timestamp_micros(100))
         );
 
         let facet = Facet::from_text("/hello/world").unwrap();
         let result = serialize_value(ReferenceValue::Facet(&facet));
         let value = deserialize_value(result);
-        assert_eq!(value, crate::schema::Value::Facet(facet));
+        assert_eq!(value, crate::schema::OwnedValue::Facet(facet));
 
         let pre_tok_str = PreTokenizedString {
             text: "hello, world".to_string(),
@@ -855,7 +855,7 @@ mod tests {
         };
         let result = serialize_value(ReferenceValue::PreTokStr(&pre_tok_str));
         let value = deserialize_value(result);
-        assert_eq!(value, crate::schema::Value::PreTokStr(pre_tok_str));
+        assert_eq!(value, crate::schema::OwnedValue::PreTokStr(pre_tok_str));
     }
 
     #[test]
@@ -865,9 +865,9 @@ mod tests {
         let value = deserialize_value(result);
         assert_eq!(
             value,
-            crate::schema::Value::Array(vec![
-                crate::schema::Value::Null,
-                crate::schema::Value::Null,
+            crate::schema::OwnedValue::Array(vec![
+                crate::schema::OwnedValue::Null,
+                crate::schema::OwnedValue::Null,
             ]),
         );
 
@@ -879,16 +879,16 @@ mod tests {
         let value = deserialize_value(result);
         assert_eq!(
             value,
-            crate::schema::Value::Array(vec![
-                crate::schema::Value::Str(String::from("Hello, world")),
-                crate::schema::Value::Str(String::from("Some demo")),
+            crate::schema::OwnedValue::Array(vec![
+                crate::schema::OwnedValue::Str(String::from("Hello, world")),
+                crate::schema::OwnedValue::Str(String::from("Some demo")),
             ]),
         );
 
         let elements = vec![];
         let result = serialize_value(ReferenceValue::Array(JsonArrayIter(elements.iter())));
         let value = deserialize_value(result);
-        assert_eq!(value, crate::schema::Value::Array(vec![]));
+        assert_eq!(value, crate::schema::OwnedValue::Array(vec![]));
 
         let elements = vec![
             serde_json::Value::Null,
@@ -899,10 +899,10 @@ mod tests {
         let value = deserialize_value(result);
         assert_eq!(
             value,
-            crate::schema::Value::Array(vec![
-                crate::schema::Value::Null,
-                crate::schema::Value::Str(String::from("Hello, world")),
-                crate::schema::Value::U64(12345),
+            crate::schema::OwnedValue::Array(vec![
+                crate::schema::OwnedValue::Null,
+                crate::schema::OwnedValue::Str(String::from("Hello, world")),
+                crate::schema::OwnedValue::U64(12345),
             ]),
         );
     }
@@ -925,17 +925,20 @@ mod tests {
         let mut expected_object = BTreeMap::new();
         expected_object.insert(
             "my-first-key".to_string(),
-            crate::schema::Value::Str(String::from("Hello")),
+            crate::schema::OwnedValue::Str(String::from("Hello")),
         );
-        expected_object.insert("my-second-key".to_string(), crate::schema::Value::Null);
-        expected_object.insert("my-third-key".to_string(), crate::schema::Value::F64(123.0));
-        assert_eq!(value, crate::schema::Value::Object(expected_object));
+        expected_object.insert("my-second-key".to_string(), crate::schema::OwnedValue::Null);
+        expected_object.insert(
+            "my-third-key".to_string(),
+            crate::schema::OwnedValue::F64(123.0),
+        );
+        assert_eq!(value, crate::schema::OwnedValue::Object(expected_object));
 
         let object = serde_json::Map::new();
         let result = serialize_value(ReferenceValue::Object(JsonObjectIter(object.iter())));
         let value = deserialize_value(result);
         let expected_object = BTreeMap::new();
-        assert_eq!(value, crate::schema::Value::Object(expected_object));
+        assert_eq!(value, crate::schema::OwnedValue::Object(expected_object));
 
         let mut object = serde_json::Map::new();
         object.insert("my-first-key".into(), serde_json::Value::Null);
@@ -944,10 +947,10 @@ mod tests {
         let result = serialize_value(ReferenceValue::Object(JsonObjectIter(object.iter())));
         let value = deserialize_value(result);
         let mut expected_object = BTreeMap::new();
-        expected_object.insert("my-first-key".to_string(), crate::schema::Value::Null);
-        expected_object.insert("my-second-key".to_string(), crate::schema::Value::Null);
-        expected_object.insert("my-third-key".to_string(), crate::schema::Value::Null);
-        assert_eq!(value, crate::schema::Value::Object(expected_object));
+        expected_object.insert("my-first-key".to_string(), crate::schema::OwnedValue::Null);
+        expected_object.insert("my-second-key".to_string(), crate::schema::OwnedValue::Null);
+        expected_object.insert("my-third-key".to_string(), crate::schema::OwnedValue::Null);
+        assert_eq!(value, crate::schema::OwnedValue::Object(expected_object));
     }
 
     #[test]
@@ -983,26 +986,29 @@ mod tests {
         let mut expected_object = BTreeMap::new();
         expected_object.insert(
             "my-array".to_string(),
-            crate::schema::Value::Array(vec![
-                crate::schema::Value::Null,
-                crate::schema::Value::Str(String::from("bobby of the sea")),
+            crate::schema::OwnedValue::Array(vec![
+                crate::schema::OwnedValue::Null,
+                crate::schema::OwnedValue::Str(String::from("bobby of the sea")),
             ]),
         );
         expected_object.insert(
             "my-object".to_string(),
-            crate::schema::Value::Object(
+            crate::schema::OwnedValue::Object(
                 vec![
-                    ("inner-1".to_string(), crate::schema::Value::I64(-123i64)),
+                    (
+                        "inner-1".to_string(),
+                        crate::schema::OwnedValue::I64(-123i64),
+                    ),
                     (
                         "inner-2".to_string(),
-                        crate::schema::Value::Str(String::from("bobby of the sea 2")),
+                        crate::schema::OwnedValue::Str(String::from("bobby of the sea 2")),
                     ),
                 ]
                 .into_iter()
                 .collect(),
             ),
         );
-        assert_eq!(value, crate::schema::Value::Object(expected_object));
+        assert_eq!(value, crate::schema::OwnedValue::Object(expected_object));
 
         // Some more extreme nesting that might behave weirdly
         let mut object = serde_json::Map::new();
@@ -1019,11 +1025,11 @@ mod tests {
         let mut expected_object = BTreeMap::new();
         expected_object.insert(
             "my-array".to_string(),
-            crate::schema::Value::Array(vec![crate::schema::Value::Array(vec![
-                crate::schema::Value::Array(vec![]),
-                crate::schema::Value::Array(vec![crate::schema::Value::Null]),
+            crate::schema::OwnedValue::Array(vec![crate::schema::OwnedValue::Array(vec![
+                crate::schema::OwnedValue::Array(vec![]),
+                crate::schema::OwnedValue::Array(vec![crate::schema::OwnedValue::Null]),
             ])]),
         );
-        assert_eq!(value, crate::schema::Value::Object(expected_object));
+        assert_eq!(value, crate::schema::OwnedValue::Object(expected_object));
     }
 }

--- a/src/schema/document/existing_type_impls.rs
+++ b/src/schema/document/existing_type_impls.rs
@@ -9,13 +9,13 @@ use std::collections::{btree_map, hash_map, BTreeMap, HashMap};
 use serde_json::Number;
 
 use crate::schema::document::{
-    ArrayAccess, DeserializeError, DocValue, Document, DocumentDeserialize, DocumentDeserializer,
-    ObjectAccess, ReferenceValue, ValueDeserialize, ValueDeserializer, ValueVisitor,
+    ArrayAccess, DeserializeError, Document, DocumentDeserialize, DocumentDeserializer,
+    ObjectAccess, ReferenceValue, Value, ValueDeserialize, ValueDeserializer, ValueVisitor,
 };
 use crate::schema::Field;
 
 // Serde compatibility support.
-impl<'a> DocValue<'a> for &'a serde_json::Value {
+impl<'a> Value<'a> for &'a serde_json::Value {
     type ChildValue = Self;
     type ArrayIter = JsonArrayIter<'a>;
     type ObjectIter = JsonObjectIter<'a>;
@@ -137,19 +137,19 @@ impl<'a> Iterator for JsonObjectIter<'a> {
 // Custom document types
 
 // BTreeMap based documents
-impl Document for BTreeMap<Field, crate::schema::Value> {
-    type Value<'a> = &'a crate::schema::Value;
+impl Document for BTreeMap<Field, crate::schema::OwnedValue> {
+    type Value<'a> = &'a crate::schema::OwnedValue;
     type FieldsValuesIter<'a> = FieldCopyingIterator<
         'a,
-        btree_map::Iter<'a, Field, crate::schema::Value>,
-        crate::schema::Value,
+        btree_map::Iter<'a, Field, crate::schema::OwnedValue>,
+        crate::schema::OwnedValue,
     >;
 
     fn iter_fields_and_values(&self) -> Self::FieldsValuesIter<'_> {
         FieldCopyingIterator(self.iter())
     }
 }
-impl DocumentDeserialize for BTreeMap<Field, crate::schema::Value> {
+impl DocumentDeserialize for BTreeMap<Field, crate::schema::OwnedValue> {
     fn deserialize<'de, D>(mut deserializer: D) -> Result<Self, DeserializeError>
     where D: DocumentDeserializer<'de> {
         let mut document = BTreeMap::new();
@@ -163,19 +163,19 @@ impl DocumentDeserialize for BTreeMap<Field, crate::schema::Value> {
 }
 
 // HashMap based documents
-impl Document for HashMap<Field, crate::schema::Value> {
-    type Value<'a> = &'a crate::schema::Value;
+impl Document for HashMap<Field, crate::schema::OwnedValue> {
+    type Value<'a> = &'a crate::schema::OwnedValue;
     type FieldsValuesIter<'a> = FieldCopyingIterator<
         'a,
-        hash_map::Iter<'a, Field, crate::schema::Value>,
-        crate::schema::Value,
+        hash_map::Iter<'a, Field, crate::schema::OwnedValue>,
+        crate::schema::OwnedValue,
     >;
 
     fn iter_fields_and_values(&self) -> Self::FieldsValuesIter<'_> {
         FieldCopyingIterator(self.iter())
     }
 }
-impl DocumentDeserialize for HashMap<Field, crate::schema::Value> {
+impl DocumentDeserialize for HashMap<Field, crate::schema::OwnedValue> {
     fn deserialize<'de, D>(mut deserializer: D) -> Result<Self, DeserializeError>
     where D: DocumentDeserializer<'de> {
         let mut document = HashMap::with_capacity(deserializer.size_hint());

--- a/src/schema/field_value.rs
+++ b/src/schema/field_value.rs
@@ -1,16 +1,16 @@
-use crate::schema::{Field, Value};
+use crate::schema::{Field, OwnedValue};
 
 /// `FieldValue` holds together a `Field` and its `Value`.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FieldValue {
     pub field: Field,
-    pub value: Value,
+    pub value: OwnedValue,
 }
 
 impl FieldValue {
     /// Constructor
-    pub fn new(field: Field, value: Value) -> FieldValue {
+    pub fn new(field: Field, value: OwnedValue) -> FieldValue {
         FieldValue { field, value }
     }
 
@@ -20,12 +20,12 @@ impl FieldValue {
     }
 
     /// Value accessor
-    pub fn value(&self) -> &Value {
+    pub fn value(&self) -> &OwnedValue {
         &self.value
     }
 }
 
-impl From<FieldValue> for Value {
+impl From<FieldValue> for OwnedValue {
     fn from(field_value: FieldValue) -> Self {
         field_value.value
     }
@@ -36,7 +36,7 @@ impl From<FieldValue> for Value {
 pub struct FieldValueIter<'a>(pub(crate) std::slice::Iter<'a, FieldValue>);
 
 impl<'a> Iterator for FieldValueIter<'a> {
-    type Item = (Field, &'a Value);
+    type Item = (Field, &'a OwnedValue);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -134,7 +134,7 @@ pub use self::bytes_options::BytesOptions;
 #[allow(deprecated)]
 pub use self::date_time_options::DatePrecision;
 pub use self::date_time_options::{DateOptions, DateTimePrecision, DATE_TIME_PRECISION_INDEXED};
-pub use self::document::{DocParsingError, DocValue, Document, TantivyDocument};
+pub use self::document::{DocParsingError, Document, TantivyDocument, Value};
 pub(crate) use self::facet::FACET_SEP_BYTE;
 pub use self::facet::{Facet, FacetParseError};
 pub use self::facet_options::FacetOptions;
@@ -153,7 +153,7 @@ pub use self::numeric_options::NumericOptions;
 pub use self::schema::{Schema, SchemaBuilder};
 pub use self::term::{Term, ValueBytes, JSON_END_OF_PATH};
 pub use self::text_options::{TextFieldIndexing, TextOptions, STRING, TEXT};
-pub use self::value::Value;
+pub use self::value::OwnedValue;
 
 /// Validator for a potential `field_name`.
 /// Returns true if the name can be use for a field name.

--- a/src/schema/named_field_document.rs
+++ b/src/schema/named_field_document.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::schema::Value;
+use crate::schema::OwnedValue;
 
 /// Internal representation of a document used for JSON
 /// serialization.
@@ -10,4 +10,4 @@ use crate::schema::Value;
 /// A `NamedFieldDocument` is a simple representation of a document
 /// as a `BTreeMap<String, Vec<Value>>`.
 #[derive(Debug, Deserialize, Serialize)]
-pub struct NamedFieldDocument(pub BTreeMap<String, Vec<Value>>);
+pub struct NamedFieldDocument(pub BTreeMap<String, Vec<OwnedValue>>);

--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -413,7 +413,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use serde_json;
 
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::schema::field_type::ValueParsingError;
     use crate::schema::schema::DocParsingError::InvalidJson;
     use crate::schema::*;
@@ -630,24 +630,24 @@ mod tests {
         let mut named_doc_map = BTreeMap::default();
         named_doc_map.insert(
             "title".to_string(),
-            vec![Value::from("title1"), Value::from("title2")],
+            vec![OwnedValue::from("title1"), OwnedValue::from("title2")],
         );
         named_doc_map.insert(
             "val".to_string(),
-            vec![Value::from(14u64), Value::from(-1i64)],
+            vec![OwnedValue::from(14u64), OwnedValue::from(-1i64)],
         );
         let doc =
             TantivyDocument::convert_named_doc(&schema, NamedFieldDocument(named_doc_map)).unwrap();
         assert_eq!(
             doc.get_all(title).collect::<Vec<_>>(),
             vec![
-                &Value::from("title1".to_string()),
-                &Value::from("title2".to_string())
+                &OwnedValue::from("title1".to_string()),
+                &OwnedValue::from("title2".to_string())
             ]
         );
         assert_eq!(
             doc.get_all(val).collect::<Vec<_>>(),
-            vec![&Value::from(14u64), &Value::from(-1i64)]
+            vec![&OwnedValue::from(14u64), &OwnedValue::from(-1i64)]
         );
     }
 
@@ -657,7 +657,7 @@ mod tests {
         let mut named_doc_map = BTreeMap::default();
         named_doc_map.insert(
             "title".to_string(),
-            vec![Value::from("title1"), Value::from("title2")],
+            vec![OwnedValue::from("title1"), OwnedValue::from("title2")],
         );
         TantivyDocument::convert_named_doc(&schema, NamedFieldDocument(named_doc_map)).unwrap();
     }

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use htmlescape::encode_minimal;
 
 use crate::query::Query;
-use crate::schema::document::{DocValue, Document};
+use crate::schema::document::{Document, Value};
 use crate::schema::Field;
 use crate::tokenizer::{TextAnalyzer, Token};
 use crate::{Score, Searcher, Term};

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -59,7 +59,7 @@ pub mod tests {
     use super::*;
     use crate::directory::{Directory, RamDirectory, WritePtr};
     use crate::fastfield::AliveBitSet;
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::schema::{
         self, Schema, TantivyDocument, TextFieldIndexing, TextOptions, STORED, TEXT,
     };

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -385,7 +385,7 @@ mod tests {
 
     use super::*;
     use crate::directory::RamDirectory;
-    use crate::schema::document::DocValue;
+    use crate::schema::document::Value;
     use crate::schema::{Field, TantivyDocument};
     use crate::store::tests::write_lorem_ipsum_store;
     use crate::store::Compressor;


### PR DESCRIPTION
rename `tantivy::schema::DocValue` to Value to avoid confusion with lucene DocValues
rename `tantivy::schema::Value` to OwnedValue