### PR TITLE
rename ReloadPolicy onCommit to onCommitWithDelay

### DIFF
--- a/examples/basic_search.rs
+++ b/examples/basic_search.rs
@@ -164,7 +164,7 @@ fn main() -> tantivy::Result<()> {
     // will reload the index automatically after each commit.
     let reader = index
         .reader_builder()
-        .reload_policy(ReloadPolicy::OnCommit)
+        .reload_policy(ReloadPolicy::OnCommitWithDelay)
         .try_into()?;
 
     // We now need to acquire a searcher.

--- a/examples/fuzzy_search.rs
+++ b/examples/fuzzy_search.rs
@@ -123,7 +123,7 @@ fn main() -> tantivy::Result<()> {
     // will reload the index automatically after each commit.
     let reader = index
         .reader_builder()
-        .reload_policy(ReloadPolicy::OnCommit)
+        .reload_policy(ReloadPolicy::OnCommitWithDelay)
         .try_into()?;
 
     // We now need to acquire a searcher.

--- a/examples/phrase_prefix_search.rs
+++ b/examples/phrase_prefix_search.rs
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
 
     let reader = index
         .reader_builder()
-        .reload_policy(ReloadPolicy::OnCommit)
+        .reload_policy(ReloadPolicy::OnCommitWithDelay)
         .try_into()?;
 
     let searcher = reader.searcher();

--- a/examples/pre_tokenized_text.rs
+++ b/examples/pre_tokenized_text.rs
@@ -94,7 +94,7 @@ fn main() -> tantivy::Result<()> {
 
     let reader = index
         .reader_builder()
-        .reload_policy(ReloadPolicy::OnCommit)
+        .reload_policy(ReloadPolicy::OnCommitWithDelay)
         .try_into()?;
 
     let searcher = reader.searcher();

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -121,7 +121,7 @@ fn test_index_on_commit_reload_policy() -> crate::Result<()> {
     let index = Index::create_in_ram(schema);
     let reader = index
         .reader_builder()
-        .reload_policy(ReloadPolicy::OnCommit)
+        .reload_policy(ReloadPolicy::OnCommitWithDelay)
         .try_into()
         .unwrap();
     assert_eq!(reader.searcher().num_docs(), 0);
@@ -147,7 +147,7 @@ mod mmap_specific {
         let index = Index::create_in_dir(tempdir_path, schema).unwrap();
         let reader = index
             .reader_builder()
-            .reload_policy(ReloadPolicy::OnCommit)
+            .reload_policy(ReloadPolicy::OnCommitWithDelay)
             .try_into()
             .unwrap();
         assert_eq!(reader.searcher().num_docs(), 0);
@@ -189,7 +189,7 @@ mod mmap_specific {
         let read_index = Index::open_in_dir(&tempdir_path).unwrap();
         let reader = read_index
             .reader_builder()
-            .reload_policy(ReloadPolicy::OnCommit)
+            .reload_policy(ReloadPolicy::OnCommitWithDelay)
             .try_into()
             .unwrap();
         assert_eq!(reader.searcher().num_docs(), 0);

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -222,8 +222,8 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// registered (and whose [`WatchHandle`] is still alive) are triggered.
     ///
     /// Internally, tantivy only uses this API to detect new commits to implement the
-    /// `OnCommit` `ReloadPolicy`. Not implementing watch in a `Directory` only prevents the
-    /// `OnCommit` `ReloadPolicy` to work properly.
+    /// `OnCommitWithDelay` `ReloadPolicy`. Not implementing watch in a `Directory` only prevents the
+    /// `OnCommitWithDelay` `ReloadPolicy` to work properly.
     fn watch(&self, watch_callback: WatchCallback) -> crate::Result<WatchHandle>;
 }
 

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -222,8 +222,8 @@ pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// registered (and whose [`WatchHandle`] is still alive) are triggered.
     ///
     /// Internally, tantivy only uses this API to detect new commits to implement the
-    /// `OnCommitWithDelay` `ReloadPolicy`. Not implementing watch in a `Directory` only prevents the
-    /// `OnCommitWithDelay` `ReloadPolicy` to work properly.
+    /// `OnCommitWithDelay` `ReloadPolicy`. Not implementing watch in a `Directory` only prevents
+    /// the `OnCommitWithDelay` `ReloadPolicy` to work properly.
     fn watch(&self, watch_callback: WatchCallback) -> crate::Result<WatchHandle>;
 }
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -28,7 +28,7 @@ pub enum ReloadPolicy {
     Manual,
     /// The index is reloaded within milliseconds after a new commit is available.
     /// This is made possible by watching changes in the `meta.json` file.
-    OnCommitWithDelay , // TODO add NEAR_REAL_TIME(target_ms)
+    OnCommitWithDelay, // TODO add NEAR_REAL_TIME(target_ms)
 }
 
 /// [`IndexReader`] builder

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -28,7 +28,7 @@ pub enum ReloadPolicy {
     Manual,
     /// The index is reloaded within milliseconds after a new commit is available.
     /// This is made possible by watching changes in the `meta.json` file.
-    OnCommit, // TODO add NEAR_REAL_TIME(target_ms)
+    OnCommitWithDelay , // TODO add NEAR_REAL_TIME(target_ms)
 }
 
 /// [`IndexReader`] builder
@@ -51,7 +51,7 @@ impl IndexReaderBuilder {
     #[must_use]
     pub(crate) fn new(index: Index) -> IndexReaderBuilder {
         IndexReaderBuilder {
-            reload_policy: ReloadPolicy::OnCommit,
+            reload_policy: ReloadPolicy::OnCommitWithDelay,
             index,
             warmers: Vec::new(),
             num_warming_threads: 1,
@@ -83,7 +83,7 @@ impl IndexReaderBuilder {
                 // No need to set anything...
                 None
             }
-            ReloadPolicy::OnCommit => {
+            ReloadPolicy::OnCommitWithDelay => {
                 let inner_reader_arc_clone = inner_reader_arc.clone();
                 let callback = move || {
                     if let Err(err) = inner_reader_arc_clone.reload() {
@@ -282,7 +282,7 @@ impl IndexReader {
     /// Update searchers so that they reflect the state of the last
     /// `.commit()`.
     ///
-    /// If you set up the [`ReloadPolicy::OnCommit`] (which is the default)
+    /// If you set up the [`ReloadPolicy::OnCommitWithDelay`] (which is the default)
     /// every commit should be rapidly reflected on your `IndexReader` and you should
     /// not need to call `reload()` at all.
     ///


### PR DESCRIPTION
Here is the pull request for issue [#1824](https://github.com/quickwit-oss/tantivy/issues/1824) that we dicussed on discord.
I simply renamed the reload policy from OnCommit to OnCommitWithDelay and updated the reference in the documentation and tests.

I tried to implement an OnCommit policy for synchronous reload but I did not succeed. 
Here are the main issues I faced:
1. IndexReader and IndexWriter can be created indipendently (see `test_index_on_commit_reload_policy_different_directories` in `core/test.rs` ) and as far as I understand they share the access to the same directory. When an IndexWriter commits the changes are propagated to the file system, if an IndexReader is executed in a different process there is no simple way to notify the commit in a synchronous way because "there isn't a  channel" between them (aside from the file system). I checked if there are some notifications for updating mmapped files but I did not find anything
2. There semantic of the reload is "lost" as the callback is passed to the directory object that implements the commit notification in a different way (worker thread for `mmap_directory`, direct call inside atomic_write for `ram_directory`). If the ReloadPolicy is "directory implementation indipendent" there is the need to associate it to the callback.

If you think it'd feasible to implement a sync OnCommit policy I ask for some advice and I'll start to dig further into the problem.



