### PR TITLE
bump index version

### DIFF
--- a/src/directory/footer.rs
+++ b/src/directory/footer.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::directory::error::Incompatibility;
 use crate::directory::{AntiCallToken, FileSlice, TerminatingWrite};
-use crate::{Version, INDEX_FORMAT_VERSION};
+use crate::{Version, INDEX_FORMAT_OLDEST_SUPPORTED_VERSION, INDEX_FORMAT_VERSION};
 
 const FOOTER_MAX_LEN: u32 = 50_000;
 
@@ -103,7 +103,7 @@ impl Footer {
     /// Has to be called after `extract_footer` to make sure it's not accessing uninitialised memory
     pub fn is_compatible(&self) -> Result<(), Incompatibility> {
         let library_version = crate::version();
-        if self.version.index_format_version < 4
+        if self.version.index_format_version < INDEX_FORMAT_OLDEST_SUPPORTED_VERSION
             || self.version.index_format_version > INDEX_FORMAT_VERSION
         {
             return Err(Incompatibility::IndexMismatch {

--- a/src/directory/footer.rs
+++ b/src/directory/footer.rs
@@ -102,10 +102,11 @@ impl Footer {
     /// Confirms that the index will be read correctly by this version of tantivy
     /// Has to be called after `extract_footer` to make sure it's not accessing uninitialised memory
     pub fn is_compatible(&self) -> Result<(), Incompatibility> {
+        const SUPPORTED_INDEX_FORMAT_VERSION_RANGE: std::ops::RangeInclusive<u32> =
+            INDEX_FORMAT_OLDEST_SUPPORTED_VERSION..=INDEX_FORMAT_VERSION;
+
         let library_version = crate::version();
-        if self.version.index_format_version < INDEX_FORMAT_OLDEST_SUPPORTED_VERSION
-            || self.version.index_format_version > INDEX_FORMAT_VERSION
-        {
+        if !SUPPORTED_INDEX_FORMAT_VERSION_RANGE.contains(&self.version.index_format_version) {
             return Err(Incompatibility::IndexMismatch {
                 library_version: library_version.clone(),
                 index_version: self.version.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,9 @@ pub use crate::schema::DatePrecision;
 pub use crate::schema::{DateOptions, DateTimePrecision, Document, TantivyDocument, Term};
 
 /// Index format version.
-const INDEX_FORMAT_VERSION: u32 = 5;
+const INDEX_FORMAT_VERSION: u32 = 6;
+/// Oldest index format version this tantivy version can read.
+const INDEX_FORMAT_OLDEST_SUPPORTED_VERSION: u32 = 4;
 
 /// Structure version for the index.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
fix #2236 

> (allow version N-1 and version N, for the current version of tantivy.)

we already have some logic to allow older index revision, but it's an unnamed constant hidden somewhere. I moved it alongside the current version