### PR TITLE
add sstable ord_to_term benchmark

### DIFF
--- a/sstable/Cargo.toml
+++ b/sstable/Cargo.toml
@@ -24,3 +24,8 @@ rand = "0.8"
 [[bench]]
 name = "stream_bench"
 harness = false
+
+[[bench]]
+name = "ord_to_term"
+harness = false
+

--- a/sstable/benches/ord_to_term.rs
+++ b/sstable/benches/ord_to_term.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+
+use common::file_slice::FileSlice;
+use common::OwnedBytes;
+use criterion::{criterion_group, criterion_main, Criterion};
+use tantivy_sstable::{self, Dictionary, MonotonicU64SSTable};
+
+fn make_test_sstable(suffix: &str) -> FileSlice {
+    let mut builder = Dictionary::<MonotonicU64SSTable>::builder(Vec::new()).unwrap();
+
+    // 125 mio elements
+    for elem in 0..125_000_000 {
+        let key = format!("prefix.{elem:07X}{suffix}").into_bytes();
+        builder.insert(&key, &elem).unwrap();
+    }
+
+    let table = builder.finish().unwrap();
+    let table = Arc::new(OwnedBytes::new(table));
+    let slice = common::file_slice::FileSlice::new(table.clone());
+
+    slice
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    {
+        let slice = make_test_sstable(".suffix");
+        let dict = Dictionary::<MonotonicU64SSTable>::open(slice.clone()).unwrap();
+        c.bench_function("ord_to_term_suffix", |b| {
+            let mut res = Vec::new();
+            b.iter(|| {
+                assert!(dict.ord_to_term(100_000, &mut res).unwrap());
+                assert!(dict.ord_to_term(19_000_000, &mut res).unwrap());
+            })
+        });
+        c.bench_function("open_and_ord_to_term_suffix", |b| {
+            let mut res = Vec::new();
+            b.iter(|| {
+                let dict = Dictionary::<MonotonicU64SSTable>::open(slice.clone()).unwrap();
+                assert!(dict.ord_to_term(100_000, &mut res).unwrap());
+                assert!(dict.ord_to_term(19_000_000, &mut res).unwrap());
+            })
+        });
+    }
+    {
+        let slice = make_test_sstable("");
+        let dict = Dictionary::<MonotonicU64SSTable>::open(slice.clone()).unwrap();
+        c.bench_function("ord_to_term", |b| {
+            let mut res = Vec::new();
+            b.iter(|| {
+                assert!(dict.ord_to_term(100_000, &mut res).unwrap());
+                assert!(dict.ord_to_term(19_000_000, &mut res).unwrap());
+            })
+        });
+        c.bench_function("open_and_ord_to_term", |b| {
+            let mut res = Vec::new();
+            b.iter(|| {
+                let dict = Dictionary::<MonotonicU64SSTable>::open(slice.clone()).unwrap();
+                assert!(dict.ord_to_term(100_000, &mut res).unwrap());
+                assert!(dict.ord_to_term(19_000_000, &mut res).unwrap());
+            })
+        });
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
```
ord_to_term_suffix      
                        time:   [6.3816 µs 6.4004 µs 6.4169 µs]

open_and_ord_to_term_suffix
                        time:   [15.715 ms 15.766 ms 15.822 ms

ord_to_term             
                        time:   [25.292 µs 25.307 µs 25.323 µs]

open_and_ord_to_term    
                        time:   [3.5459 ms 3.5549 ms 3.5643 ms]

```