### PR TITLE
Add shared search executor

### DIFF
--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -322,6 +322,12 @@ impl Index {
         Ok(())
     }
 
+    /// Custom thread pool by a outer thread pool.
+    pub fn set_shared_multithread_executor(&mut self, shared_thread_pool: Arc<Executor>) -> crate::Result<()> {
+        self.executor = shared_thread_pool.clone();
+        Ok(())
+    }
+
     /// Replace the default single thread search executor pool
     /// by a thread pool with as many threads as there are CPUs on the system.
     pub fn set_default_multithread_executor(&mut self) -> crate::Result<()> {


### PR DESCRIPTION
The approach to integrating `Tantivy` with `ClickHouse` is as follows: 
A `ClickHouse` Table will have multiple `DataParts`, each with its own `Tantivy` index. However, I would like `ClickHouse` to share a thread pool among different `DataParts` during concurrent searches, in order to reduce resource overhead during the search process. I have created a bridging repo([tantivy-search](https://github.com/MochiXu/tantivy-search/tree/tantivy_0.21.1)) between `Tantivy` and `ClickHouse`. 

The code for using a shared thread pool can be referred to at this [link](https://github.com/MochiXu/tantivy-search/blob/c5c741b7abb438bf93da5f43652d72eeabed1e0a/src/search/index_searcher.rs#L104C1-L126C6).