### PR TITLE
fix Clone for TopNComputer, add top_hits bench

### DIFF
--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -720,7 +720,7 @@ impl SegmentCollector for TopScoreSegmentCollector {
 /// Fast TopN Computation
 ///
 /// For TopN == 0, it will be relative expensive.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(from = "TopNComputerDeser<Score, D, REVERSE_ORDER>")]
 pub struct TopNComputer<Score, D, const REVERSE_ORDER: bool = true> {
     /// The buffer reverses sort order to get top-semantics instead of bottom-semantics
@@ -734,6 +734,22 @@ struct TopNComputerDeser<Score, D, const REVERSE_ORDER: bool> {
     buffer: Vec<ComparableDoc<Score, D, REVERSE_ORDER>>,
     top_n: usize,
     threshold: Option<Score>,
+}
+
+// Custom clone to keep capacity
+impl<Score: Clone, D: Clone, const REVERSE_ORDER: bool> Clone
+    for TopNComputer<Score, D, REVERSE_ORDER>
+{
+    fn clone(&self) -> Self {
+        let mut buffer_clone = Vec::with_capacity(self.buffer.capacity());
+        buffer_clone.extend(self.buffer.iter().cloned());
+
+        TopNComputer {
+            buffer: buffer_clone,
+            top_n: self.top_n,
+            threshold: self.threshold.clone(),
+        }
+    }
 }
 
 impl<Score, D, const R: bool> From<TopNComputerDeser<Score, D, R>> for TopNComputer<Score, D, R> {

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -719,6 +719,10 @@ impl SegmentCollector for TopScoreSegmentCollector {
 
 /// Fast TopN Computation
 ///
+/// Capacity of the vec is 2 * top_n.
+/// The buffer is truncated to the top_n elements when it reaches the capacity of the Vec.
+/// That means capacity has special meaning and should be carried over when cloning or serializing.
+///
 /// For TopN == 0, it will be relative expensive.
 #[derive(Serialize, Deserialize)]
 #[serde(from = "TopNComputerDeser<Score, D, REVERSE_ORDER>")]
@@ -728,7 +732,7 @@ pub struct TopNComputer<Score, D, const REVERSE_ORDER: bool = true> {
     top_n: usize,
     pub(crate) threshold: Option<Score>,
 }
-// Intermediate struct for TopNComputer for deserialization, to fix vec capacity
+// Intermediate struct for TopNComputer for deserialization, to keep vec capacity
 #[derive(Deserialize)]
 struct TopNComputerDeser<Score, D, const REVERSE_ORDER: bool> {
     buffer: Vec<ComparableDoc<Score, D, REVERSE_ORDER>>,


### PR DESCRIPTION
fix Clone for TopNComputer to carry vec capacity

add top_hits agg bench
```
test bench::bench_aggregation_terms_many_with_sub_agg                                    ... bench: 123,475,175 ns/iter (+/- 30,608,889)
test bench::bench_aggregation_terms_many_with_sub_agg_multi                              ... bench: 194,170,414 ns/iter (+/- 36,495,516)
test bench::bench_aggregation_terms_many_with_sub_agg_opt                                ... bench: 179,742,809 ns/iter (+/- 29,976,507)
test bench::bench_aggregation_terms_many_with_sub_agg_sparse                             ... bench:  27,592,534 ns/iter (+/- 2,672,370)
test bench::bench_aggregation_terms_many_with_top_hits_agg                               ... bench: 552,851,227 ns/iter (+/- 71,975,886)
test bench::bench_aggregation_terms_many_with_top_hits_agg_multi                         ... bench: 558,616,384 ns/iter (+/- 100,890,124)
test bench::bench_aggregation_terms_many_with_top_hits_agg_opt                           ... bench: 554,031,368 ns/iter (+/- 165,452,650)
test bench::bench_aggregation_terms_many_with_top_hits_agg_sparse                        ... bench:  46,435,919 ns/iter (+/- 13,681,935)
```