### PR TITLE
run coverage only after merge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,6 @@ name: Coverage
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 # Ensures that we cancel running jobs for the same PR / same workflow.
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,6 @@ jobs:
     - name: Check Stable Compilation
       run: cargo build --all-features
 
-    - name: Check Nightly Compilation
-      run: cargo +nightly build --all-features
     
     - name: Check Bench Compilation
       run: cargo +nightly bench --no-run --profile=dev --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,15 @@ jobs:
 
     - name: Check Formatting
       run: cargo +nightly fmt --all -- --check
+    
+    - name: Check Stable Compilation
+      run: cargo build --all-features
+
+    - name: Check Nightly Compilation
+      run: cargo +nightly build --all-features
+    
+    - name: Check Bench Compilation
+      run: cargo +nightly bench --no-run --profile=dev --all-features
 
     - uses: actions-rs/clippy-check@v1
       with:


### PR DESCRIPTION
coverage is a quite slow step in CI. It can be run only after merging

Add compile benchmarks to regular CI test