### PR TITLE
Derive Debug for SchemaBuilder

### DIFF
--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -30,7 +30,7 @@ use crate::TantivyError;
 /// let body_field = schema_builder.add_text_field("body", TEXT);
 /// let schema = schema_builder.build();
 /// ```
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct SchemaBuilder {
     fields: Vec<FieldEntry>,
     fields_map: HashMap<String, Field>,


### PR DESCRIPTION
This can be useful for debugging and could be used in the Python bindings.