### PR TITLE
feat(aggregators/metric): Add a top_hits aggregator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ tokenizer-api = { version= "0.2", path="./tokenizer-api", package="tantivy-token
 sketches-ddsketch = { version = "0.2.1", features = ["use_serde"] }
 futures-util = { version = "0.3.28", optional = true }
 fnv = "1.0.7"
-serde-tuple-vec-map = "1.0.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = "1.0.30"
 htmlescape = "0.3.1"
 fail = { version = "0.5.0", optional = true }
 murmurhash32 = "0.3.0"
-time = { version = "0.3.10", features = ["serde-well-known", "macros"] }
+time = { version = "0.3.10", features = ["serde-well-known"] }
 smallvec = "1.8.0"
 rayon = "1.5.2"
 lru = "0.12.0"
@@ -80,6 +80,7 @@ futures = "0.3.21"
 paste = "1.0.11"
 more-asserts = "0.3.1"
 rand_distr = "0.4.3"
+time = { version = "0.3.10", features = ["serde-well-known", "macros"] }
 
 [target.'cfg(not(windows))'.dev-dependencies]
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ tokenizer-api = { version= "0.2", path="./tokenizer-api", package="tantivy-token
 sketches-ddsketch = { version = "0.2.1", features = ["use_serde"] }
 futures-util = { version = "0.3.28", optional = true }
 fnv = "1.0.7"
+serde-tuple-vec-map = "1.0.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = "1.0.30"
 htmlescape = "0.3.1"
 fail = { version = "0.5.0", optional = true }
 murmurhash32 = "0.3.0"
-time = { version = "0.3.10", features = ["serde-well-known"] }
+time = { version = "0.3.10", features = ["serde-well-known", "macros"] }
 smallvec = "1.8.0"
 rayon = "1.5.2"
 lru = "0.12.0"

--- a/src/aggregation/agg_limits.rs
+++ b/src/aggregation/agg_limits.rs
@@ -73,9 +73,9 @@ impl AggregationLimits {
     /// Create a new ResourceLimitGuard, that will release the memory when dropped.
     pub fn new_guard(&self) -> ResourceLimitGuard {
         ResourceLimitGuard {
-            /// The counter which is shared between the aggregations for one request.
+            // The counter which is shared between the aggregations for one request.
             memory_consumption: Arc::clone(&self.memory_consumption),
-            /// The memory_limit in bytes
+            // The memory_limit in bytes
             memory_limit: self.memory_limit,
             allocated_with_the_guard: 0,
         }

--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -35,7 +35,7 @@ use super::bucket::{
 };
 use super::metric::{
     AverageAggregation, CountAggregation, MaxAggregation, MinAggregation,
-    PercentilesAggregationReq, StatsAggregation, SumAggregation,
+    PercentilesAggregationReq, StatsAggregation, SumAggregation, TopHitsAggregation,
 };
 
 /// The top-level aggregation request structure, which contains [`Aggregation`] and their user
@@ -147,6 +147,9 @@ pub enum AggregationVariants {
     /// Computes the sum of the extracted values.
     #[serde(rename = "percentiles")]
     Percentiles(PercentilesAggregationReq),
+    /// Finds the top k values matching some order
+    #[serde(rename = "top_hits")]
+    TopHits(TopHitsAggregation),
 }
 
 impl AggregationVariants {
@@ -164,6 +167,9 @@ impl AggregationVariants {
             AggregationVariants::Stats(stats) => stats.field_name(),
             AggregationVariants::Sum(sum) => sum.field_name(),
             AggregationVariants::Percentiles(per) => per.field_name(),
+            // FIXME: a single fast field doesn't make sense for top hits
+            // What should we do here?
+            AggregationVariants::TopHits(top_hits) => top_hits.field_name(),
         }
     }
 

--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -158,7 +158,7 @@ pub enum AggregationVariants {
 }
 
 impl AggregationVariants {
-    /// Returns the name of the field used by the aggregation.
+    /// Returns the name of the field(s) used by the aggregation.
     pub fn get_fast_field_names(&self) -> Vec<&str> {
         match self {
             AggregationVariants::Terms(terms) => vec![terms.field.as_str()],

--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -158,7 +158,7 @@ pub enum AggregationVariants {
 }
 
 impl AggregationVariants {
-    /// Returns the name of the field(s) used by the aggregation.
+    /// Returns the name of the fields used by the aggregation.
     pub fn get_fast_field_names(&self) -> Vec<&str> {
         match self {
             AggregationVariants::Terms(terms) => vec![terms.field.as_str()],

--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -93,7 +93,12 @@ impl Aggregation {
     }
 
     fn get_fast_field_names(&self, fast_field_names: &mut HashSet<String>) {
-        fast_field_names.insert(self.agg.get_fast_field_name().to_string());
+        fast_field_names.extend(
+            self.agg
+                .get_fast_field_names()
+                .iter()
+                .map(|s| s.to_string()),
+        );
         fast_field_names.extend(get_fast_field_names(&self.sub_aggregation));
     }
 }
@@ -154,22 +159,20 @@ pub enum AggregationVariants {
 
 impl AggregationVariants {
     /// Returns the name of the field used by the aggregation.
-    pub fn get_fast_field_name(&self) -> &str {
+    pub fn get_fast_field_names(&self) -> Vec<&str> {
         match self {
-            AggregationVariants::Terms(terms) => terms.field.as_str(),
-            AggregationVariants::Range(range) => range.field.as_str(),
-            AggregationVariants::Histogram(histogram) => histogram.field.as_str(),
-            AggregationVariants::DateHistogram(histogram) => histogram.field.as_str(),
-            AggregationVariants::Average(avg) => avg.field_name(),
-            AggregationVariants::Count(count) => count.field_name(),
-            AggregationVariants::Max(max) => max.field_name(),
-            AggregationVariants::Min(min) => min.field_name(),
-            AggregationVariants::Stats(stats) => stats.field_name(),
-            AggregationVariants::Sum(sum) => sum.field_name(),
-            AggregationVariants::Percentiles(per) => per.field_name(),
-            // FIXME: a single fast field doesn't make sense for top hits
-            // What should we do here?
-            AggregationVariants::TopHits(top_hits) => top_hits.field_name(),
+            AggregationVariants::Terms(terms) => vec![terms.field.as_str()],
+            AggregationVariants::Range(range) => vec![range.field.as_str()],
+            AggregationVariants::Histogram(histogram) => vec![histogram.field.as_str()],
+            AggregationVariants::DateHistogram(histogram) => vec![histogram.field.as_str()],
+            AggregationVariants::Average(avg) => vec![avg.field_name()],
+            AggregationVariants::Count(count) => vec![count.field_name()],
+            AggregationVariants::Max(max) => vec![max.field_name()],
+            AggregationVariants::Min(min) => vec![min.field_name()],
+            AggregationVariants::Stats(stats) => vec![stats.field_name()],
+            AggregationVariants::Sum(sum) => vec![sum.field_name()],
+            AggregationVariants::Percentiles(per) => vec![per.field_name()],
+            AggregationVariants::TopHits(top_hits) => top_hits.field_names(),
         }
     }
 

--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -53,7 +53,6 @@ pub struct AggregationWithAccessor {
     /// If this needs to used by other aggregations, we need to refactor this.
     // NOTE: we can make all other aggregations use this instead of the `accessor` and `field_type`
     // (making them obsolete) But will it have a performance impact?
-    // pub(crate) accessors: HashMap<String, (Column<u64>, ColumnType)>,
     pub(crate) accessors: Vec<(Column<u64>, ColumnType)>,
     pub(crate) value_accessors: HashMap<String, DynamicColumn>,
     pub(crate) agg: Aggregation,

--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -196,7 +196,7 @@ impl AggregationWithAccessor {
                         .map(|m| matches!(m, Key::Str(_)))
                         .unwrap_or(false);
 
-                // Actually we could convert the text to a number and have the fast path, if it
+                // Actually we could convert the text to a number and have the fast path, if it is
                 // provided in Rfc3339 format. But this use case is probably common
                 // enough to justify the effort.
                 let text_on_date_col = column_and_types.len() == 1

--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -207,12 +207,13 @@ impl AggregationWithAccessor {
                         missing.clone()
                     };
 
-                    let missing_value_for_accessor =
-                        if let Some(missing) = missing_value_term_agg.as_ref() {
-                            get_missing_val(column_type, missing, agg.agg.get_fast_field_name())?
-                        } else {
-                            None
-                        };
+                    let missing_value_for_accessor = if let Some(missing) =
+                        missing_value_term_agg.as_ref()
+                    {
+                        get_missing_val(column_type, missing, agg.agg.get_fast_field_names()[0])?
+                    } else {
+                        None
+                    };
 
                     let agg = AggregationWithAccessor {
                         segment_id,
@@ -266,7 +267,7 @@ impl AggregationWithAccessor {
             }
             TopHits(top_hits) => {
                 let accessors: Vec<(Column<u64>, ColumnType)> = top_hits
-                    .get_fields()
+                    .field_names()
                     .iter()
                     .map(|field| {
                         get_ff_reader(reader, field, Some(get_numeric_or_date_column_types()))

--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -309,7 +309,7 @@ impl AggregationWithAccessor {
                     .map(|field_name| {
                         Ok((
                             field_name.to_string(),
-                            get_dynamic_column(reader, field_name)?,
+                            get_dynamic_columns(reader, &field_name)?,
                         ))
                     })
                     .collect::<crate::Result<_>>()?;
@@ -395,7 +395,7 @@ fn get_ff_reader(
     Ok(ff_field_with_type)
 }
 
-fn get_dynamic_column(
+fn get_dynamic_columns(
     reader: &SegmentReader,
     field_name: &str,
 ) -> crate::Result<Vec<columnar::DynamicColumn>> {

--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -35,7 +35,7 @@ impl AggregationsWithAccessor {
 }
 
 pub struct AggregationWithAccessor {
-    pub(crate) segment_id: SegmentOrdinal,
+    pub(crate) segment_ordinal: SegmentOrdinal,
     /// In general there can be buckets without fast field access, e.g. buckets that are created
     /// based on search terms. That is not that case currently, but eventually this needs to be
     /// Option or moved.
@@ -67,7 +67,7 @@ impl AggregationWithAccessor {
         agg: &Aggregation,
         sub_aggregation: &Aggregations,
         reader: &SegmentReader,
-        segment_id: SegmentOrdinal,
+        segment_ordinal: SegmentOrdinal,
         limits: AggregationLimits,
     ) -> crate::Result<Vec<AggregationWithAccessor>> {
         let mut agg = agg.clone();
@@ -78,7 +78,7 @@ impl AggregationWithAccessor {
                                      aggs: &mut Vec<AggregationWithAccessor>|
          -> crate::Result<()> {
             let res = AggregationWithAccessor {
-                segment_id,
+                segment_ordinal,
                 accessor,
                 accessors: Default::default(),
                 value_accessors: Default::default(),
@@ -86,7 +86,7 @@ impl AggregationWithAccessor {
                 sub_aggregation: get_aggs_with_segment_accessor_and_validate(
                     sub_aggregation,
                     reader,
-                    segment_id,
+                    segment_ordinal,
                     &limits,
                 )?,
                 agg: agg.clone(),
@@ -106,7 +106,7 @@ impl AggregationWithAccessor {
          -> crate::Result<()> {
             let (accessor, field_type) = accessors.first().expect("at least one accessor");
             let res = AggregationWithAccessor {
-                segment_id,
+                segment_ordinal,
                 // TODO: We should do away with the `accessor` field altogether
                 accessor: accessor.clone(),
                 value_accessors,
@@ -115,7 +115,7 @@ impl AggregationWithAccessor {
                 sub_aggregation: get_aggs_with_segment_accessor_and_validate(
                     sub_aggregation,
                     reader,
-                    segment_id,
+                    segment_ordinal,
                     &limits,
                 )?,
                 agg: agg.clone(),
@@ -235,7 +235,7 @@ impl AggregationWithAccessor {
                     };
 
                     let agg = AggregationWithAccessor {
-                        segment_id,
+                        segment_ordinal,
                         missing_value_for_accessor,
                         accessor,
                         accessors: Default::default(),
@@ -244,7 +244,7 @@ impl AggregationWithAccessor {
                         sub_aggregation: get_aggs_with_segment_accessor_and_validate(
                             sub_aggregation,
                             reader,
-                            segment_id,
+                            segment_ordinal,
                             &limits,
                         )?,
                         agg: agg.clone(),
@@ -354,7 +354,7 @@ fn get_numeric_or_date_column_types() -> &'static [ColumnType] {
 pub(crate) fn get_aggs_with_segment_accessor_and_validate(
     aggs: &Aggregations,
     reader: &SegmentReader,
-    segment_id: SegmentOrdinal,
+    segment_ordinal: SegmentOrdinal,
     limits: &AggregationLimits,
 ) -> crate::Result<AggregationsWithAccessor> {
     let mut aggss = Vec::new();
@@ -363,7 +363,7 @@ pub(crate) fn get_aggs_with_segment_accessor_and_validate(
             agg,
             agg.sub_aggregation(),
             reader,
-            segment_id,
+            segment_ordinal,
             limits.clone(),
         )?;
         for agg in aggs {

--- a/src/aggregation/agg_result.rs
+++ b/src/aggregation/agg_result.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use super::bucket::GetDocCount;
-use super::metric::{PercentilesMetricResult, SingleMetricResult, Stats};
+use super::metric::{PercentilesMetricResult, SingleMetricResult, Stats, TopHitsMetricResult};
 use super::{AggregationError, Key};
 use crate::TantivyError;
 
@@ -90,8 +90,10 @@ pub enum MetricResult {
     Stats(Stats),
     /// Sum metric result.
     Sum(SingleMetricResult),
-    /// Sum metric result.
+    /// Percentiles metric result.
     Percentiles(PercentilesMetricResult),
+    /// Top hits metric result
+    TopHits(TopHitsMetricResult),
 }
 
 impl MetricResult {
@@ -105,6 +107,9 @@ impl MetricResult {
             MetricResult::Sum(sum) => Ok(sum.value),
             MetricResult::Percentiles(_) => Err(TantivyError::AggregationError(
                 AggregationError::InvalidRequest("percentiles can't be used to order".to_string()),
+            )),
+            MetricResult::TopHits(_) => Err(TantivyError::AggregationError(
+                AggregationError::InvalidRequest("top_hits can't be used to order".to_string()),
             )),
         }
     }

--- a/src/aggregation/bucket/histogram/date_histogram.rs
+++ b/src/aggregation/bucket/histogram/date_histogram.rs
@@ -307,6 +307,7 @@ pub mod tests {
     ) -> crate::Result<Index> {
         let mut schema_builder = Schema::builder();
         schema_builder.add_date_field("date", FAST);
+        schema_builder.add_json_field("mixed", FAST);
         schema_builder.add_text_field("text", FAST | STRING);
         schema_builder.add_text_field("text2", FAST | STRING);
         let schema = schema_builder.build();

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -110,7 +110,7 @@ pub struct TermsAggregation {
     #[serde(alias = "shard_size")]
     pub split_size: Option<u32>,
 
-    /// The get more accurate results, we fetch more than `size` from each segment.
+    /// To get more accurate results, we fetch more than `size` from each segment.
     ///
     /// Increasing this value is will increase the cost for more accuracy.
     ///

--- a/src/aggregation/bucket/term_missing_agg.rs
+++ b/src/aggregation/bucket/term_missing_agg.rs
@@ -90,7 +90,10 @@ impl SegmentAggregationCollector for TermMissingAgg {
         agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()> {
         let agg = &mut agg_with_accessor.aggs.values[self.accessor_idx];
-        let has_value = agg.accessors.iter().any(|acc| acc.index.has_value(doc));
+        let has_value = agg
+            .accessors
+            .iter()
+            .any(|(acc, _)| acc.index.has_value(doc));
         if !has_value {
             self.missing_count += 1;
             if let Some(sub_agg) = self.sub_agg.as_mut() {

--- a/src/aggregation/bucket/term_missing_agg.rs
+++ b/src/aggregation/bucket/term_missing_agg.rs
@@ -92,7 +92,7 @@ impl SegmentAggregationCollector for TermMissingAgg {
         let agg = &mut agg_with_accessor.aggs.values[self.accessor_idx];
         let has_value = agg
             .accessors
-            .iter()
+            .values()
             .any(|(acc, _)| acc.index.has_value(doc));
         if !has_value {
             self.missing_count += 1;

--- a/src/aggregation/bucket/term_missing_agg.rs
+++ b/src/aggregation/bucket/term_missing_agg.rs
@@ -92,7 +92,7 @@ impl SegmentAggregationCollector for TermMissingAgg {
         let agg = &mut agg_with_accessor.aggs.values[self.accessor_idx];
         let has_value = agg
             .accessors
-            .values()
+            .iter()
             .any(|(acc, _)| acc.index.has_value(doc));
         if !has_value {
             self.missing_count += 1;

--- a/src/aggregation/collector.rs
+++ b/src/aggregation/collector.rs
@@ -145,11 +145,11 @@ impl AggregationSegmentCollector {
     pub fn from_agg_req_and_reader(
         agg: &Aggregations,
         reader: &SegmentReader,
-        segment_local_id: SegmentOrdinal,
+        segment_ordinal: SegmentOrdinal,
         limits: &AggregationLimits,
     ) -> crate::Result<Self> {
         let mut aggs_with_accessor =
-            get_aggs_with_segment_accessor_and_validate(agg, reader, segment_local_id, limits)?;
+            get_aggs_with_segment_accessor_and_validate(agg, reader, segment_ordinal, limits)?;
         let result =
             BufAggregationCollector::new(build_segment_agg_collector(&mut aggs_with_accessor)?);
         Ok(AggregationSegmentCollector {

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -92,6 +92,11 @@ pub struct TopHitsVecEntry {
     pub id: DocAddress,
     /// The sort values of the document, depending on the sort criteria in the request.
     pub sort: Vec<Option<u64>>,
+
+    /// Search results, for queries that include field retrieval requests
+    /// (`docvalue_fields`).
+    #[serde(flatten)]
+    pub search_results: SearchFieldResults,
 }
 
 /// The top_hits metric aggregation results a list of top hits by sort criteria.

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -96,7 +96,7 @@ pub struct TopHitsVecEntry {
     /// Search results, for queries that include field retrieval requests
     /// (`docvalue_fields`).
     #[serde(flatten)]
-    pub search_results: SearchFieldResults,
+    pub search_results: FieldRetrivalResult,
 }
 
 /// The top_hits metric aggregation results a list of top hits by sort criteria.

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -23,6 +23,7 @@ mod min;
 mod percentiles;
 mod stats;
 mod sum;
+mod top_hits;
 pub use average::*;
 pub use count::*;
 pub use max::*;
@@ -32,6 +33,9 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 pub use stats::*;
 pub use sum::*;
+pub use top_hits::*;
+
+use crate::DocAddress;
 
 /// Single-metric aggregations use this common result structure.
 ///
@@ -79,6 +83,24 @@ pub struct PercentileValuesVecEntry {
 pub struct PercentilesMetricResult {
     /// The result of the percentile metric.
     pub values: PercentileValues,
+}
+
+/// The top_hits metric results entry
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TopHitsVecEntry {
+    /// The document id, composed of segment local `DocId` and segment ordinal.
+    pub id: DocAddress,
+    /// The sort values of the document, depending on the sort criteria in the request.
+    pub sort: Vec<u64>,
+}
+
+/// The top_hits metric aggregation results a list of top hits by sort criteria.
+///
+/// The main reason for wrapping it in `hits` is to match elasticsearch output structure.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TopHitsMetricResult {
+    /// The result of the top_hits metric.
+    pub hits: Vec<TopHitsVecEntry>,
 }
 
 #[cfg(test)]

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -91,7 +91,7 @@ pub struct TopHitsVecEntry {
     /// The document id, composed of segment local `DocId` and segment ordinal.
     pub id: DocAddress,
     /// The sort values of the document, depending on the sort criteria in the request.
-    pub sort: Vec<u64>,
+    pub sort: Vec<Option<u64>>,
 }
 
 /// The top_hits metric aggregation results a list of top hits by sort criteria.

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -35,8 +35,6 @@ pub use stats::*;
 pub use sum::*;
 pub use top_hits::*;
 
-use crate::DocAddress;
-
 /// Single-metric aggregations use this common result structure.
 ///
 /// Main reason to wrap it in value is to match elasticsearch output structure.
@@ -88,8 +86,6 @@ pub struct PercentilesMetricResult {
 /// The top_hits metric results entry
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TopHitsVecEntry {
-    /// The document id, composed of segment local `DocId` and segment ordinal.
-    pub id: DocAddress,
     /// The sort values of the document, depending on the sort criteria in the request.
     pub sort: Vec<Option<u64>>,
 

--- a/src/aggregation/metric/percentiles.rs
+++ b/src/aggregation/metric/percentiles.rs
@@ -133,7 +133,6 @@ pub(crate) struct SegmentPercentilesCollector {
     field_type: ColumnType,
     pub(crate) percentiles: PercentilesCollector,
     pub(crate) accessor_idx: usize,
-    val_cache: Vec<u64>,
     missing: Option<u64>,
 }
 
@@ -243,7 +242,6 @@ impl SegmentPercentilesCollector {
             field_type,
             percentiles: PercentilesCollector::new(),
             accessor_idx,
-            val_cache: Default::default(),
             missing,
         })
     }

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -88,7 +88,9 @@ impl<'de> Deserialize<'de> for KeyOrder {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: Deserializer<'de> {
         let k_o: HashMap<String, Order> = Deserialize::deserialize(deserializer)?;
-        let (k, v) = k_o.into_iter().next().unwrap();
+        let (k, v) = k_o.into_iter().next().ok_or(serde::de::Error::custom(
+            "Expected exactly one key-value pair in KeyOrder",
+        ))?;
         Ok(Self(k, v))
     }
 }

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -96,15 +96,8 @@ impl<'de> Deserialize<'de> for KeyOrder {
 }
 
 impl TopHitsAggregation {
-    /// Supposed to return the field name the aggregation is performed on.
-    /// This is not implemented yet, because it doesn't make sense for multi-field top hits.
-    /// FIXME: Would it make sense to return a `{fields.join(';')}` or something?
-    pub fn field_name(&self) -> &str {
-        todo!();
-    }
-
     /// Return fields accessed by the aggregator, in order.
-    pub fn get_fields(&self) -> Vec<&str> {
+    pub fn field_names(&self) -> Vec<&str> {
         self.sort
             .iter()
             .map(|KeyOrder(field, _)| field.as_str())

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -30,6 +30,13 @@ use crate::{DocAddress, DocId, SegmentOrdinal};
 /// used as a sub-aggregation, inside a `terms` aggregation or a `filters` aggregation,
 /// for example.
 ///
+/// Note that this aggregator does not return the actual document addresses, but
+/// rather a list of the values of the fields that were requested to be retrieved.
+/// These values can be specified in the `docvalue_fields` parameter, which can include
+/// a list of fast fields to be retrieved. At the moment, only fast fields are supported
+/// but it is possible that we support the `fields` parameter to retrieve any stored
+/// field in the future.
+///
 /// The following example demonstrates a request for the top_hits aggregation:
 /// ```JSON
 /// {
@@ -47,6 +54,7 @@ use crate::{DocAddress, DocId, SegmentOrdinal};
 ///                 "sort": [
 ///                     { "date": "desc" }
 ///                 ]
+///                 "docvalue_fields": ["date", "title", "iden"]
 ///             }
 ///         }
 /// }
@@ -59,12 +67,20 @@ use crate::{DocAddress, DocId, SegmentOrdinal};
 /// {
 ///     "hits": [
 ///         {
-///           "id": <doc_address>,
-///           score: [<time_u64>]
+///           "score": [<time_u64>],
+///           "docvalue_fields": {
+///             "date": "<date_RFC3339>",
+///             "title": "<title>",
+///             "iden": "<iden>"
+///           }
 ///         },
 ///         {
-///             "id": <doc_address>,
-///             score: [<time_u64>]
+///           "score": [<time_u64>]
+///           "docvalue_fields": {
+///             "date": "<date_RFC3339>",
+///             "title": "<title>",
+///             "iden": "<iden>"
+///           }
 ///         }
 ///     ]
 /// }

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -1,0 +1,320 @@
+extern crate tuple_vec_map;
+
+use std::collections::BinaryHeap;
+use std::fmt::Formatter;
+
+use serde::{Deserialize, Serialize};
+
+use super::{TopHitsMetricResult, TopHitsVecEntry};
+use crate::aggregation::bucket::Order;
+use crate::aggregation::intermediate_agg_result::{
+    IntermediateAggregationResult, IntermediateMetricResult,
+};
+use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
+use crate::{DocAddress, SegmentOrdinal};
+
+/// # Top Hits
+///
+/// The top hits aggregation is a useful tool to answer questions like:
+/// - "What are the most recent posts by each author?"
+/// - "What are the most popular items in each category?"
+///
+/// It does so by keeping track of the most relevant document being aggregated,
+/// in terms of a sort criterion that can consist of multiple fields and their
+/// sort-orders (ascending or descending).
+///
+/// `top_hits` should not be used as a top-level aggregation. It is intended to be
+/// used as a sub-aggregation, inside a `terms` aggregation or a `filters` aggregation,
+/// for example.
+///
+/// The following example demonstrates a request for the top_hits aggregation:
+/// ```json
+/// {
+///     "aggs": {
+///         "top_authors": {
+///             "terms": {
+///                 "field": "author",
+///                 "size": 5
+///             }
+///         },
+///         "aggs": {
+///             "top_hits": {
+///                 "size": 2,
+///                 "from": 0
+///                 "sort": [
+///                     { "date": "desc" }
+///                 ]
+///             }
+///         }
+/// }
+/// ```
+///
+/// This request will return an object containing the top two documents, sorted
+/// by the `date` field in descending order. You can also sort by multiple fields, which
+/// helps to resolve ties:
+/// ```json
+/// {
+///     "hits": [
+///         {
+///             "id":
+///         }
+///     ]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct TopHitsAggregation {
+    #[serde(with = "tuple_vec_map")]
+    sort: Vec<(String, Order)>,
+    size: usize,
+    from: Option<usize>,
+}
+
+impl TopHitsAggregation {
+    /// Supposed to return the field name the aggregation is performed on.
+    /// This is not implemented yet, because it doesn't make sense for multi-field top hits.
+    /// FIXME: Would it make sense to return a `{fields.join(';')}` or something?
+    pub fn field_name(&self) -> &str {
+        todo!();
+    }
+
+    // pub fn get_fields(&self) -> Vec<&str> {
+    //     self.sort.iter().map(|(field, _)| field.as_str()).collect()
+    // }
+}
+
+/// Holds a single comparable doc feature, and the order in which it should be sorted.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+struct ComparableDocFeature {
+    /// Stores any u64-mappable feature.
+    value: u64,
+    order: Order,
+}
+
+impl Ord for ComparableDocFeature {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.order {
+            Order::Asc => self.value.cmp(&other.value),
+            Order::Desc => other.value.cmp(&self.value),
+        }
+    }
+}
+
+impl PartialOrd for ComparableDocFeature {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for ComparableDocFeature {
+    fn eq(&self, other: &Self) -> bool {
+        self.value.cmp(&other.value) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for ComparableDocFeature {}
+
+/// Multi-feature comparable docs that can be used in a binary heap.
+/// Includes a custom `Ord` implementation that:
+/// - Allows to sort documents by multiple features
+/// - Inverts sorting order to make `BinaryHeap`, a max-heap, behave like a min-heap that lets us
+///   access its lowest-scoring member.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+struct ComparableDocMultipleFeatures {
+    doc: DocAddress,
+    features: Vec<ComparableDocFeature>,
+}
+
+impl Ord for ComparableDocMultipleFeatures {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        for (self_feature, other_feature) in self.features.iter().zip(other.features.iter()) {
+            let cmp = self_feature.cmp(other_feature);
+            if cmp != std::cmp::Ordering::Equal {
+                return cmp.reverse();
+            }
+        }
+        self.doc.cmp(&other.doc).reverse()
+    }
+}
+
+impl PartialOrd for ComparableDocMultipleFeatures {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for ComparableDocMultipleFeatures {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for ComparableDocMultipleFeatures {}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct TopHitsCollector {
+    req: TopHitsAggregation,
+    heap: BinaryHeap<ComparableDocMultipleFeatures>,
+}
+
+impl std::fmt::Debug for TopHitsCollector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TopHitsCollector")
+            .field("req", &self.req)
+            .field("heap_len", &self.heap.len())
+            .finish()
+    }
+}
+
+impl std::cmp::PartialEq for TopHitsCollector {
+    fn eq(&self, _other: &Self) -> bool {
+        false
+    }
+}
+
+impl TopHitsCollector {
+    fn collect(&mut self, comparable_doc: ComparableDocMultipleFeatures) -> crate::Result<()> {
+        if self.heap.len() < self.req.size + self.req.from.unwrap_or(0) {
+            self.heap.push(comparable_doc);
+            Ok(())
+        } else {
+            let mut min_doc = self
+                .heap
+                .peek_mut()
+                .expect("heap should have at least one element at max capacity");
+            if comparable_doc < *min_doc {
+                *min_doc = comparable_doc;
+            }
+            Ok(())
+        }
+    }
+
+    pub fn merge_fruits(&mut self, other_fruit: Self) -> crate::Result<()> {
+        for doc in other_fruit.heap.into_vec() {
+            self.collect(doc)?;
+        }
+        Ok(())
+    }
+
+    pub fn finalize(self) -> TopHitsMetricResult {
+        let mut hits: Vec<TopHitsVecEntry> = self
+            .heap
+            // TODO: use `into_sorted_vec` once it's stable
+            // Using an in-order iterator would avoid allocating a new vector.
+            // Ref: https://github.com/rust-lang/rust/issues/59278
+            .into_sorted_vec()
+            .into_iter()
+            .map(|doc| TopHitsVecEntry {
+                id: doc.doc,
+                sort: doc.features.iter().map(|f| f.value).collect(),
+            })
+            .collect();
+
+        // Remove the first `from` elements
+        // Truncating from end would be more efficient, but we need to truncate from the front
+        // because `into_sorted_vec` gives us a descending order because of the inverted
+        // `Ord` semantics of the heap elements.
+        hits.drain(..self.req.from.unwrap_or(0));
+        TopHitsMetricResult { hits }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SegmentTopHitsCollector {
+    segment_id: SegmentOrdinal,
+    accessor_idx: usize,
+    inner_collector: TopHitsCollector,
+}
+
+impl SegmentTopHitsCollector {
+    // // TODO: confirm if this is required (idts)
+    // pub fn new(
+    //     segment_id: SegmentOrdinal,
+    //     accessor_idx: usize,
+    //     req: TopHitsAggregation,
+    // ) -> SegmentTopHitsCollector { SegmentTopHitsCollector { segment_id, accessor_idx,
+    //   inner_collector: TopHitsCollector { req, heap: BinaryHeap::new(), }, }
+    // }
+
+    pub fn from_req(
+        req: &TopHitsAggregation,
+        accessor_idx: usize,
+        segment_id: SegmentOrdinal,
+    ) -> Self {
+        Self {
+            inner_collector: TopHitsCollector {
+                req: req.clone(),
+                heap: BinaryHeap::with_capacity(req.size + req.from.unwrap_or(0)),
+            },
+            segment_id,
+            accessor_idx,
+        }
+    }
+}
+
+impl std::fmt::Debug for SegmentTopHitsCollector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SegmentTopHitsCollector")
+            .field("segment_id", &self.segment_id)
+            .field("accessor_idx", &self.accessor_idx)
+            .field("inner_collector", &self.inner_collector)
+            .finish()
+    }
+}
+
+impl SegmentAggregationCollector for SegmentTopHitsCollector {
+    fn add_intermediate_aggregation_result(
+        self: Box<Self>,
+        agg_with_accessor: &crate::aggregation::agg_req_with_accessor::AggregationsWithAccessor,
+        results: &mut crate::aggregation::intermediate_agg_result::IntermediateAggregationResults,
+    ) -> crate::Result<()> {
+        let name = agg_with_accessor.aggs.keys[self.accessor_idx].to_string();
+        let intermediate_result = IntermediateMetricResult::TopHits(self.inner_collector);
+        results.push(
+            name,
+            IntermediateAggregationResult::Metric(intermediate_result),
+        );
+        Ok(())
+    }
+
+    fn collect(
+        &mut self,
+        doc_id: crate::DocId,
+        agg_with_accessor: &mut crate::aggregation::agg_req_with_accessor::AggregationsWithAccessor,
+    ) -> crate::Result<()> {
+        let features: Vec<ComparableDocFeature> = agg_with_accessor.aggs.values[self.accessor_idx]
+            .accessors
+            .iter()
+            .zip(self.inner_collector.req.sort.iter())
+            .map(|((c, _), (_, order))| {
+                let order = *order;
+                match c.values_for_doc(doc_id).next() {
+                    Some(value) => ComparableDocFeature { value, order },
+                    // TODO: confirm if this default 0-value is correct
+                    None => ComparableDocFeature { value: 0, order },
+                }
+            })
+            .collect();
+        self.inner_collector.collect(ComparableDocMultipleFeatures {
+            doc: DocAddress {
+                doc_id,
+                segment_ord: self.segment_id,
+            },
+            features,
+        });
+        Ok(())
+    }
+
+    fn collect_block(
+        &mut self,
+        docs: &[crate::DocId],
+        agg_with_accessor: &mut crate::aggregation::agg_req_with_accessor::AggregationsWithAccessor,
+    ) -> crate::Result<()> {
+        // TODO: Consider getting fields with the column block accessor and refactor this.
+        // ---
+        // Would the additional complexity of getting fields with the column_block_accessor
+        // make sense here? Probably yes, but I want to get a first-pass review first
+        // before proceeding.
+        for doc in docs {
+            self.collect(*doc, agg_with_accessor)?;
+        }
+        Ok(())
+    }
+}

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -438,7 +438,7 @@ impl TopHitsCollector {
 
 #[derive(Clone)]
 pub(crate) struct SegmentTopHitsCollector {
-    segment_id: SegmentOrdinal,
+    segment_ordinal: SegmentOrdinal,
     accessor_idx: usize,
     inner_collector: TopHitsCollector,
 }
@@ -447,14 +447,14 @@ impl SegmentTopHitsCollector {
     pub fn from_req(
         req: &TopHitsAggregation,
         accessor_idx: usize,
-        segment_id: SegmentOrdinal,
+        segment_ordinal: SegmentOrdinal,
     ) -> Self {
         Self {
             inner_collector: TopHitsCollector {
                 req: req.clone(),
                 top_n: TopNComputer::new(req.size + req.from.unwrap_or(0)),
             },
-            segment_id,
+            segment_ordinal,
             accessor_idx,
         }
     }
@@ -463,7 +463,7 @@ impl SegmentTopHitsCollector {
 impl std::fmt::Debug for SegmentTopHitsCollector {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SegmentTopHitsCollector")
-            .field("segment_id", &self.segment_id)
+            .field("segment_id", &self.segment_ordinal)
             .field("accessor_idx", &self.accessor_idx)
             .field("inner_collector", &self.inner_collector)
             .finish()
@@ -518,7 +518,7 @@ impl SegmentAggregationCollector for SegmentTopHitsCollector {
         self.inner_collector.collect(
             ComparableDocFeatures(features, retrieval_result),
             DocAddress {
-                segment_ord: self.segment_id,
+                segment_ord: self.segment_ordinal,
                 doc_id,
             },
         );

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -110,7 +110,6 @@ pub struct FieldRetrivalResult {
 
 impl RetrievalFields {
     fn get_field_names(&self) -> Vec<&str> {
-        // TOOD: support wildcard, we'll need a step to do this translation/matching
         self.doc_value_fields.iter().map(|s| s.as_str()).collect()
     }
 
@@ -752,7 +751,8 @@ mod tests {
                     ],
                     "from": 1,
                     "docvalue_fields": [
-                        "date"
+                        "date",
+                        "tex*",
                     ],
                 }
         }
@@ -783,10 +783,20 @@ mod tests {
                             date_2017.unix_timestamp_nanos() as i64
                         ))],
                         search_results: FieldRetrivalResult {
-                            doc_value_fields: vec![(
-                                "date".to_string(),
-                                Some(SchemaValue::Date(DateTime::from_utc(date_2017)))
-                            )]
+                            doc_value_fields: vec![
+                                (
+                                    "date".to_string(),
+                                    Some(SchemaValue::Date(DateTime::from_utc(date_2017)))
+                                ),
+                                (
+                                    "text".to_string(),
+                                    Some(SchemaValue::Str("ccc".to_string()))
+                                ),
+                                (
+                                    "text2".to_string(),
+                                    Some(SchemaValue::Str("ddd".to_string()))
+                                )
+                            ]
                             .into_iter()
                             .collect()
                         }
@@ -800,10 +810,20 @@ mod tests {
                             date_2016.unix_timestamp_nanos() as i64
                         ))],
                         search_results: FieldRetrivalResult {
-                            doc_value_fields: vec![(
-                                "date".to_string(),
-                                Some(SchemaValue::Date(DateTime::from_utc(date_2016)))
-                            )]
+                            doc_value_fields: vec![
+                                (
+                                    "date".to_string(),
+                                    Some(SchemaValue::Date(DateTime::from_utc(date_2016)))
+                                ),
+                                (
+                                    "text".to_string(),
+                                    Some(SchemaValue::Str("aaa".to_string()))
+                                ),
+                                (
+                                    "text2".to_string(),
+                                    Some(SchemaValue::Str("bbb".to_string()))
+                                )
+                            ]
                             .into_iter()
                             .collect()
                         }

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -193,20 +193,26 @@ impl RetrievalFields {
                         .term_ords(doc_id)
                         .map(|term_ord| {
                             let mut buffer = vec![];
-                            match accessor.ord_to_bytes(term_ord, &mut buffer).unwrap() {
-                                false => OwnedValue::Null,
-                                true => OwnedValue::Bytes(buffer),
-                            }
+                            assert!(
+                                accessor
+                                    .ord_to_bytes(term_ord, &mut buffer)
+                                    .expect("could not read term dictionary"),
+                                "term corresponding to term_ord does not exist"
+                            );
+                            OwnedValue::Bytes(buffer)
                         })
                         .collect::<Vec<_>>(),
                     DynamicColumn::Str(accessor) => accessor
                         .term_ords(doc_id)
                         .map(|term_ord| {
                             let mut buffer = vec![];
-                            match accessor.ord_to_bytes(term_ord, &mut buffer).unwrap() {
-                                false => OwnedValue::Null,
-                                true => OwnedValue::Str(String::from_utf8(buffer).expect("")),
-                            }
+                            assert!(
+                                accessor
+                                    .ord_to_bytes(term_ord, &mut buffer)
+                                    .expect("could not read term dictionary"),
+                                "term corresponding to term_ord does not exist"
+                            );
+                            OwnedValue::Str(String::from_utf8(buffer).unwrap())
                         })
                         .collect::<Vec<_>>(),
                     DynamicColumn::Bool(accessor) => accessor

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -165,69 +165,74 @@ impl RetrievalFields {
 
     fn get_document_field_data(
         &self,
-        accessors: &HashMap<String, DynamicColumn>,
+        accessors: &HashMap<String, Vec<DynamicColumn>>,
         doc_id: DocId,
     ) -> FieldRetrivalResult {
         let dvf = self
             .doc_value_fields
             .iter()
             .map(|field| {
-                let accessor = accessors
+                let accessors = accessors
                     .get(field)
                     .expect("could not find field in accessors");
 
-                let values: Vec<OwnedValue> = match accessor {
-                    DynamicColumn::U64(accessor) => accessor
-                        .values_for_doc(doc_id)
-                        .map(OwnedValue::U64)
-                        .collect::<Vec<_>>(),
-                    DynamicColumn::I64(accessor) => accessor
-                        .values_for_doc(doc_id)
-                        .map(OwnedValue::I64)
-                        .collect::<Vec<_>>(),
-                    DynamicColumn::F64(accessor) => accessor
-                        .values_for_doc(doc_id)
-                        .map(OwnedValue::F64)
-                        .collect::<Vec<_>>(),
-                    DynamicColumn::Bytes(accessor) => accessor
-                        .term_ords(doc_id)
-                        .map(|term_ord| {
-                            let mut buffer = vec![];
-                            assert!(
-                                accessor
-                                    .ord_to_bytes(term_ord, &mut buffer)
-                                    .expect("could not read term dictionary"),
-                                "term corresponding to term_ord does not exist"
-                            );
-                            OwnedValue::Bytes(buffer)
-                        })
-                        .collect::<Vec<_>>(),
-                    DynamicColumn::Str(accessor) => accessor
-                        .term_ords(doc_id)
-                        .map(|term_ord| {
-                            let mut buffer = vec![];
-                            assert!(
-                                accessor
-                                    .ord_to_bytes(term_ord, &mut buffer)
-                                    .expect("could not read term dictionary"),
-                                "term corresponding to term_ord does not exist"
-                            );
-                            OwnedValue::Str(String::from_utf8(buffer).unwrap())
-                        })
-                        .collect::<Vec<_>>(),
-                    DynamicColumn::Bool(accessor) => accessor
-                        .values_for_doc(doc_id)
-                        .map(OwnedValue::Bool)
-                        .collect::<Vec<_>>(),
-                    DynamicColumn::IpAddr(accessor) => accessor
-                        .values_for_doc(doc_id)
-                        .map(OwnedValue::IpAddr)
-                        .collect::<Vec<_>>(),
-                    DynamicColumn::DateTime(accessor) => accessor
-                        .values_for_doc(doc_id)
-                        .map(OwnedValue::Date)
-                        .collect::<Vec<_>>(),
-                };
+                let values: Vec<OwnedValue> = accessors
+                    .iter()
+                    .map(|accessor| match accessor {
+                        DynamicColumn::U64(accessor) => accessor
+                            .values_for_doc(doc_id)
+                            .map(OwnedValue::U64)
+                            .collect::<Vec<_>>(),
+                        DynamicColumn::I64(accessor) => accessor
+                            .values_for_doc(doc_id)
+                            .map(OwnedValue::I64)
+                            .collect::<Vec<_>>(),
+                        DynamicColumn::F64(accessor) => accessor
+                            .values_for_doc(doc_id)
+                            .map(OwnedValue::F64)
+                            .collect::<Vec<_>>(),
+                        DynamicColumn::Bytes(accessor) => accessor
+                            .term_ords(doc_id)
+                            .map(|term_ord| {
+                                let mut buffer = vec![];
+                                assert!(
+                                    accessor
+                                        .ord_to_bytes(term_ord, &mut buffer)
+                                        .expect("could not read term dictionary"),
+                                    "term corresponding to term_ord does not exist"
+                                );
+                                OwnedValue::Bytes(buffer)
+                            })
+                            .collect::<Vec<_>>(),
+                        DynamicColumn::Str(accessor) => accessor
+                            .term_ords(doc_id)
+                            .map(|term_ord| {
+                                let mut buffer = vec![];
+                                assert!(
+                                    accessor
+                                        .ord_to_bytes(term_ord, &mut buffer)
+                                        .expect("could not read term dictionary"),
+                                    "term corresponding to term_ord does not exist"
+                                );
+                                OwnedValue::Str(String::from_utf8(buffer).unwrap())
+                            })
+                            .collect::<Vec<_>>(),
+                        DynamicColumn::Bool(accessor) => accessor
+                            .values_for_doc(doc_id)
+                            .map(OwnedValue::Bool)
+                            .collect::<Vec<_>>(),
+                        DynamicColumn::IpAddr(accessor) => accessor
+                            .values_for_doc(doc_id)
+                            .map(OwnedValue::IpAddr)
+                            .collect::<Vec<_>>(),
+                        DynamicColumn::DateTime(accessor) => accessor
+                            .values_for_doc(doc_id)
+                            .map(OwnedValue::Date)
+                            .collect::<Vec<_>>(),
+                    })
+                    .flatten()
+                    .collect();
+
                 (field.to_owned(), OwnedValue::Array(values))
             })
             .collect();

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -782,17 +782,17 @@ mod tests {
                     {
                         "sort": [common::i64_to_u64(date_2017.unix_timestamp_nanos() as i64)],
                         "docvalue_fields": {
-                            "date": SchemaValue::Date(DateTime::from_utc(date_2017)),
-                            "text": "ccc",
-                            "text2": "ddd",
+                            "date": [ SchemaValue::Date(DateTime::from_utc(date_2017)) ],
+                            "text": [ "ccc" ],
+                            "text2": [ "ddd" ],
                         }
                     },
                     {
                         "sort": [common::i64_to_u64(date_2016.unix_timestamp_nanos() as i64)],
                         "docvalue_fields": {
-                            "date": SchemaValue::Date(DateTime::from_utc(date_2016)),
-                            "text": "aaa",
-                            "text2": "bbb",
+                            "date": [ SchemaValue::Date(DateTime::from_utc(date_2016)) ],
+                            "text": [ "aaa" ],
+                            "text2": [ "bbb" ],
                         }
                     }
                 ]

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -27,7 +27,7 @@
 //! Notice: Intermediate aggregation results should not be de/serialized via JSON format.
 //! Postcard is a good choice.
 //!
-//! ```
+//! ```verbatim
 //! let agg_req: Aggregations = serde_json::from_str(json_request_string).unwrap();
 //! let collector = AggregationCollector::from_aggs(agg_req, None);
 //! let searcher = reader.searcher();

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -27,7 +27,7 @@
 //! Notice: Intermediate aggregation results should not be de/serialized via JSON format.
 //! Postcard is a good choice.
 //!
-//! ```verbatim
+//! ```
 //! let agg_req: Aggregations = serde_json::from_str(json_request_string).unwrap();
 //! let collector = AggregationCollector::from_aggs(agg_req, None);
 //! let searcher = reader.searcher();

--- a/src/aggregation/segment_agg_result.rs
+++ b/src/aggregation/segment_agg_result.rs
@@ -16,6 +16,7 @@ use super::metric::{
     SumAggregation,
 };
 use crate::aggregation::bucket::TermMissingAgg;
+use crate::aggregation::metric::SegmentTopHitsCollector;
 
 pub(crate) trait SegmentAggregationCollector: CollectorClone + Debug {
     fn add_intermediate_aggregation_result(
@@ -160,6 +161,11 @@ pub(crate) fn build_single_agg_segment_collector(
                 accessor_idx,
             )?,
         )),
+        TopHits(top_hits_req) => Ok(Box::new(SegmentTopHitsCollector::from_req(
+            top_hits_req,
+            accessor_idx,
+            req.segment_id,
+        ))),
     }
 }
 

--- a/src/aggregation/segment_agg_result.rs
+++ b/src/aggregation/segment_agg_result.rs
@@ -164,7 +164,7 @@ pub(crate) fn build_single_agg_segment_collector(
         TopHits(top_hits_req) => Ok(Box::new(SegmentTopHitsCollector::from_req(
             top_hits_req,
             accessor_idx,
-            req.segment_id,
+            req.segment_ordinal,
         ))),
     }
 }

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -97,6 +97,7 @@ pub use self::multi_collector::{FruitHandle, MultiCollector, MultiFruit};
 mod top_collector;
 
 mod top_score_collector;
+pub use self::top_collector::ComparableDoc;
 pub use self::top_score_collector::{TopDocs, TopNComputer};
 
 mod custom_score_top_collector;

--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -1,23 +1,28 @@
 use std::cmp::Ordering;
 use std::marker::PhantomData;
 
+use serde::{Deserialize, Serialize};
+
 use super::top_score_collector::TopNComputer;
 use crate::{DocAddress, DocId, SegmentOrdinal, SegmentReader};
 
 /// Contains a feature (field, score, etc.) of a document along with the document address.
 ///
-/// It has a custom implementation of `PartialOrd` that reverses the order. This is because the
-/// default Rust heap is a max heap, whereas a min heap is needed.
-///
-/// Additionally, it guarantees stable sorting: in case of a tie on the feature, the document
+/// It guarantees stable sorting: in case of a tie on the feature, the document
 /// address is used.
 ///
 /// WARNING: equality is not what you would expect here.
 /// Two elements are equal if their feature is equal, and regardless of whether `doc`
 /// is equal. This should be perfectly fine for this usage, but let's make sure this
 /// struct is never public.
-pub(crate) struct ComparableDoc<T, D> {
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct ComparableDoc<T, D> {
+    /// The feature of the document. In practice, this is
+    /// is any type that implements `PartialOrd`.
     pub feature: T,
+    /// The document address. In practice, this is any
+    /// type that implements `PartialOrd`, and is guaranteed
+    /// to be unique for each document.
     pub doc: D,
 }
 impl<T: std::fmt::Debug, D: std::fmt::Debug> std::fmt::Debug for ComparableDoc<T, D> {

--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -11,12 +11,16 @@ use crate::{DocAddress, DocId, SegmentOrdinal, SegmentReader};
 /// It guarantees stable sorting: in case of a tie on the feature, the document
 /// address is used.
 ///
+/// The REVERSE_ORDER generic parameter controls whether the by-feature order
+/// should be reversed, which is useful for achieving for example largest-first
+/// semantics without having to wrap the feature in a `Reverse`.
+///
 /// WARNING: equality is not what you would expect here.
 /// Two elements are equal if their feature is equal, and regardless of whether `doc`
 /// is equal. This should be perfectly fine for this usage, but let's make sure this
 /// struct is never public.
 #[derive(Clone, Default, Serialize, Deserialize)]
-pub struct ComparableDoc<T, D> {
+pub struct ComparableDoc<T, D, const REVERSE_ORDER: bool = false> {
     /// The feature of the document. In practice, this is
     /// is any type that implements `PartialOrd`.
     pub feature: T,
@@ -25,28 +29,30 @@ pub struct ComparableDoc<T, D> {
     /// to be unique for each document.
     pub doc: D,
 }
-impl<T: std::fmt::Debug, D: std::fmt::Debug> std::fmt::Debug for ComparableDoc<T, D> {
+impl<T: std::fmt::Debug, D: std::fmt::Debug, const R: bool> std::fmt::Debug
+    for ComparableDoc<T, D, R>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ComparableDoc")
+        f.debug_struct(format!("ComparableDoc<_, _ {R}").as_str())
             .field("feature", &self.feature)
             .field("doc", &self.doc)
             .finish()
     }
 }
 
-impl<T: PartialOrd, D: PartialOrd> PartialOrd for ComparableDoc<T, D> {
+impl<T: PartialOrd, D: PartialOrd, const R: bool> PartialOrd for ComparableDoc<T, D, R> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<T: PartialOrd, D: PartialOrd> Ord for ComparableDoc<T, D> {
+impl<T: PartialOrd, D: PartialOrd, const R: bool> Ord for ComparableDoc<T, D, R> {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
-        // Reversed to make BinaryHeap work as a min-heap
-        let by_feature = other
+        let by_feature = self
             .feature
-            .partial_cmp(&self.feature)
+            .partial_cmp(&other.feature)
+            .map(|ord| if R { ord.reverse() } else { ord })
             .unwrap_or(Ordering::Equal);
 
         let lazy_by_doc_address = || self.doc.partial_cmp(&other.doc).unwrap_or(Ordering::Equal);
@@ -58,13 +64,13 @@ impl<T: PartialOrd, D: PartialOrd> Ord for ComparableDoc<T, D> {
     }
 }
 
-impl<T: PartialOrd, D: PartialOrd> PartialEq for ComparableDoc<T, D> {
+impl<T: PartialOrd, D: PartialOrd, const R: bool> PartialEq for ComparableDoc<T, D, R> {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal
     }
 }
 
-impl<T: PartialOrd, D: PartialOrd> Eq for ComparableDoc<T, D> {}
+impl<T: PartialOrd, D: PartialOrd, const R: bool> Eq for ComparableDoc<T, D, R> {}
 
 pub(crate) struct TopCollector<T> {
     pub limit: usize,
@@ -104,10 +110,10 @@ where T: PartialOrd + Clone
         if self.limit == 0 {
             return Ok(Vec::new());
         }
-        let mut top_collector = TopNComputer::new(self.limit + self.offset);
+        let mut top_collector: TopNComputer<_, _> = TopNComputer::new(self.limit + self.offset);
         for child_fruit in children {
             for (feature, doc) in child_fruit {
-                top_collector.push(ComparableDoc { feature, doc });
+                top_collector.push(feature, doc);
             }
         }
 
@@ -148,6 +154,8 @@ where T: PartialOrd + Clone
 /// The theoretical complexity for collecting the top `K` out of `n` documents
 /// is `O(n + K)`.
 pub(crate) struct TopSegmentCollector<T> {
+    /// We reverse the order of the feature in order to
+    /// have top-semantics instead of bottom semantics.
     topn_computer: TopNComputer<T, DocId>,
     segment_ord: u32,
 }
@@ -185,7 +193,7 @@ impl<T: PartialOrd + Clone> TopSegmentCollector<T> {
     /// will compare the lowest scoring item with the given one and keep whichever is greater.
     #[inline]
     pub fn collect(&mut self, doc: DocId, feature: T) {
-        self.topn_computer.push(ComparableDoc { feature, doc });
+        self.topn_computer.push(feature, doc);
     }
 }
 

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -718,7 +718,7 @@ impl SegmentCollector for TopScoreSegmentCollector {
         self.0.collect(doc, score);
     }
 
-    fn harvest(self) -> Vec<(Score, DocAddress)> {
+    fn harvest(self) -> Self::Fruit {
         self.0.harvest()
     }
 }

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -718,7 +718,7 @@ impl SegmentCollector for TopScoreSegmentCollector {
         self.0.collect(doc, score);
     }
 
-    fn harvest(self) -> Self::Fruit {
+    fn harvest(self) -> Vec<(Score, DocAddress)> {
         self.0.harvest()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ impl DocAddress {
 ///
 /// The id used for the segment is actually an ordinal
 /// in the list of `Segment`s held by a `Searcher`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct DocAddress {
     /// The segment ordinal id that identifies the segment
     /// hosting the document in the `Searcher` it is called from.


### PR DESCRIPTION
## Summary

Implements the [`top_hits`][elastic-search-top-hits] aggregator. The aggregator is backed by ~~a BinaryHeap based on prior discussions on [Discord#tantivy-dev][tantivy-dev-top-hits-discussion]~~ the new `TopNComputer`.

[elastic-search-top-hits]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html
[tantivy-dev-top-hits-discussion]: https://discord.com/channels/908281611840282624/915785344396439552/1154687081180823612