### PR TITLE
remove Document: DocumentDeserialize dependency

### DIFF
--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -5,7 +5,7 @@ use std::{fmt, io};
 use crate::collector::Collector;
 use crate::core::{Executor, SegmentReader};
 use crate::query::{Bm25StatisticsProvider, EnableScoring, Query};
-use crate::schema::document::Document;
+use crate::schema::document::{Document, DocumentDeserialize};
 use crate::schema::{Schema, Term};
 use crate::space_usage::SearcherSpaceUsage;
 use crate::store::{CacheStats, StoreReader};
@@ -84,7 +84,10 @@ impl Searcher {
     ///
     /// The searcher uses the segment ordinal to route the
     /// request to the right `Segment`.
-    pub fn doc<D: Document>(&self, doc_address: DocAddress) -> crate::Result<D> {
+    pub fn doc<D: Document + DocumentDeserialize>(
+        &self,
+        doc_address: DocAddress,
+    ) -> crate::Result<D> {
         let store_reader = &self.inner.store_readers[doc_address.segment_ord as usize];
         store_reader.get(doc_address.doc_id)
     }
@@ -104,7 +107,10 @@ impl Searcher {
 
     /// Fetches a document in an asynchronous manner.
     #[cfg(feature = "quickwit")]
-    pub async fn doc_async<D: Document>(&self, doc_address: DocAddress) -> crate::Result<D> {
+    pub async fn doc_async<D: Document + DocumentDeserialize>(
+        &self,
+        doc_address: DocAddress,
+    ) -> crate::Result<D> {
         let store_reader = &self.inner.store_readers[doc_address.segment_ord as usize];
         store_reader.get_async(doc_address.doc_id).await
     }

--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -84,10 +84,7 @@ impl Searcher {
     ///
     /// The searcher uses the segment ordinal to route the
     /// request to the right `Segment`.
-    pub fn doc<D: Document + DocumentDeserialize>(
-        &self,
-        doc_address: DocAddress,
-    ) -> crate::Result<D> {
+    pub fn doc<D: DocumentDeserialize>(&self, doc_address: DocAddress) -> crate::Result<D> {
         let store_reader = &self.inner.store_readers[doc_address.segment_ord as usize];
         store_reader.get(doc_address.doc_id)
     }
@@ -107,7 +104,7 @@ impl Searcher {
 
     /// Fetches a document in an asynchronous manner.
     #[cfg(feature = "quickwit")]
-    pub async fn doc_async<D: Document + DocumentDeserialize>(
+    pub async fn doc_async<D: DocumentDeserialize>(
         &self,
         doc_address: DocAddress,
     ) -> crate::Result<D> {

--- a/src/schema/document/mod.rs
+++ b/src/schema/document/mod.rs
@@ -174,7 +174,7 @@ pub use self::value::{ReferenceValue, Value};
 use super::*;
 
 /// The core trait representing a document within the index.
-pub trait Document: DocumentDeserialize + Send + Sync + 'static {
+pub trait Document: Send + Sync + 'static {
     /// The value of the field.
     type Value<'a>: Value<'a> + Clone
     where Self: 'a;

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -198,7 +198,7 @@ impl StoreReader {
     ///
     /// It should not be called to score documents
     /// for instance.
-    pub fn get<D: Document + DocumentDeserialize>(&self, doc_id: DocId) -> crate::Result<D> {
+    pub fn get<D: DocumentDeserialize>(&self, doc_id: DocId) -> crate::Result<D> {
         let mut doc_bytes = self.get_document_bytes(doc_id)?;
 
         let deserializer = BinaryDocumentDeserializer::from_reader(&mut doc_bytes)
@@ -370,10 +370,7 @@ impl StoreReader {
     }
 
     /// Fetches a document asynchronously. Async version of [`get`](Self::get).
-    pub async fn get_async<D: Document + DocumentDeserialize>(
-        &self,
-        doc_id: DocId,
-    ) -> crate::Result<D> {
+    pub async fn get_async<D: DocumentDeserialize>(&self, doc_id: DocId) -> crate::Result<D> {
         let mut doc_bytes = self.get_document_bytes_async(doc_id).await?;
 
         let deserializer = BinaryDocumentDeserializer::from_reader(&mut doc_bytes)


### PR DESCRIPTION
The dependency requires users to implement an API they may not use.
