### PR TITLE
Take string references instead of owned values building Facet paths

### DIFF
--- a/src/schema/facet.rs
+++ b/src/schema/facet.rs
@@ -131,16 +131,16 @@ impl Facet {
     pub fn from_path<Path>(path: Path) -> Facet
     where
         Path: IntoIterator,
-        Path::Item: ToString,
+        Path::Item: AsRef<str>,
     {
         let mut facet_string: String = String::with_capacity(100);
         let mut step_it = path.into_iter();
         if let Some(step) = step_it.next() {
-            facet_string.push_str(&step.to_string());
+            facet_string.push_str(step.as_ref());
         }
         for step in step_it {
             facet_string.push(FACET_SEP_CHAR);
-            facet_string.push_str(&step.to_string());
+            facet_string.push_str(step.as_ref());
         }
         Facet(facet_string)
     }


### PR DESCRIPTION
This lets callers who already have `String` components of a Facet path avoid double-allocating them. 

The PR is a breaking change since it pushes dealing with `ToString`'s allocation (or skipping it :) ) up to the caller. Though for anyone already using `&str` or `String` their code will continue to compile. Everyone else will need to be explicit and call `.to_string` first to get the prior behavior.