### PR TITLE
Extend DocumentDeserialize with a stateful variant DocumentDeserializeSeed

### DIFF
--- a/src/schema/document/de.rs
+++ b/src/schema/document/de.rs
@@ -69,6 +69,28 @@ pub trait DocumentDeserialize: Sized {
     where D: DocumentDeserializer<'de>;
 }
 
+/// A stateful extension of [`DocumentDeserialize`].
+pub trait DocumentDeserializeSeed: Sized {
+    /// The type produced by using this seed.
+    type Value;
+
+    /// Attempts to deserialize `Self::Value` from the given `seed` and `deserializer`.
+    fn deserialize<'de, D>(self, deserializer: D) -> Result<Self::Value, DeserializeError>
+    where D: DocumentDeserializer<'de>;
+}
+
+impl<T> DocumentDeserializeSeed for PhantomData<T>
+where T: DocumentDeserialize
+{
+    /// The type produced by using this seed.
+    type Value = T;
+
+    fn deserialize<'de, D>(self, deserializer: D) -> Result<Self::Value, DeserializeError>
+    where D: DocumentDeserializer<'de> {
+        <T as DocumentDeserialize>::deserialize(deserializer)
+    }
+}
+
 /// A deserializer that can walk through each entry in the document.
 pub trait DocumentDeserializer<'de> {
     /// A indicator as to how many values are in the document.

--- a/src/schema/document/default_document.rs
+++ b/src/schema/document/default_document.rs
@@ -603,7 +603,7 @@ impl<'a> Iterator for CompactDocObjectIter<'a> {
             container: self.container,
             value,
         };
-        return Some((key, value));
+        Some((key, value))
     }
 }
 
@@ -637,7 +637,7 @@ impl<'a> Iterator for CompactDocArrayIter<'a> {
             container: self.container,
             value,
         };
-        return Some(value);
+        Some(value)
     }
 }
 

--- a/src/schema/document/mod.rs
+++ b/src/schema/document/mod.rs
@@ -169,8 +169,9 @@ use std::mem;
 
 pub(crate) use self::de::BinaryDocumentDeserializer;
 pub use self::de::{
-    ArrayAccess, DeserializeError, DocumentDeserialize, DocumentDeserializer, ObjectAccess,
-    ValueDeserialize, ValueDeserializer, ValueType, ValueVisitor,
+    ArrayAccess, DeserializeError, DocumentDeserialize, DocumentDeserializeSeed,
+    DocumentDeserializer, ObjectAccess, ValueDeserialize, ValueDeserializer, ValueType,
+    ValueVisitor,
 };
 pub use self::default_document::{
     CompactDocArrayIter, CompactDocObjectIter, CompactDocValue, DocParsingError, TantivyDocument,


### PR DESCRIPTION
This is modelled on Serde's `DeserializeSeed` include how the relevant API entry points gain a `_seed` variant. It can be used for example to obtain runtime field ID values when deserializing a struct field by field without relying on the order of the fields as written to/read from the document store.