### PR TITLE
chore: Expose TopDocs::order_by_u64_field again

### DIFF
--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -307,7 +307,7 @@ impl TopDocs {
     ///
     /// To comfortably work with `u64`s, `i64`s, `f64`s, or `date`s, please refer to
     /// the [.order_by_fast_field(...)](TopDocs::order_by_fast_field) method.
-    fn order_by_u64_field(
+    pub fn order_by_u64_field(
         self,
         field: impl ToString,
         order: Order,


### PR DESCRIPTION
The `TopDocs::order_by_u64_field` API was restricted from public use in #2111, but it is useful in contexts where the field type may not be important or known ahead of time.

Note that the unavailability of this API breaks ordering on non-u64 fields in tantity-py. Reference: https://github.com/quickwit-oss/tantivy-py/pull/166