### PR TITLE
RFC: Transparently fetch multiple documents grouped per block

### DIFF
--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -188,10 +188,11 @@ impl Searcher {
 
         let futures = groups
             .into_iter()
-            .map(|((segment_ord, _cache_key), doc_ids)| {
+            .map(|((segment_ord, cache_key), doc_ids)| {
                 // Each group fetches documents from exactly one block and
                 // therefore gets an independent block cache of size one.
-                let store_reader = self.inner.store_readers[segment_ord as usize].fork_cache(1);
+                let store_reader =
+                    self.inner.store_readers[segment_ord as usize].fork_cache(1, &[cache_key]);
 
                 async move {
                     let mut docs = Vec::new();

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -37,8 +37,10 @@ mod reader;
 mod writer;
 pub use self::compressors::{Compressor, ZstdCompressor};
 pub use self::decompressors::Decompressor;
+#[cfg(feature = "quickwit")]
+pub(crate) use self::reader::CacheKey;
 pub(crate) use self::reader::DOCSTORE_CACHE_CAPACITY;
-pub use self::reader::{CacheKey, CacheStats, StoreReader};
+pub use self::reader::{CacheStats, StoreReader};
 pub use self::writer::StoreWriter;
 mod store_compressor;
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -38,7 +38,7 @@ mod writer;
 pub use self::compressors::{Compressor, ZstdCompressor};
 pub use self::decompressors::Decompressor;
 pub(crate) use self::reader::DOCSTORE_CACHE_CAPACITY;
-pub use self::reader::{CacheStats, StoreReader};
+pub use self::reader::{CacheKey, CacheStats, StoreReader};
 pub use self::writer::StoreWriter;
 mod store_compressor;
 

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -92,7 +92,7 @@ impl BlockCache {
 
 /// Opaque cache key which indicates which documents are cached together.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CacheKey(usize);
+pub(crate) struct CacheKey(usize);
 
 #[derive(Debug, Default)]
 /// CacheStats for the `StoreReader`.
@@ -148,7 +148,8 @@ impl StoreReader {
     }
 
     /// Clones the given store reader with an independent block cache of the given size.
-    pub fn fork_cache(&self, cache_num_blocks: usize) -> Self {
+    #[cfg(feature = "quickwit")]
+    pub(crate) fn fork_cache(&self, cache_num_blocks: usize) -> Self {
         Self {
             decompressor: self.decompressor,
             data: self.data.clone(),
@@ -180,7 +181,8 @@ impl StoreReader {
     ///
     /// Note that looking up the cache key of a document
     /// will not yet pull anything into the block cache.
-    pub fn cache_key(&self, doc_id: DocId) -> crate::Result<CacheKey> {
+    #[cfg(feature = "quickwit")]
+    pub(crate) fn cache_key(&self, doc_id: DocId) -> crate::Result<CacheKey> {
         let checkpoint = self.block_checkpoint(doc_id)?;
         Ok(CacheKey(checkpoint.byte_range.start))
     }


### PR DESCRIPTION
My personal take on the discussion in #2252, i.e. expose enough information and control to schedule concurrent reads into independent block caches as to maximize cache effectiveness and then expose this as `Searcher::docs_async` which yields an iterator of futures which user code can then poll concurrently or in parallel as it sees fit.