### PR TITLE
fix postcard compatibility for top_hits, add postcard test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ paste = "1.0.11"
 more-asserts = "0.3.1"
 rand_distr = "0.4.3"
 time = { version = "0.3.10", features = ["serde-well-known", "macros"] }
+postcard = { version = "1.0.4", features = [
+  "use-std",
+], default-features = false }
 
 [target.'cfg(not(windows))'.dev-dependencies]
 criterion = { version = "0.5", default-features = false }

--- a/common/src/datetime.rs
+++ b/common/src/datetime.rs
@@ -40,7 +40,7 @@ pub type DatePrecision = DateTimePrecision;
 /// All constructors and conversions are provided as explicit
 /// functions and not by implementing any `From`/`Into` traits
 /// to prevent unintended usage.
-#[derive(Clone, Default, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct DateTime {
     // Timestamp in nanoseconds.
     pub(crate) timestamp_nanos: i64,

--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -292,7 +292,7 @@ impl AggregationWithAccessor {
                 add_agg_with_accessor(&agg, accessor, column_type, &mut res)?;
             }
             TopHits(ref mut top_hits) => {
-                top_hits.validate_and_resolve(reader.fast_fields().columnar())?;
+                top_hits.validate_and_resolve_field_names(reader.fast_fields().columnar())?;
                 let accessors: Vec<(Column<u64>, ColumnType)> = top_hits
                     .field_names()
                     .iter()

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -314,7 +314,7 @@ impl IntermediateMetricResult {
                     .into_final_result(req.agg.as_percentile().expect("unexpected metric type")),
             ),
             IntermediateMetricResult::TopHits(top_hits) => {
-                MetricResult::TopHits(top_hits.finalize())
+                MetricResult::TopHits(top_hits.into_final_result())
             }
         }
     }

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -20,7 +20,7 @@ use super::bucket::{
 };
 use super::metric::{
     IntermediateAverage, IntermediateCount, IntermediateMax, IntermediateMin, IntermediateStats,
-    IntermediateSum, PercentilesCollector, TopHitsCollector,
+    IntermediateSum, PercentilesCollector, TopHitsTopNComputer,
 };
 use super::segment_agg_result::AggregationLimits;
 use super::{format_date, AggregationError, Key, SerializedKey};
@@ -221,9 +221,9 @@ pub(crate) fn empty_from_req(req: &Aggregation) -> IntermediateAggregationResult
         Percentiles(_) => IntermediateAggregationResult::Metric(
             IntermediateMetricResult::Percentiles(PercentilesCollector::default()),
         ),
-        TopHits(_) => IntermediateAggregationResult::Metric(IntermediateMetricResult::TopHits(
-            TopHitsCollector::default(),
-        )),
+        TopHits(ref req) => IntermediateAggregationResult::Metric(
+            IntermediateMetricResult::TopHits(TopHitsTopNComputer::new(req.clone())),
+        ),
     }
 }
 
