### PR TITLE
Fix serde for TopNComputer

### DIFF
--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -151,7 +151,7 @@ impl RetrievalFields {
                     return Ok(vec![field.to_owned()]);
                 }
 
-                let pattern = globbed_string_to_regex(&field)?;
+                let pattern = globbed_string_to_regex(field)?;
                 let fields = reader
                     .iter_columns()?
                     .map(|(name, _)| {

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -730,7 +730,7 @@ pub struct TopNComputer<Score, D, const REVERSE_ORDER: bool = true> {
 }
 // Intermediate struct for TopNComputer for deserialization, to fix vec capacity
 #[derive(Deserialize)]
-pub struct TopNComputerDeser<Score, D, const REVERSE_ORDER: bool = true> {
+struct TopNComputerDeser<Score, D, const REVERSE_ORDER: bool> {
     buffer: Vec<ComparableDoc<Score, D, REVERSE_ORDER>>,
     top_n: usize,
     threshold: Option<Score>,

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -323,7 +323,10 @@ impl Index {
     }
 
     /// Custom thread pool by a outer thread pool.
-    pub fn set_shared_multithread_executor(&mut self, shared_thread_pool: Arc<Executor>) -> crate::Result<()> {
+    pub fn set_shared_multithread_executor(
+        &mut self,
+        shared_thread_pool: Arc<Executor>,
+    ) -> crate::Result<()> {
         self.executor = shared_thread_pool.clone();
         Ok(())
     }


### PR DESCRIPTION
The top hits aggregation changed the TopNComputer to be serializable,
but capacity needs to be carried over, as it contains logic which is
checked against when pushing elements (capacity == 0 is not allowed).
