### PR TITLE
multilayer sstable

### DIFF
--- a/columnar/src/tests.rs
+++ b/columnar/src/tests.rs
@@ -26,7 +26,7 @@ fn test_dataframe_writer_str() {
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("my_string").unwrap();
     assert_eq!(cols.len(), 1);
-    assert_eq!(cols[0].num_bytes(), 87);
+    assert_eq!(cols[0].num_bytes(), 99);
 }
 
 #[test]
@@ -40,7 +40,7 @@ fn test_dataframe_writer_bytes() {
     assert_eq!(columnar.num_columns(), 1);
     let cols: Vec<DynamicColumnHandle> = columnar.read_columns("my_string").unwrap();
     assert_eq!(cols.len(), 1);
-    assert_eq!(cols[0].num_bytes(), 87);
+    assert_eq!(cols[0].num_bytes(), 99);
 }
 
 #[test]

--- a/ownedbytes/src/lib.rs
+++ b/ownedbytes/src/lib.rs
@@ -1,5 +1,5 @@
 use std::convert::TryInto;
-use std::ops::{Deref, Range};
+use std::ops::Deref;
 use std::sync::Arc;
 use std::{fmt, io};
 
@@ -37,7 +37,7 @@ impl OwnedBytes {
     /// creates a fileslice that is just a view over a slice of the data.
     #[must_use]
     #[inline]
-    pub fn slice(&self, range: Range<usize>) -> Self {
+    pub fn slice(&self, range: impl std::slice::SliceIndex<[u8], Output = [u8]>) -> Self {
         OwnedBytes {
             data: &self.data[range],
             box_stable_deref: self.box_stable_deref.clone(),

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -131,7 +131,7 @@ mod tests {
         }
         let file = directory.open_read(path).unwrap();
 
-        assert_eq!(file.len(), 93);
+        assert_eq!(file.len(), 105);
         let fast_field_readers = FastFieldReaders::open(file, SCHEMA.clone()).unwrap();
         let column = fast_field_readers
             .u64("field")
@@ -181,7 +181,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 121);
+        assert_eq!(file.len(), 133);
         let fast_field_readers = FastFieldReaders::open(file, SCHEMA.clone()).unwrap();
         let col = fast_field_readers
             .u64("field")
@@ -214,7 +214,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 94);
+        assert_eq!(file.len(), 106);
         let fast_field_readers = FastFieldReaders::open(file, SCHEMA.clone()).unwrap();
         let fast_field_reader = fast_field_readers
             .u64("field")
@@ -246,7 +246,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 4489);
+        assert_eq!(file.len(), 4501);
         {
             let fast_field_readers = FastFieldReaders::open(file, SCHEMA.clone()).unwrap();
             let col = fast_field_readers
@@ -279,7 +279,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 265);
+        assert_eq!(file.len(), 277);
 
         {
             let fast_field_readers = FastFieldReaders::open(file, schema).unwrap();
@@ -773,7 +773,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 102);
+        assert_eq!(file.len(), 114);
         let fast_field_readers = FastFieldReaders::open(file, schema).unwrap();
         let bool_col = fast_field_readers.bool("field_bool").unwrap();
         assert_eq!(bool_col.first(0), Some(true));
@@ -805,7 +805,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 114);
+        assert_eq!(file.len(), 126);
         let readers = FastFieldReaders::open(file, schema).unwrap();
         let bool_col = readers.bool("field_bool").unwrap();
         for i in 0..25 {
@@ -830,7 +830,7 @@ mod tests {
             write.terminate().unwrap();
         }
         let file = directory.open_read(path).unwrap();
-        assert_eq!(file.len(), 104);
+        assert_eq!(file.len(), 116);
         let fastfield_readers = FastFieldReaders::open(file, schema).unwrap();
         let col = fastfield_readers.bool("field_bool").unwrap();
         assert_eq!(col.first(0), None);

--- a/sstable/README.md
+++ b/sstable/README.md
@@ -92,7 +92,7 @@ Note: as the SSTable does not support redundant keys, there is no ambiguity betw
 +-------+-------+-----+------------------+------------+-------------+---------+---------+
 | Block | Block | ... | FirstLayerOffset | LayerCount | IndexOffset | NumTerm | Version |
 +-------+-------+-----+------------------+------------+-------------+---------+---------+
-|----(# of blocks)----|---(optional? cf LayerCount)---|
+|----(# of blocks)----|
 ```
 - Block(SSTBlock): uses IndexValue for its Values format
 - FirstLayerOffset(u64): Offset between the start of the footer and the start of the top level index

--- a/sstable/README.md
+++ b/sstable/README.md
@@ -105,16 +105,6 @@ Blocks referencing the main table and block referencing the index itself are enc
 are not directly differentiated. Offsets in blocks referencing the index are relative to the start of
 the footer, blocks referencing the main table are relative to the start of that table.
 
-#### TODO(trinity) open questions:
-the changes are small enough that it's easy to support both v2 and v3 at once (LayerCount alias with a
-4 byte empty block we aways add at the end of an sstable. If LayerCount is zero, we are in v2, and must
-not read FirstLayerOffset, if we are in v3, LayerCount is non zero and we read FirstLayerOffset.
-If we keep that version number to 2, the format is then also forward compatible: an old version would decode
-IndexOffset and after, and find enough information to decode the bottom layer sstable, and would stop at
-the empty block added end of that sstable. The non-bottom layers would be loaded to memory, but never actually
-processed.
-Do we want to support that usage (put back version to v2), or prevent it and use v3?
-
 ### IndexValue
 ```
 +------------+----------+-------+-------+-----+

--- a/sstable/src/lib.rs
+++ b/sstable/src/lib.rs
@@ -28,7 +28,7 @@ use crate::value::{RangeValueReader, RangeValueWriter};
 pub type TermOrdinal = u64;
 
 const DEFAULT_KEY_CAPACITY: usize = 50;
-const SSTABLE_VERSION: u32 = 2;
+const SSTABLE_VERSION: u32 = 3;
 
 // TODO tune that value. Maybe it's too little?
 #[cfg(not(test))]
@@ -406,7 +406,7 @@ mod test {
                 1, 0, 0, 0, // layer count
                 16, 0, 0, 0, 0, 0, 0, 0, // index start offset
                 3, 0, 0, 0, 0, 0, 0, 0, // num term
-                2, 0, 0, 0, // version
+                3, 0, 0, 0, // version
             ]
         );
         let buffer = OwnedBytes::new(buffer);

--- a/sstable/src/streamer.rs
+++ b/sstable/src/streamer.rs
@@ -110,7 +110,7 @@ where
             Bound::Included(key) | Bound::Excluded(key) => self
                 .term_dict
                 .sstable_index
-                .get_block_with_key(key)
+                .get_block_with_key(key)?
                 .map(|block| block.first_ordinal)
                 .unwrap_or(0),
             Bound::Unbounded => 0,

--- a/sstable/src/value/index.rs
+++ b/sstable/src/value/index.rs
@@ -3,6 +3,10 @@ use std::io;
 use crate::value::{deserialize_vint_u64, ValueReader, ValueWriter};
 use crate::{vint, BlockAddr};
 
+// TODO define a LazyIndexValueReader?
+// one which keeps state could be useful for ord_to_block fns,
+// one which doesn't at all woud be perfect for term_to_block fns
+// pending bench to asses real impact
 #[derive(Default)]
 pub(crate) struct IndexValueReader {
     vals: Vec<BlockAddr>,


### PR DESCRIPTION
fix #1948 
related to https://github.com/quickwit-oss/quickwit/issues/3964

implement a new file format for sstable which allows much faster opening of very large table, at the cost of somewhat slower individual queries to the table
current results:
```
before:
        ord_to_term_suffix           time:   [15.442 µs 15.452 µs 15.464 µs]
        open_and_ord_to_term_suffix  time:   [37.591 ms 37.638 ms 37.688 ms]
        ord_to_term                  time:   [65.466 µs 65.483 µs 65.503 µs]
        open_and_ord_to_term         time:   [8.6174 ms 8.6311 ms 8.6474 ms]
after:
        ord_to_term_suffix           time:   [41.148 µs 41.222 µs 41.320 µs]
        open_and_ord_to_term_suffix  time:   [81.646 µs 81.663 µs 81.679 µs]
        ord_to_term                  time:   [92.304 µs 92.331 µs 92.360 µs]
        open_and_ord_to_term         time:   [99.245 µs 99.653 µs 100.41 µs]
```