### PR TITLE
Allow optional whitespace before bound specification in range queries

### DIFF
--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -469,8 +469,10 @@ fn range(inp: &str) -> IResult<&str, UserInputLeaf> {
         },
     );
 
-    let lower_to_upper =
-        separated_pair(lower_bound, tuple((space1, tag("TO"), space1)), upper_bound);
+    let lower_to_upper = preceded(
+        space0,
+        separated_pair(lower_bound, tuple((space1, tag("TO"), space1)), upper_bound),
+    );
 
     map(
         alt((elastic_unbounded_range, lower_to_upper)),
@@ -1537,7 +1539,9 @@ mod test {
     fn test_parse_query_with_range() {
         test_parse_query_to_ast_helper("[1 TO 5]", "[\"1\" TO \"5\"]");
         test_parse_query_to_ast_helper("foo:{a TO z}", "\"foo\":{\"a\" TO \"z\"}");
+        test_parse_query_to_ast_helper("foo: \t{a TO z}", "\"foo\":{\"a\" TO \"z\"}");
         test_parse_query_to_ast_helper("foo:[1 TO toto}", "\"foo\":[\"1\" TO \"toto\"}");
+        test_parse_query_to_ast_helper("foo: [1 TO toto}", "\"foo\":[\"1\" TO \"toto\"}");
         test_parse_query_to_ast_helper("foo:[* TO toto}", "\"foo\":{\"*\" TO \"toto\"}");
         test_parse_query_to_ast_helper("foo:[1 TO *}", "\"foo\":[\"1\" TO \"*\"}");
         test_parse_query_to_ast_helper(


### PR DESCRIPTION
Closes #2289 