@@ -285,7 +285,7 @@ pub enum IntermediateMetricResult {
     /// Intermediate sum result.
     Sum(IntermediateSum),
     /// Intermediate top_hits result
-    TopHits(TopHitsCollector),
+    TopHits(TopHitsTopNComputer),
 }
 
 impl IntermediateMetricResult {

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -25,6 +25,8 @@ mod stats;
 mod sum;
 mod top_hits;
 
+use std::collections::HashMap;
+
 pub use average::*;
 pub use count::*;
 pub use max::*;
@@ -35,6 +37,8 @@ use serde::{Deserialize, Serialize};
 pub use stats::*;
 pub use sum::*;
 pub use top_hits::*;
+
+use crate::schema::OwnedValue;
 
 /// Single-metric aggregations use this common result structure.
 ///
@@ -92,8 +96,9 @@ pub struct TopHitsVecEntry {
 
     /// Search results, for queries that include field retrieval requests
     /// (`docvalue_fields`).
-    #[serde(flatten)]
-    pub search_results: FieldRetrivalResult,
+    #[serde(rename = "docvalue_fields")]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub doc_value_fields: HashMap<String, OwnedValue>,
 }
 
 /// The top_hits metric aggregation results a list of top hits by sort criteria.

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -99,17 +99,6 @@ pub struct TopHitsAggregation {
     doc_value_fields: Vec<String>,
 }
 
-/// Intermediate Search query result for each matched document
-///
-/// Unlike the final result, this struct is postcard compatible.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-pub struct IntermediateFieldRetrivalResult {
-    /// The fast fields returned for each hit.
-    #[serde(rename = "docvalue_fields")]
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub doc_value_fields: HashMap<String, RetrievedValue>,
-}
-
 #[derive(Debug, Clone, PartialEq, Default)]
 struct KeyOrder {
     field: String,
@@ -128,17 +117,30 @@ impl Serialize for KeyOrder {
 impl<'de> Deserialize<'de> for KeyOrder {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: Deserializer<'de> {
-        let mut k_o = <HashMap<String, Order>>::deserialize(deserializer)?.into_iter();
-        let (k, v) = k_o.next().ok_or(serde::de::Error::custom(
-            "Expected exactly one key-value pair in KeyOrder, found none",
+        let mut key_order = <HashMap<String, Order>>::deserialize(deserializer)?.into_iter();
+        let (field, order) = key_order.next().ok_or(serde::de::Error::custom(
+            "Expected exactly one key-value pair in sort parameter of top_hits, found none",
         ))?;
-        if k_o.next().is_some() {
-            return Err(serde::de::Error::custom(
-                "Expected exactly one key-value pair in KeyOrder, found more",
-            ));
+        if key_order.next().is_some() {
+            return Err(serde::de::Error::custom(format!(
+                "Expected exactly one key-value pair in sort parameter of top_hits, found {:?}",
+                key_order
+            )));
         }
-        Ok(Self { field: k, order: v })
+        Ok(Self { field, order })
     }
+}
+
+// Tranform a glob (`pattern*`, for example) into a regex::Regex (`^pattern.*$`)
+fn globbed_string_to_regex(glob: &str) -> Result<Regex, crate::TantivyError> {
+    // Replace `*` glob with `.*` regex
+    let sanitized = format!("^{}$", regex::escape(glob).replace(r"\*", ".*"));
+    Regex::new(&sanitized.replace('*', ".*")).map_err(|e| {
+        crate::TantivyError::SchemaError(format!(
+            "Invalid regex '{}' in docvalue_fields: {}",
+            glob, e
+        ))
+    })
 }
 
 impl TopHitsAggregation {
@@ -147,17 +149,6 @@ impl TopHitsAggregation {
         &mut self,
         reader: &ColumnarReader,
     ) -> crate::Result<()> {
-        // Tranform a glob (`pattern*`, for example) into a regex::Regex (`^pattern.*$`)
-        let globbed_string_to_regex = |glob: &str| {
-            // Replace `*` glob with `.*` regex
-            let sanitized = format!("^{}$", regex::escape(glob).replace(r"\*", ".*"));
-            Regex::new(&sanitized.replace('*', ".*")).map_err(|e| {
-                crate::TantivyError::SchemaError(format!(
-                    "Invalid regex '{}' in docvalue_fields: {}",
-                    glob, e
-                ))
-            })
-        };
         self.doc_value_fields = self
             .doc_value_fields
             .iter()
@@ -211,8 +202,8 @@ impl TopHitsAggregation {
         &self,
         accessors: &HashMap<String, Vec<DynamicColumn>>,
         doc_id: DocId,
-    ) -> IntermediateFieldRetrivalResult {
-        let dvf = self
+    ) -> HashMap<String, FastFieldValue> {
+        let doc_value_fields = self
             .doc_value_fields
             .iter()
             .map(|field| {
@@ -220,20 +211,20 @@ impl TopHitsAggregation {
                     .get(field)
                     .unwrap_or_else(|| panic!("field '{}' not found in accessors", field));
 
-                let values: Vec<RetrievedValue> = accessors
+                let values: Vec<FastFieldValue> = accessors
                     .iter()
                     .flat_map(|accessor| match accessor {
                         DynamicColumn::U64(accessor) => accessor
                             .values_for_doc(doc_id)
-                            .map(RetrievedValue::U64)
+                            .map(FastFieldValue::U64)
                             .collect::<Vec<_>>(),
                         DynamicColumn::I64(accessor) => accessor
                             .values_for_doc(doc_id)
-                            .map(RetrievedValue::I64)
+                            .map(FastFieldValue::I64)
                             .collect::<Vec<_>>(),
                         DynamicColumn::F64(accessor) => accessor
                             .values_for_doc(doc_id)
-                            .map(RetrievedValue::F64)
+                            .map(FastFieldValue::F64)
                             .collect::<Vec<_>>(),
                         DynamicColumn::Bytes(accessor) => accessor
                             .term_ords(doc_id)
@@ -245,7 +236,7 @@ impl TopHitsAggregation {
                                         .expect("could not read term dictionary"),
                                     "term corresponding to term_ord does not exist"
                                 );
-                                RetrievedValue::Bytes(buffer)
+                                FastFieldValue::Bytes(buffer)
                             })
                             .collect::<Vec<_>>(),
                         DynamicColumn::Str(accessor) => accessor
@@ -258,36 +249,34 @@ impl TopHitsAggregation {
                                         .expect("could not read term dictionary"),
                                     "term corresponding to term_ord does not exist"
                                 );
-                                RetrievedValue::Str(String::from_utf8(buffer).unwrap())
+                                FastFieldValue::Str(String::from_utf8(buffer).unwrap())
                             })
                             .collect::<Vec<_>>(),
                         DynamicColumn::Bool(accessor) => accessor
                             .values_for_doc(doc_id)
-                            .map(RetrievedValue::Bool)
+                            .map(FastFieldValue::Bool)
                             .collect::<Vec<_>>(),
                         DynamicColumn::IpAddr(accessor) => accessor
                             .values_for_doc(doc_id)
-                            .map(RetrievedValue::IpAddr)
+                            .map(FastFieldValue::IpAddr)
                             .collect::<Vec<_>>(),
                         DynamicColumn::DateTime(accessor) => accessor
                             .values_for_doc(doc_id)
-                            .map(RetrievedValue::Date)
+                            .map(FastFieldValue::Date)
                             .collect::<Vec<_>>(),
                     })
                     .collect();
 
-                (field.to_owned(), RetrievedValue::Array(values))
+                (field.to_owned(), FastFieldValue::Array(values))
             })
             .collect();
-        IntermediateFieldRetrivalResult {
-            doc_value_fields: dvf,
-        }
+        doc_value_fields
     }
 }
 
 /// A retrieved value from a fast field.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum RetrievedValue {
+pub enum FastFieldValue {
     /// The str type is used for any text information.
     Str(String),
     /// Unsigned 64-bits Integer `u64`
@@ -308,34 +297,34 @@ pub enum RetrievedValue {
     Array(Vec<Self>),
 }
 
-impl From<RetrievedValue> for OwnedValue {
-    fn from(value: RetrievedValue) -> Self {
+impl From<FastFieldValue> for OwnedValue {
+    fn from(value: FastFieldValue) -> Self {
         match value {
-            RetrievedValue::Str(s) => OwnedValue::Str(s),
-            RetrievedValue::U64(u) => OwnedValue::U64(u),
-            RetrievedValue::I64(i) => OwnedValue::I64(i),
-            RetrievedValue::F64(f) => OwnedValue::F64(f),
-            RetrievedValue::Bool(b) => OwnedValue::Bool(b),
-            RetrievedValue::Date(d) => OwnedValue::Date(d),
-            RetrievedValue::Bytes(b) => OwnedValue::Bytes(b),
-            RetrievedValue::IpAddr(ip) => OwnedValue::IpAddr(ip),
-            RetrievedValue::Array(a) => {
+            FastFieldValue::Str(s) => OwnedValue::Str(s),
+            FastFieldValue::U64(u) => OwnedValue::U64(u),
+            FastFieldValue::I64(i) => OwnedValue::I64(i),
+            FastFieldValue::F64(f) => OwnedValue::F64(f),
+            FastFieldValue::Bool(b) => OwnedValue::Bool(b),
+            FastFieldValue::Date(d) => OwnedValue::Date(d),
+            FastFieldValue::Bytes(b) => OwnedValue::Bytes(b),
+            FastFieldValue::IpAddr(ip) => OwnedValue::IpAddr(ip),
+            FastFieldValue::Array(a) => {
                 OwnedValue::Array(a.into_iter().map(OwnedValue::from).collect())
             }
         }
     }
 }
 
-/// Holds a single comparable doc feature, and the order in which it should be sorted.
+/// Holds a fast field value in its u64 representation, and the order in which it should be sorted.
 #[derive(Clone, Serialize, Deserialize, Debug)]
-struct ComparableDocFeature {
-    /// Stores any u64-mappable feature.
+struct DocValueAndOrder {
+    /// A fast field value in its u64 representation.
     value: Option<u64>,
-    /// Sort order for the doc feature
+    /// Sort order for the value
     order: Order,
 }
 
-impl Ord for ComparableDocFeature {
+impl Ord for DocValueAndOrder {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         let invert = |cmp: std::cmp::Ordering| match self.order {
             Order::Asc => cmp,
@@ -351,26 +340,32 @@ impl Ord for ComparableDocFeature {
     }
 }
 
-impl PartialOrd for ComparableDocFeature {
+impl PartialOrd for DocValueAndOrder {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl PartialEq for ComparableDocFeature {
+impl PartialEq for DocValueAndOrder {
     fn eq(&self, other: &Self) -> bool {
         self.value.cmp(&other.value) == std::cmp::Ordering::Equal
     }
 }
 
-impl Eq for ComparableDocFeature {}
+impl Eq for DocValueAndOrder {}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-struct ComparableDocFeatures(Vec<ComparableDocFeature>, IntermediateFieldRetrivalResult);
+struct DocSortValuesAndFields {
+    sorts: Vec<DocValueAndOrder>,
 
-impl Ord for ComparableDocFeatures {
+    #[serde(rename = "docvalue_fields")]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    doc_value_fields: HashMap<String, FastFieldValue>,
+}
+
+impl Ord for DocSortValuesAndFields {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        for (self_feature, other_feature) in self.0.iter().zip(other.0.iter()) {
+        for (self_feature, other_feature) in self.sorts.iter().zip(other.sorts.iter()) {
             let cmp = self_feature.cmp(other_feature);
             if cmp != std::cmp::Ordering::Equal {
                 return cmp;
@@ -380,53 +375,43 @@ impl Ord for ComparableDocFeatures {
     }
 }
 
-impl PartialOrd for ComparableDocFeatures {
+impl PartialOrd for DocSortValuesAndFields {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl PartialEq for ComparableDocFeatures {
+impl PartialEq for DocSortValuesAndFields {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == std::cmp::Ordering::Equal
     }
 }
 
-impl Eq for ComparableDocFeatures {}
+impl Eq for DocSortValuesAndFields {}
 
 /// The TopHitsCollector used for collecting over segments and merging results.
-#[derive(Clone, Serialize, Deserialize)]
-pub struct TopHitsCollector {
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct TopHitsTopNComputer {
     req: TopHitsAggregation,
-    top_n: TopNComputer<ComparableDocFeatures, DocAddress, false>,
+    top_n: TopNComputer<DocSortValuesAndFields, DocAddress, false>,
 }
 
-impl Default for TopHitsCollector {
-    fn default() -> Self {
-        Self {
-            req: TopHitsAggregation::default(),
-            top_n: TopNComputer::new(1),
-        }
-    }
-}
-
-impl std::fmt::Debug for TopHitsCollector {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TopHitsCollector")
-            .field("req", &self.req)
-            .field("top_n_threshold", &self.top_n.threshold)
-            .finish()
-    }
-}
-
-impl std::cmp::PartialEq for TopHitsCollector {
+impl std::cmp::PartialEq for TopHitsTopNComputer {
     fn eq(&self, _other: &Self) -> bool {
         false
     }
 }
 
-impl TopHitsCollector {
-    fn collect(&mut self, features: ComparableDocFeatures, doc: DocAddress) {
+impl TopHitsTopNComputer {
+    /// Create a new TopHitsCollector
+    pub fn new(req: TopHitsAggregation) -> Self {
+        Self {
+            top_n: TopNComputer::new(req.size + req.from.unwrap_or(0)),
+            req,
+        }
+    }
+
+    fn collect(&mut self, features: DocSortValuesAndFields, doc: DocAddress) {
         self.top_n.push(features, doc);
     }
 
@@ -444,10 +429,9 @@ impl TopHitsCollector {
             .into_sorted_vec()
             .into_iter()
             .map(|doc| TopHitsVecEntry {
-                sort: doc.feature.0.iter().map(|f| f.value).collect(),
+                sort: doc.feature.sorts.iter().map(|f| f.value).collect(),
                 doc_value_fields: doc
                     .feature
-                    .1
                     .doc_value_fields
                     .into_iter()
                     .map(|(k, v)| (k, v.into()))
@@ -464,48 +448,63 @@ impl TopHitsCollector {
     }
 }
 
-#[derive(Clone)]
-pub(crate) struct SegmentTopHitsCollector {
+#[derive(Clone, Debug)]
+pub(crate) struct TopHitsSegmentCollector {
     segment_ordinal: SegmentOrdinal,
     accessor_idx: usize,
-    inner_collector: TopHitsCollector,
+    req: TopHitsAggregation,
+    top_n: TopNComputer<Vec<DocValueAndOrder>, DocAddress, false>,
 }
 
-impl SegmentTopHitsCollector {
+impl TopHitsSegmentCollector {
     pub fn from_req(
         req: &TopHitsAggregation,
         accessor_idx: usize,
         segment_ordinal: SegmentOrdinal,
     ) -> Self {
         Self {
-            inner_collector: TopHitsCollector {
-                req: req.clone(),
-                top_n: TopNComputer::new(req.size + req.from.unwrap_or(0)),
-            },
+            req: req.clone(),
+            top_n: TopNComputer::new(req.size + req.from.unwrap_or(0)),
             segment_ordinal,
             accessor_idx,
         }
     }
-}
+    fn into_top_hits_collector(
+        self,
+        value_accessors: &HashMap<String, Vec<DynamicColumn>>,
+    ) -> TopHitsTopNComputer {
+        let mut top_hits_computer = TopHitsTopNComputer::new(self.req.clone());
+        let top_results = self.top_n.into_vec();
 
-impl std::fmt::Debug for SegmentTopHitsCollector {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SegmentTopHitsCollector")
-            .field("segment_id", &self.segment_ordinal)
-            .field("accessor_idx", &self.accessor_idx)
-            .field("inner_collector", &self.inner_collector)
-            .finish()
+        for res in top_results {
+            let doc_value_fields = self
+                .req
+                .get_document_field_data(value_accessors, res.doc.doc_id);
+            top_hits_computer.collect(
+                DocSortValuesAndFields {
+                    sorts: res.feature,
+                    doc_value_fields,
+                },
+                res.doc,
+            );
+        }
+
+        top_hits_computer
     }
 }
 
-impl SegmentAggregationCollector for SegmentTopHitsCollector {
+impl SegmentAggregationCollector for TopHitsSegmentCollector {
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
         agg_with_accessor: &crate::aggregation::agg_req_with_accessor::AggregationsWithAccessor,
         results: &mut crate::aggregation::intermediate_agg_result::IntermediateAggregationResults,
     ) -> crate::Result<()> {
         let name = agg_with_accessor.aggs.keys[self.accessor_idx].to_string();
-        let intermediate_result = IntermediateMetricResult::TopHits(self.inner_collector);
+
+        let value_accessors = &agg_with_accessor.aggs.values[self.accessor_idx].value_accessors;
+
+        let intermediate_result =
+            IntermediateMetricResult::TopHits(self.into_top_hits_collector(value_accessors));
         results.push(
             name,
             IntermediateAggregationResult::Metric(intermediate_result),
@@ -518,9 +517,7 @@ impl SegmentAggregationCollector for SegmentTopHitsCollector {
         agg_with_accessor: &mut crate::aggregation::agg_req_with_accessor::AggregationsWithAccessor,
     ) -> crate::Result<()> {
         let accessors = &agg_with_accessor.aggs.values[self.accessor_idx].accessors;
-        let value_accessors = &agg_with_accessor.aggs.values[self.accessor_idx].value_accessors;
-        let features: Vec<ComparableDocFeature> = self
-            .inner_collector
+        let sorts: Vec<DocValueAndOrder> = self
             .req
             .sort
             .iter()
@@ -533,17 +530,12 @@ impl SegmentAggregationCollector for SegmentTopHitsCollector {
                     .0
                     .values_for_doc(doc_id)
                     .next();
-                ComparableDocFeature { value, order }
+                DocValueAndOrder { value, order }
             })
             .collect();
 
-        let retrieval_result = self
-            .inner_collector
-            .req
-            .get_document_field_data(value_accessors, doc_id);
-
-        self.inner_collector.collect(
-            ComparableDocFeatures(features, retrieval_result),
+        self.top_n.push(
+            sorts,
             DocAddress {
                 segment_ord: self.segment_ordinal,
                 doc_id,
@@ -557,11 +549,7 @@ impl SegmentAggregationCollector for SegmentTopHitsCollector {
         docs: &[crate::DocId],
         agg_with_accessor: &mut crate::aggregation::agg_req_with_accessor::AggregationsWithAccessor,
     ) -> crate::Result<()> {
-        // TODO: Consider getting fields with the column block accessor and refactor this.
-        // ---
-        // Would the additional complexity of getting fields with the column_block_accessor
-        // make sense here? Probably yes, but I want to get a first-pass review first
-        // before proceeding.
+        // TODO: Consider getting fields with the column block accessor.
         for doc in docs {
             self.collect(*doc, agg_with_accessor)?;
         }
@@ -576,7 +564,7 @@ mod tests {
     use serde_json::Value;
     use time::macros::datetime;
 
-    use super::{ComparableDocFeature, ComparableDocFeatures, Order};
+    use super::{DocSortValuesAndFields, DocValueAndOrder, Order};
     use crate::aggregation::agg_req::Aggregations;
     use crate::aggregation::agg_result::AggregationResults;
     use crate::aggregation::bucket::tests::get_test_index_from_docs;
@@ -584,44 +572,44 @@ mod tests {
     use crate::aggregation::AggregationCollector;
     use crate::collector::ComparableDoc;
     use crate::query::AllQuery;
-    use crate::schema::OwnedValue as SchemaValue;
+    use crate::schema::OwnedValue;
 
-    fn invert_order(cmp_feature: ComparableDocFeature) -> ComparableDocFeature {
-        let ComparableDocFeature { value, order } = cmp_feature;
+    fn invert_order(cmp_feature: DocValueAndOrder) -> DocValueAndOrder {
+        let DocValueAndOrder { value, order } = cmp_feature;
         let order = match order {
             Order::Asc => Order::Desc,
             Order::Desc => Order::Asc,
         };
-        ComparableDocFeature { value, order }
+        DocValueAndOrder { value, order }
     }
 
-    fn collector_with_capacity(capacity: usize) -> super::TopHitsCollector {
-        super::TopHitsCollector {
+    fn collector_with_capacity(capacity: usize) -> super::TopHitsTopNComputer {
+        super::TopHitsTopNComputer {
             top_n: super::TopNComputer::new(capacity),
-            ..Default::default()
+            req: Default::default(),
         }
     }
 
-    fn invert_order_features(cmp_features: ComparableDocFeatures) -> ComparableDocFeatures {
-        let ComparableDocFeatures(cmp_features, search_results) = cmp_features;
-        let cmp_features = cmp_features
+    fn invert_order_features(mut cmp_features: DocSortValuesAndFields) -> DocSortValuesAndFields {
+        cmp_features.sorts = cmp_features
+            .sorts
             .into_iter()
             .map(invert_order)
             .collect::<Vec<_>>();
-        ComparableDocFeatures(cmp_features, search_results)
+        cmp_features
     }
 
     #[test]
     fn test_comparable_doc_feature() -> crate::Result<()> {
-        let small = ComparableDocFeature {
+        let small = DocValueAndOrder {
             value: Some(1),
             order: Order::Asc,
         };
-        let big = ComparableDocFeature {
+        let big = DocValueAndOrder {
             value: Some(2),
             order: Order::Asc,
         };
-        let none = ComparableDocFeature {
+        let none = DocValueAndOrder {
             value: None,
             order: Order::Asc,
         };
@@ -643,21 +631,21 @@ mod tests {
 
     #[test]
     fn test_comparable_doc_features() -> crate::Result<()> {
-        let features_1 = ComparableDocFeatures(
-            vec![ComparableDocFeature {
+        let features_1 = DocSortValuesAndFields {
+            sorts: vec![DocValueAndOrder {
                 value: Some(1),
                 order: Order::Asc,
             }],
-            Default::default(),
-        );
+            doc_value_fields: Default::default(),
+        };
 
-        let features_2 = ComparableDocFeatures(
-            vec![ComparableDocFeature {
+        let features_2 = DocSortValuesAndFields {
+            sorts: vec![DocValueAndOrder {
                 value: Some(2),
                 order: Order::Asc,
             }],
-            Default::default(),
-        );
+            doc_value_fields: Default::default(),
+        };
 
         assert!(features_1 < features_2);
 
@@ -716,39 +704,39 @@ mod tests {
                     segment_ord: 0,
                     doc_id: 0,
                 },
-                feature: ComparableDocFeatures(
-                    vec![ComparableDocFeature {
+                feature: DocSortValuesAndFields {
+                    sorts: vec![DocValueAndOrder {
                         value: Some(1),
                         order: Order::Asc,
                     }],
-                    Default::default(),
-                ),
+                    doc_value_fields: Default::default(),
+                },
             },
             ComparableDoc {
                 doc: crate::DocAddress {
                     segment_ord: 0,
                     doc_id: 2,
                 },
-                feature: ComparableDocFeatures(
-                    vec![ComparableDocFeature {
+                feature: DocSortValuesAndFields {
+                    sorts: vec![DocValueAndOrder {
                         value: Some(3),
                         order: Order::Asc,
                     }],
-                    Default::default(),
-                ),
+                    doc_value_fields: Default::default(),
+                },
             },
             ComparableDoc {
                 doc: crate::DocAddress {
                     segment_ord: 0,
                     doc_id: 1,
                 },
-                feature: ComparableDocFeatures(
-                    vec![ComparableDocFeature {
+                feature: DocSortValuesAndFields {
+                    sorts: vec![DocValueAndOrder {
                         value: Some(5),
                         order: Order::Asc,
                     }],
-                    Default::default(),
-                ),
+                    doc_value_fields: Default::default(),
+                },
             },
         ];
 
@@ -764,15 +752,15 @@ mod tests {
             super::TopHitsMetricResult {
                 hits: vec![
                     super::TopHitsVecEntry {
-                        sort: vec![docs[0].feature.0[0].value],
+                        sort: vec![docs[0].feature.sorts[0].value],
                         doc_value_fields: Default::default(),
                     },
                     super::TopHitsVecEntry {
-                        sort: vec![docs[1].feature.0[0].value],
+                        sort: vec![docs[1].feature.sorts[0].value],
                         doc_value_fields: Default::default(),
                     },
                     super::TopHitsVecEntry {
-                        sort: vec![docs[2].feature.0[0].value],
+                        sort: vec![docs[2].feature.sorts[0].value],
                         doc_value_fields: Default::default(),
                     },
                 ]
@@ -830,7 +818,7 @@ mod tests {
                     {
                         "sort": [common::i64_to_u64(date_2017.unix_timestamp_nanos() as i64)],
                         "docvalue_fields": {
-                            "date": [ SchemaValue::Date(DateTime::from_utc(date_2017)) ],
+                            "date": [ OwnedValue::Date(DateTime::from_utc(date_2017)) ],
                             "text": [ "ccc" ],
                             "text2": [ "ddd" ],
                             "mixed.dyn_arr": [ 3, "4" ],
@@ -839,7 +827,7 @@ mod tests {
                     {
                         "sort": [common::i64_to_u64(date_2016.unix_timestamp_nanos() as i64)],
                         "docvalue_fields": {
-                            "date": [ SchemaValue::Date(DateTime::from_utc(date_2016)) ],
+                            "date": [ OwnedValue::Date(DateTime::from_utc(date_2016)) ],
                             "text": [ "aaa" ],
                             "text2": [ "bbb" ],
                             "mixed.dyn_arr": [ 6, "7" ],

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fmt::Formatter;
 use std::net::Ipv6Addr;
 
 use columnar::{ColumnarReader, DynamicColumn};

--- a/src/aggregation/segment_agg_result.rs
+++ b/src/aggregation/segment_agg_result.rs
@@ -16,7 +16,7 @@ use super::metric::{
     SumAggregation,
 };
 use crate::aggregation::bucket::TermMissingAgg;
-use crate::aggregation::metric::SegmentTopHitsCollector;
+use crate::aggregation::metric::TopHitsSegmentCollector;
 
 pub(crate) trait SegmentAggregationCollector: CollectorClone + Debug {
     fn add_intermediate_aggregation_result(
@@ -161,7 +161,7 @@ pub(crate) fn build_single_agg_segment_collector(
                 accessor_idx,
             )?,
         )),
-        TopHits(top_hits_req) => Ok(Box::new(SegmentTopHitsCollector::from_req(
+        TopHits(top_hits_req) => Ok(Box::new(TopHitsSegmentCollector::from_req(
             top_hits_req,
             accessor_idx,
             req.segment_ordinal,

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -732,6 +732,19 @@ pub struct TopNComputer<Score, D, const REVERSE_ORDER: bool = true> {
     top_n: usize,
     pub(crate) threshold: Option<Score>,
 }
+
+impl<Score: std::fmt::Debug, D, const REVERSE_ORDER: bool> std::fmt::Debug
+    for TopNComputer<Score, D, REVERSE_ORDER>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TopNComputer")
+            .field("buffer_len", &self.buffer.len())
+            .field("top_n", &self.top_n)
+            .field("current_threshold", &self.threshold)
+            .finish()
+    }
+}
+
 // Intermediate struct for TopNComputer for deserialization, to keep vec capacity
 #[derive(Deserialize)]
 struct TopNComputerDeser<Score, D, const REVERSE_ORDER: bool> {


### PR DESCRIPTION
fixes https://github.com/quickwit-oss/quickwit/issues/4840

Fix intermediate result postcard serialization by removing flatten
Fix intermediate result postcard deserialization by replacing `OwnedValue` (no self-describing formats)

Delay doc value fetchting to end of segment collection, closes https://github.com/quickwit-oss/tantivy/issues/2347
Fix naming and struct organization