### PR TITLE
Standardize on a single fast hasher, i.e. rustc-hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ common = { version= "0.6", path = "./common/", package = "tantivy-common" }
 tokenizer-api = { version= "0.2", path="./tokenizer-api", package="tantivy-tokenizer-api" }
 sketches-ddsketch = { version = "0.2.1", features = ["use_serde"] }
 futures-util = { version = "0.3.28", optional = true }
-fnv = "1.0.7"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/src/core/inverted_index_reader.rs
+++ b/src/core/inverted_index_reader.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use common::BinarySerializable;
-use fnv::FnvHashSet;
+use rustc_hash::FxHashSet;
 
 use crate::directory::FileSlice;
 use crate::positions::PositionReader;
@@ -78,7 +78,7 @@ impl InvertedIndexReader {
     pub fn list_encoded_fields(&self) -> io::Result<Vec<(String, Type)>> {
         let mut stream = self.termdict.stream()?;
         let mut fields = Vec::new();
-        let mut fields_set = FnvHashSet::default();
+        let mut fields_set = FxHashSet::default();
         while let Some((term, _term_info)) = stream.next() {
             if let Some(index) = term.iter().position(|&byte| byte == JSON_END_OF_PATH) {
                 if !fields_set.contains(&term[..index + 2]) {

--- a/src/core/segment_reader.rs
+++ b/src/core/segment_reader.rs
@@ -3,8 +3,8 @@ use std::ops::BitOrAssign;
 use std::sync::{Arc, RwLock};
 use std::{fmt, io};
 
-use fnv::FnvHashMap;
 use itertools::Itertools;
+use rustc_hash::FxHashMap;
 
 use crate::core::{InvertedIndexReader, Segment, SegmentComponent, SegmentId};
 use crate::directory::{CompositeFile, FileSlice};
@@ -300,7 +300,7 @@ impl SegmentReader {
     /// to not be listed.
     pub fn fields_metadata(&self) -> crate::Result<Vec<FieldMetadata>> {
         let mut indexed_fields: Vec<FieldMetadata> = Vec::new();
-        let mut map_to_canonical = FnvHashMap::default();
+        let mut map_to_canonical = FxHashMap::default();
         for (field, field_entry) in self.schema().fields() {
             let field_name = field_entry.name().to_string();
             let is_indexed = field_entry.is_indexed();

--- a/src/indexer/path_to_unordered_id.rs
+++ b/src/indexer/path_to_unordered_id.rs
@@ -1,4 +1,4 @@
-use fnv::FnvHashMap;
+use rustc_hash::FxHashMap;
 
 /// `Field` is represented by an unsigned 32-bit integer type.
 /// The schema holds the mapping between field names and `Field` objects.
@@ -24,7 +24,7 @@ impl From<u32> for OrderedPathId {
 
 #[derive(Default)]
 pub(crate) struct PathToUnorderedId {
-    map: FnvHashMap<String, u32>,
+    map: FxHashMap<String, u32>,
 }
 
 impl PathToUnorderedId {


### PR DESCRIPTION
We currently use both fnv and rustc-hash which basically fulfill the same role of very fast but low quality hashes. Since rustc-hash was originally created as a more modern replacement for fnv, let's standardize on that one.