### PR TITLE
split Term into Term and IndexingTerm

### DIFF
--- a/src/core/json_utils.rs
+++ b/src/core/json_utils.rs
@@ -4,6 +4,7 @@ use rustc_hash::FxHashMap;
 
 use crate::postings::{IndexingContext, IndexingPosition, PostingsWriter};
 use crate::schema::document::{ReferenceValue, ReferenceValueLeaf, Value};
+use crate::schema::indexing_term::IndexingTerm;
 use crate::schema::{Field, Type};
 use crate::time::format_description::well_known::Rfc3339;
 use crate::time::{OffsetDateTime, UtcOffset};
@@ -74,7 +75,7 @@ pub(crate) fn index_json_values<'a, V: Value<'a>>(
     json_visitors: impl Iterator<Item = crate::Result<V::ObjectIter>>,
     text_analyzer: &mut TextAnalyzer,
     expand_dots_enabled: bool,
-    term_buffer: &mut Term,
+    term_buffer: &mut IndexingTerm,
     postings_writer: &mut dyn PostingsWriter,
     json_path_writer: &mut JsonPathWriter,
     ctx: &mut IndexingContext,
@@ -103,7 +104,7 @@ fn index_json_object<'a, V: Value<'a>>(
     doc: DocId,
     json_visitor: V::ObjectIter,
     text_analyzer: &mut TextAnalyzer,
-    term_buffer: &mut Term,
+    term_buffer: &mut IndexingTerm,
     json_path_writer: &mut JsonPathWriter,
     postings_writer: &mut dyn PostingsWriter,
     ctx: &mut IndexingContext,
@@ -130,17 +131,17 @@ fn index_json_value<'a, V: Value<'a>>(
     doc: DocId,
     json_value: V,
     text_analyzer: &mut TextAnalyzer,
-    term_buffer: &mut Term,
+    term_buffer: &mut IndexingTerm,
     json_path_writer: &mut JsonPathWriter,
     postings_writer: &mut dyn PostingsWriter,
     ctx: &mut IndexingContext,
     positions_per_path: &mut IndexingPositionsPerPath,
 ) {
-    let set_path_id = |term_buffer: &mut Term, unordered_id: u32| {
+    let set_path_id = |term_buffer: &mut IndexingTerm, unordered_id: u32| {
         term_buffer.truncate_value_bytes(0);
         term_buffer.append_bytes(&unordered_id.to_be_bytes());
     };
-    let set_type = |term_buffer: &mut Term, typ: Type| {
+    let set_type = |term_buffer: &mut IndexingTerm, typ: Type| {
         term_buffer.append_bytes(&[typ.to_code()]);
     };
 
@@ -211,18 +212,16 @@ fn index_json_value<'a, V: Value<'a>>(
                 postings_writer.subscribe(doc, 0u32, term_buffer, ctx);
             }
             ReferenceValueLeaf::PreTokStr(_) => {
-                unimplemented!(
-                    "Pre-tokenized string support in dynamic fields is not yet implemented"
-                )
+                unimplemented!("Pre-tokenized string support in JSON fields is not yet implemented")
             }
             ReferenceValueLeaf::Bytes(_) => {
-                unimplemented!("Bytes support in dynamic fields is not yet implemented")
+                unimplemented!("Bytes support in JSON fields is not yet implemented")
             }
             ReferenceValueLeaf::Facet(_) => {
-                unimplemented!("Facet support in dynamic fields is not yet implemented")
+                unimplemented!("Facet support in JSON fields is not yet implemented")
             }
             ReferenceValueLeaf::IpAddr(_) => {
-                unimplemented!("IP address support in dynamic fields is not yet implemented")
+                unimplemented!("IP address support in JSON fields is not yet implemented")
             }
         },
         ReferenceValue::Array(elements) => {

--- a/src/core/json_utils.rs
+++ b/src/core/json_utils.rs
@@ -253,10 +253,7 @@ fn index_json_value<'a, V: Value<'a>>(
 /// Tries to infer a JSON type from a string and append it to the term.
 ///
 /// The term must be json + JSON path.
-pub(crate) fn convert_to_fast_value_and_append_to_json_term(
-    mut term: Term,
-    phrase: &str,
-) -> Option<Term> {
+pub fn convert_to_fast_value_and_append_to_json_term(mut term: Term, phrase: &str) -> Option<Term> {
     assert_eq!(
         term.value()
             .as_json()

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -15,7 +15,8 @@ use crate::postings::{
     PerFieldPostingsWriter, PostingsWriter,
 };
 use crate::schema::document::{Document, ReferenceValue, Value};
-use crate::schema::{FieldEntry, FieldType, Schema, Term, DATE_TIME_PRECISION_INDEXED};
+use crate::schema::indexing_term::IndexingTerm;
+use crate::schema::{FieldEntry, FieldType, Schema, DATE_TIME_PRECISION_INDEXED};
 use crate::store::{StoreReader, StoreWriter};
 use crate::tokenizer::{FacetTokenizer, PreTokenizedStream, TextAnalyzer, Tokenizer};
 use crate::{DocId, Opstamp, SegmentComponent, TantivyError};
@@ -70,7 +71,7 @@ pub struct SegmentWriter {
     pub(crate) json_path_writer: JsonPathWriter,
     pub(crate) doc_opstamps: Vec<Opstamp>,
     per_field_text_analyzers: Vec<TextAnalyzer>,
-    term_buffer: Term,
+    term_buffer: IndexingTerm,
     schema: Schema,
 }
 
@@ -126,7 +127,7 @@ impl SegmentWriter {
             )?,
             doc_opstamps: Vec::with_capacity(1_000),
             per_field_text_analyzers,
-            term_buffer: Term::with_capacity(16),
+            term_buffer: IndexingTerm::with_capacity(16),
             schema,
         })
     }

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -1,4 +1,3 @@
-use columnar::MonotonicallyMappableToU64;
 use common::JsonPathWriter;
 use itertools::Itertools;
 use tokenizer_api::BoxTokenStream;
@@ -16,7 +15,7 @@ use crate::postings::{
 };
 use crate::schema::document::{Document, ReferenceValue, Value};
 use crate::schema::indexing_term::IndexingTerm;
-use crate::schema::{FieldEntry, FieldType, Schema, DATE_TIME_PRECISION_INDEXED};
+use crate::schema::{FieldEntry, FieldType, Schema};
 use crate::store::{StoreReader, StoreWriter};
 use crate::tokenizer::{FacetTokenizer, PreTokenizedStream, TextAnalyzer, Tokenizer};
 use crate::{DocId, Opstamp, SegmentComponent, TantivyError};

--- a/src/postings/json_postings_writer.rs
+++ b/src/postings/json_postings_writer.rs
@@ -8,8 +8,8 @@ use crate::indexer::path_to_unordered_id::OrderedPathId;
 use crate::postings::postings_writer::SpecializedPostingsWriter;
 use crate::postings::recorder::{BufferLender, DocIdRecorder, Recorder};
 use crate::postings::{FieldSerializer, IndexingContext, IndexingPosition, PostingsWriter};
-use crate::schema::indexing_term::{IndexingTerm, ValueBytes};
-use crate::schema::{Field, Type};
+use crate::schema::indexing_term::IndexingTerm;
+use crate::schema::{Field, Type, ValueBytes};
 use crate::tokenizer::TokenStream;
 use crate::DocId;
 
@@ -67,26 +67,25 @@ impl<Rec: Recorder> PostingsWriter for JsonPostingsWriter<Rec> {
         ctx: &IndexingContext,
         serializer: &mut FieldSerializer,
     ) -> io::Result<()> {
-        let mut term_buffer = IndexingTerm::with_capacity(48);
+        let mut term_buffer = JsonTermSerializer(Vec::with_capacity(48));
         let mut buffer_lender = BufferLender::default();
-        term_buffer.clear_with_field_and_type(Type::Json, Field::from_field_id(0));
         let mut prev_term_id = u32::MAX;
         let mut term_path_len = 0; // this will be set in the first iteration
         for (_field, path_id, term, addr) in term_addrs {
             if prev_term_id != path_id.path_id() {
-                term_buffer.truncate_value_bytes(0);
+                term_buffer.clear();
                 term_buffer.append_path(ordered_id_to_path[path_id.path_id() as usize].as_bytes());
                 term_buffer.append_bytes(&[JSON_END_OF_PATH]);
-                term_path_len = term_buffer.len_bytes();
+                term_path_len = term_buffer.len();
                 prev_term_id = path_id.path_id();
             }
-            term_buffer.truncate_value_bytes(term_path_len);
+            term_buffer.truncate(term_path_len);
             term_buffer.append_bytes(term);
             let json_value = ValueBytes::wrap(term);
             let typ = json_value.typ();
             if typ == Type::Str {
                 SpecializedPostingsWriter::<Rec>::serialize_one_term(
-                    term_buffer.serialized_value_bytes(),
+                    term_buffer.as_bytes(),
                     *addr,
                     doc_id_map,
                     &mut buffer_lender,
@@ -95,7 +94,7 @@ impl<Rec: Recorder> PostingsWriter for JsonPostingsWriter<Rec> {
                 )?;
             } else {
                 SpecializedPostingsWriter::<DocIdRecorder>::serialize_one_term(
-                    term_buffer.serialized_value_bytes(),
+                    term_buffer.as_bytes(),
                     *addr,
                     doc_id_map,
                     &mut buffer_lender,
@@ -109,5 +108,42 @@ impl<Rec: Recorder> PostingsWriter for JsonPostingsWriter<Rec> {
 
     fn total_num_tokens(&self) -> u64 {
         self.str_posting_writer.total_num_tokens() + self.non_str_posting_writer.total_num_tokens()
+    }
+}
+
+struct JsonTermSerializer(Vec<u8>);
+impl JsonTermSerializer {
+    #[inline]
+    pub fn append_path(&mut self, bytes: &[u8]) {
+        if bytes.contains(&0u8) {
+            self.0
+                .extend(bytes.iter().map(|&b| if b == 0 { b'0' } else { b }));
+        } else {
+            self.0.extend_from_slice(bytes);
+        }
+    }
+
+    /// Appends value bytes to the Term.
+    ///
+    /// This function returns the segment that has just been added.
+    #[inline]
+    pub fn append_bytes(&mut self, bytes: &[u8]) -> &mut [u8] {
+        let len_before = self.0.len();
+        self.0.extend_from_slice(bytes);
+        &mut self.0[len_before..]
+    }
+
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len);
+    }
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.0
     }
 }

--- a/src/query/phrase_prefix_query/phrase_prefix_query.rs
+++ b/src/query/phrase_prefix_query/phrase_prefix_query.rs
@@ -137,7 +137,7 @@ impl Query for PhrasePrefixQuery {
             // There are no prefix. Let's just match the suffix.
             let end_term =
                 if let Some(end_value) = prefix_end(self.prefix.1.serialized_value_bytes()) {
-                    let mut end_term = Term::with_capacity(end_value.len());
+                    let mut end_term = Term::new();
                     end_term.set_field_and_type(self.field, self.prefix.1.typ());
                     end_term.append_bytes(&end_value);
                     Bound::Excluded(end_term)

--- a/src/schema/indexing_term.rs
+++ b/src/schema/indexing_term.rs
@@ -1,0 +1,257 @@
+use std::hash::{Hash, Hasher};
+use std::net::Ipv6Addr;
+
+use columnar::{MonotonicallyMappableToU128, MonotonicallyMappableToU64};
+
+use super::date_time_options::DATE_TIME_PRECISION_INDEXED;
+use super::Field;
+use crate::fastfield::FastValue;
+use crate::schema::Type;
+use crate::DateTime;
+
+/// Term represents the value that the token can take.
+/// It's a serialized representation over different types.
+///
+/// It actually wraps a `Vec<u8>`. The first 5 bytes are metadata.
+/// 4 bytes are the field id, and the last byte is the type.
+///
+/// The serialized value `ValueBytes` is considered everything after the 4 first bytes (term id).
+#[derive(Clone)]
+pub struct IndexingTerm<B = Vec<u8>>(B)
+where
+    B: AsRef<[u8]>;
+
+/// The number of bytes used as metadata by `Term`.
+const TERM_METADATA_LENGTH: usize = 5;
+
+impl IndexingTerm {
+    /// Create a new Term with a buffer with a given capacity.
+    pub fn with_capacity(capacity: usize) -> IndexingTerm {
+        let mut data = Vec::with_capacity(TERM_METADATA_LENGTH + capacity);
+        data.resize(TERM_METADATA_LENGTH, 0u8);
+        IndexingTerm(data)
+    }
+
+    /// Panics when the term is not empty... ie: some value is set.
+    /// Use `clear_with_field_and_type` in that case.
+    ///
+    /// Sets field and the type.
+    pub(crate) fn set_field_and_type(&mut self, field: Field, typ: Type) {
+        assert!(self.is_empty());
+        self.0[0..4].clone_from_slice(field.field_id().to_be_bytes().as_ref());
+        self.0[4] = typ.to_code();
+    }
+
+    /// Is empty if there are no value bytes.
+    pub fn is_empty(&self) -> bool {
+        self.0.len() == TERM_METADATA_LENGTH
+    }
+
+    /// Removes the value_bytes and set the field and type code.
+    pub(crate) fn clear_with_field_and_type(&mut self, typ: Type, field: Field) {
+        self.truncate_value_bytes(0);
+        self.set_field_and_type(field, typ);
+    }
+
+    /// Sets a u64 value in the term.
+    ///
+    /// U64 are serialized using (8-byte) BigEndian
+    /// representation.
+    /// The use of BigEndian has the benefit of preserving
+    /// the natural order of the values.
+    pub fn set_u64(&mut self, val: u64) {
+        self.set_fast_value(val);
+    }
+
+    /// Sets a `i64` value in the term.
+    pub fn set_i64(&mut self, val: i64) {
+        self.set_fast_value(val);
+    }
+
+    /// Sets a `f64` value in the term.
+    pub fn set_f64(&mut self, val: f64) {
+        self.set_fast_value(val);
+    }
+
+    /// Sets a `bool` value in the term.
+    pub fn set_bool(&mut self, val: bool) {
+        self.set_fast_value(val);
+    }
+
+    fn set_fast_value<T: FastValue>(&mut self, val: T) {
+        self.set_bytes(val.to_u64().to_be_bytes().as_ref());
+    }
+
+    /// Append a type marker + fast value to a term.
+    /// This is used in JSON type to append a fast value after the path.
+    ///
+    /// It will not clear existing bytes.
+    pub(crate) fn append_type_and_fast_value<T: FastValue>(&mut self, val: T) {
+        self.0.push(T::to_type().to_code());
+        let value = if T::to_type() == Type::Date {
+            DateTime::from_u64(val.to_u64())
+                .truncate(DATE_TIME_PRECISION_INDEXED)
+                .to_u64()
+        } else {
+            val.to_u64()
+        };
+        self.0.extend(value.to_be_bytes().as_ref());
+    }
+
+    /// Sets a `Ipv6Addr` value in the term.
+    pub fn set_ip_addr(&mut self, val: Ipv6Addr) {
+        self.set_bytes(val.to_u128().to_be_bytes().as_ref());
+    }
+
+    /// Sets the value of a `Bytes` field.
+    pub fn set_bytes(&mut self, bytes: &[u8]) {
+        self.truncate_value_bytes(0);
+        self.0.extend(bytes);
+    }
+
+    /// Truncates the value bytes of the term. Value and field type stays the same.
+    pub fn truncate_value_bytes(&mut self, len: usize) {
+        self.0.truncate(len + TERM_METADATA_LENGTH);
+    }
+
+    /// The length of the bytes.
+    pub fn len_bytes(&self) -> usize {
+        self.0.len() - TERM_METADATA_LENGTH
+    }
+
+    /// Appends value bytes to the Term.
+    ///
+    /// This function returns the segment that has just been added.
+    #[inline]
+    pub fn append_bytes(&mut self, bytes: &[u8]) -> &mut [u8] {
+        let len_before = self.0.len();
+        self.0.extend_from_slice(bytes);
+        &mut self.0[len_before..]
+    }
+
+    /// Appends json path bytes to the Term.
+    /// If the path contains 0 bytes, they are replaced by a "0" string.
+    /// The 0 byte is used to mark the end of the path.
+    ///
+    /// This function returns the segment that has just been added.
+    #[inline]
+    pub fn append_path(&mut self, bytes: &[u8]) -> &mut [u8] {
+        let len_before = self.0.len();
+        if bytes.contains(&0u8) {
+            self.0
+                .extend(bytes.iter().map(|&b| if b == 0 { b'0' } else { b }));
+        } else {
+            self.0.extend_from_slice(bytes);
+        }
+        &mut self.0[len_before..]
+    }
+}
+
+impl<B> IndexingTerm<B>
+where
+    B: AsRef<[u8]>,
+{
+    /// Wraps a object holding bytes
+    pub fn wrap(data: B) -> IndexingTerm<B> {
+        IndexingTerm(data)
+    }
+
+    /// Returns the field.
+    pub fn field(&self) -> Field {
+        let field_id_bytes: [u8; 4] = (&self.0.as_ref()[..4]).try_into().unwrap();
+        Field::from_field_id(u32::from_be_bytes(field_id_bytes))
+    }
+
+    /// Returns the serialized representation of the value.
+    /// (this does neither include the field id nor the value type.)
+    ///
+    /// If the term is a string, its value is utf-8 encoded.
+    /// If the term is a u64, its value is encoded according
+    /// to `byteorder::BigEndian`.
+    pub fn serialized_value_bytes(&self) -> &[u8] {
+        &self.0.as_ref()[TERM_METADATA_LENGTH..]
+    }
+
+    /// Returns the serialized representation of Term.
+    /// This includes field_id, value type and value.
+    ///
+    /// Do NOT rely on this byte representation in the index.
+    /// This value is likely to change in the future.
+    #[inline]
+    pub fn serialized_term(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+/// ValueBytes represents a serialized value.
+/// The value can be of any type of [`Type`] (e.g. string, u64, f64, bool, date, JSON).
+/// The serialized representation matches the lexographical order of the type.
+///
+/// The `ValueBytes` format is as follow:
+/// `[type code: u8][serialized value]`
+///
+/// For JSON `ValueBytes` equals to:
+/// `[type code=JSON][JSON path][JSON_END_OF_PATH][ValueBytes]`
+///
+/// The nested ValueBytes in JSON is never of type JSON. (there's no recursion)
+#[derive(Clone)]
+pub struct ValueBytes<B>(B)
+where
+    B: AsRef<[u8]>;
+
+impl<B> ValueBytes<B>
+where
+    B: AsRef<[u8]>,
+{
+    /// Wraps a object holding bytes
+    pub fn wrap(data: B) -> ValueBytes<B> {
+        ValueBytes(data)
+    }
+
+    fn typ_code(&self) -> u8 {
+        self.0.as_ref()[0]
+    }
+
+    /// Return the type of the term.
+    pub fn typ(&self) -> Type {
+        Type::from_code(self.typ_code()).expect("The term has an invalid type code")
+    }
+}
+
+impl<B> Ord for IndexingTerm<B>
+where
+    B: AsRef<[u8]>,
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.serialized_term().cmp(other.serialized_term())
+    }
+}
+
+impl<B> PartialOrd for IndexingTerm<B>
+where
+    B: AsRef<[u8]>,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<B> PartialEq for IndexingTerm<B>
+where
+    B: AsRef<[u8]>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.serialized_term() == other.serialized_term()
+    }
+}
+
+impl<B> Eq for IndexingTerm<B> where B: AsRef<[u8]> {}
+
+impl<B> Hash for IndexingTerm<B>
+where
+    B: AsRef<[u8]>,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_ref().hash(state)
+    }
+}

--- a/src/schema/indexing_term.rs
+++ b/src/schema/indexing_term.rs
@@ -8,48 +8,42 @@ use crate::fastfield::FastValue;
 use crate::schema::Type;
 use crate::DateTime;
 
-/// Term represents the value that the token can take.
+/// IndexingTerm represents is the serialized information of a term during indexing.
 /// It's a serialized representation over different types.
 ///
-/// It actually wraps a `Vec<u8>`. The first 5 bytes are metadata.
-/// 4 bytes are the field id, and the last byte is the type.
+/// It actually wraps a `Vec<u8>`.
 ///
-/// The serialized value `ValueBytes` is considered everything after the 4 first bytes (term id).
+/// The format is as follow:
+/// `[field id: u32][serialized value]`
+///
+/// For JSON it equals to:
+/// `[field id: u32][path id: u32][type code: u8][serialized value]`
+///
+/// The format is chosen to easily partition the terms by field during serialization, as all terms
+/// are stored in one hashmap.
 #[derive(Clone)]
-pub struct IndexingTerm<B = Vec<u8>>(B)
-where
-    B: AsRef<[u8]>;
+pub(crate) struct IndexingTerm(Vec<u8>);
 
-/// The number of bytes used as metadata by `Term`.
-const TERM_METADATA_LENGTH: usize = 5;
+/// The number of bytes used as for the field id by `Term`.
+const FIELD_ID_LENGTH: usize = 4;
 
 impl IndexingTerm {
-    /// Create a new Term with a buffer with a given capacity.
-    pub fn with_capacity(capacity: usize) -> IndexingTerm {
-        let mut data = Vec::with_capacity(TERM_METADATA_LENGTH + capacity);
-        data.resize(TERM_METADATA_LENGTH, 0u8);
+    /// Create a new IndexingTerm.
+    pub fn new() -> IndexingTerm {
+        let mut data = Vec::with_capacity(FIELD_ID_LENGTH + 32);
+        data.resize(FIELD_ID_LENGTH, 0u8);
         IndexingTerm(data)
-    }
-
-    /// Panics when the term is not empty... ie: some value is set.
-    /// Use `clear_with_field_and_type` in that case.
-    ///
-    /// Sets field and the type.
-    pub(crate) fn set_field_and_type(&mut self, field: Field, typ: Type) {
-        assert!(self.is_empty());
-        self.0[0..4].clone_from_slice(field.field_id().to_be_bytes().as_ref());
-        self.0[4] = typ.to_code();
     }
 
     /// Is empty if there are no value bytes.
     pub fn is_empty(&self) -> bool {
-        self.0.len() == TERM_METADATA_LENGTH
+        self.0.len() == FIELD_ID_LENGTH
     }
 
-    /// Removes the value_bytes and set the field and type code.
-    pub(crate) fn clear_with_field_and_type(&mut self, typ: Type, field: Field) {
+    /// Removes the value_bytes and set the field
+    pub(crate) fn clear_with_field(&mut self, field: Field) {
         self.truncate_value_bytes(0);
-        self.set_field_and_type(field, typ);
+        self.0[0..4].clone_from_slice(field.field_id().to_be_bytes().as_ref());
     }
 
     /// Sets a u64 value in the term.
@@ -59,6 +53,11 @@ impl IndexingTerm {
     /// The use of BigEndian has the benefit of preserving
     /// the natural order of the values.
     pub fn set_u64(&mut self, val: u64) {
+        self.set_fast_value(val);
+    }
+
+    /// Sets a `DateTime` value in the term.
+    pub fn set_date(&mut self, val: DateTime) {
         self.set_fast_value(val);
     }
 
@@ -78,7 +77,19 @@ impl IndexingTerm {
     }
 
     fn set_fast_value<T: FastValue>(&mut self, val: T) {
-        self.set_bytes(val.to_u64().to_be_bytes().as_ref());
+        self.truncate_value_bytes(0);
+        self.append_fast_value(val);
+    }
+
+    /// Sets a `Ipv6Addr` value in the term.
+    pub fn set_ip_addr(&mut self, val: Ipv6Addr) {
+        self.set_value_bytes(val.to_u128().to_be_bytes().as_ref());
+    }
+
+    /// Sets the value bytes of the term.
+    pub fn set_value_bytes(&mut self, bytes: &[u8]) {
+        self.truncate_value_bytes(0);
+        self.0.extend(bytes);
     }
 
     /// Append a type marker + fast value to a term.
@@ -87,6 +98,13 @@ impl IndexingTerm {
     /// It will not clear existing bytes.
     pub(crate) fn append_type_and_fast_value<T: FastValue>(&mut self, val: T) {
         self.0.push(T::to_type().to_code());
+        self.append_fast_value(val)
+    }
+
+    /// Append a fast value to a term.
+    ///
+    /// It will not clear existing bytes.
+    pub fn append_fast_value<T: FastValue>(&mut self, val: T) {
         let value = if T::to_type() == Type::Date {
             DateTime::from_u64(val.to_u64())
                 .truncate(DATE_TIME_PRECISION_INDEXED)
@@ -97,60 +115,33 @@ impl IndexingTerm {
         self.0.extend(value.to_be_bytes().as_ref());
     }
 
-    /// Sets a `Ipv6Addr` value in the term.
-    pub fn set_ip_addr(&mut self, val: Ipv6Addr) {
-        self.set_bytes(val.to_u128().to_be_bytes().as_ref());
-    }
-
-    /// Sets the value of a `Bytes` field.
-    pub fn set_bytes(&mut self, bytes: &[u8]) {
-        self.truncate_value_bytes(0);
-        self.0.extend(bytes);
-    }
-
     /// Truncates the value bytes of the term. Value and field type stays the same.
     pub fn truncate_value_bytes(&mut self, len: usize) {
-        self.0.truncate(len + TERM_METADATA_LENGTH);
+        self.0.truncate(len + FIELD_ID_LENGTH);
     }
 
     /// The length of the bytes.
     pub fn len_bytes(&self) -> usize {
-        self.0.len() - TERM_METADATA_LENGTH
+        self.0.len() - FIELD_ID_LENGTH
     }
 
-    /// Appends value bytes to the Term.
+    /// Appends bytes to the Term.
     ///
     /// This function returns the segment that has just been added.
     #[inline]
-    pub fn append_bytes(&mut self, bytes: &[u8]) -> &mut [u8] {
-        let len_before = self.0.len();
+    pub fn append_bytes(&mut self, bytes: &[u8]) {
         self.0.extend_from_slice(bytes);
-        &mut self.0[len_before..]
-    }
-}
-
-impl<B> IndexingTerm<B>
-where
-    B: AsRef<[u8]>,
-{
-    /// Wraps a object holding bytes
-    pub fn wrap(data: B) -> IndexingTerm<B> {
-        IndexingTerm(data)
-    }
-
-    /// Returns the field.
-    pub fn field(&self) -> Field {
-        let field_id_bytes: [u8; 4] = (&self.0.as_ref()[..4]).try_into().unwrap();
-        Field::from_field_id(u32::from_be_bytes(field_id_bytes))
     }
 
     /// Returns the serialized representation of Term.
-    /// This includes field_id, value type and value.
-    ///
-    /// Do NOT rely on this byte representation in the index.
-    /// This value is likely to change in the future.
+    /// This includes field_id, value bytes
     #[inline]
-    pub fn serialized_term(&self) -> &[u8] {
+    pub fn serialized_for_hashmap(&self) -> &[u8] {
         self.0.as_ref()
     }
+}
+
+pub fn get_field_from_indexing_term(bytes: &[u8]) -> Field {
+    let field_id_bytes: [u8; 4] = bytes[..4].try_into().unwrap();
+    Field::from_field_id(u32::from_be_bytes(field_id_bytes))
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -109,6 +109,7 @@
 pub mod document;
 mod facet;
 mod facet_options;
+pub(crate) mod indexing_term;
 mod schema;
 pub(crate) mod term;
 

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -1,4 +1,4 @@
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::net::Ipv6Addr;
 use std::{fmt, str};
 
@@ -18,38 +18,40 @@ use crate::DateTime;
 /// 4 bytes are the field id, and the last byte is the type.
 ///
 /// The serialized value `ValueBytes` is considered everything after the 4 first bytes (term id).
-#[derive(Clone)]
-pub struct Term<B = Vec<u8>>(B)
-where
-    B: AsRef<[u8]>;
+#[derive(Clone, Hash, PartialEq, Ord, PartialOrd, Eq)]
+pub struct Term(Vec<u8>);
 
 /// The number of bytes used as metadata by `Term`.
 const TERM_METADATA_LENGTH: usize = 5;
 
 impl Term {
-    /// Create a new Term with a buffer with a given capacity.
-    pub fn with_capacity(capacity: usize) -> Term {
-        let mut data = Vec::with_capacity(TERM_METADATA_LENGTH + capacity);
+    /// Create a new Term
+    pub fn new() -> Term {
+        let mut data = Vec::with_capacity(TERM_METADATA_LENGTH + 32);
         data.resize(TERM_METADATA_LENGTH, 0u8);
         Term(data)
     }
 
     pub(crate) fn with_type_and_field(typ: Type, field: Field) -> Term {
-        let mut term = Self::with_capacity(8);
-        term.set_field_and_type(field, typ);
-        term
+        Self::with_bytes_and_field_and_payload(typ, field, &[])
     }
 
     fn with_bytes_and_field_and_payload(typ: Type, field: Field, bytes: &[u8]) -> Term {
-        let mut term = Self::with_capacity(bytes.len());
+        let mut term = Self::new();
         term.set_field_and_type(field, typ);
         term.0.extend_from_slice(bytes);
         term
     }
 
+    /// Sets a fast value in the term.
+    ///
+    /// fast values are converted to u64 and then serialized using (8-byte) BigEndian
+    /// representation.
+    /// The use of BigEndian has the benefit of preserving
+    /// the natural order of the values.
     fn from_fast_value<T: FastValue>(field: Field, val: &T) -> Term {
         let mut term = Self::with_type_and_field(T::to_type(), field);
-        term.set_u64(val.to_u64());
+        term.set_bytes(val.to_u64().to_be_bytes().as_ref());
         term
     }
 
@@ -71,7 +73,7 @@ impl Term {
     /// Builds a term given a field, and a `Ipv6Addr`-value
     pub fn from_field_ip_addr(field: Field, ip_addr: Ipv6Addr) -> Term {
         let mut term = Self::with_type_and_field(Type::IpAddr, field);
-        term.set_ip_addr(ip_addr);
+        term.set_bytes(ip_addr.to_u128().to_be_bytes().as_ref());
         term
     }
 
@@ -122,40 +124,6 @@ impl Term {
         self.0[4] = typ.to_code();
     }
 
-    /// Sets a u64 value in the term.
-    ///
-    /// U64 are serialized using (8-byte) BigEndian
-    /// representation.
-    /// The use of BigEndian has the benefit of preserving
-    /// the natural order of the values.
-    pub fn set_u64(&mut self, val: u64) {
-        self.set_fast_value(val);
-    }
-
-    /// Sets a `i64` value in the term.
-    pub fn set_i64(&mut self, val: i64) {
-        self.set_fast_value(val);
-    }
-
-    /// Sets a `DateTime` value in the term.
-    pub fn set_date(&mut self, date: DateTime) {
-        self.set_fast_value(date);
-    }
-
-    /// Sets a `f64` value in the term.
-    pub fn set_f64(&mut self, val: f64) {
-        self.set_fast_value(val);
-    }
-
-    /// Sets a `bool` value in the term.
-    pub fn set_bool(&mut self, val: bool) {
-        self.set_fast_value(val);
-    }
-
-    fn set_fast_value<T: FastValue>(&mut self, val: T) {
-        self.set_bytes(val.to_u64().to_be_bytes().as_ref());
-    }
-
     /// Append a type marker + fast value to a term.
     /// This is used in JSON type to append a fast value after the path.
     ///
@@ -181,13 +149,8 @@ impl Term {
         self.0.extend(val.as_bytes().as_ref());
     }
 
-    /// Sets a `Ipv6Addr` value in the term.
-    pub fn set_ip_addr(&mut self, val: Ipv6Addr) {
-        self.set_bytes(val.to_u128().to_be_bytes().as_ref());
-    }
-
     /// Sets the value of a `Bytes` field.
-    pub fn set_bytes(&mut self, bytes: &[u8]) {
+    fn set_bytes(&mut self, bytes: &[u8]) {
         self.truncate_value_bytes(0);
         self.0.extend(bytes);
     }
@@ -206,26 +169,10 @@ impl Term {
         self.0.extend_from_slice(bytes);
         &mut self.0[len_before..]
     }
-}
-
-impl<B> Term<B>
-where
-    B: AsRef<[u8]>,
-{
-    /// Wraps a object holding bytes
-    pub fn wrap(data: B) -> Term<B> {
-        Term(data)
-    }
 
     /// Return the type of the term.
     pub fn typ(&self) -> Type {
         self.value().typ()
-    }
-
-    /// Returns the field.
-    pub fn field(&self) -> Field {
-        let field_id_bytes: [u8; 4] = (&self.0.as_ref()[..4]).try_into().unwrap();
-        Field::from_field_id(u32::from_be_bytes(field_id_bytes))
     }
 
     /// Returns the serialized representation of the value.
@@ -235,13 +182,7 @@ where
     /// If the term is a u64, its value is encoded according
     /// to `byteorder::BigEndian`.
     pub(crate) fn serialized_value_bytes(&self) -> &[u8] {
-        &self.0.as_ref()[TERM_METADATA_LENGTH..]
-    }
-
-    /// Returns the value of the term.
-    /// address or JSON path + value. (this does not include the field.)
-    pub fn value(&self) -> ValueBytes<&[u8]> {
-        ValueBytes::wrap(&self.0.as_ref()[4..])
+        &self.0[TERM_METADATA_LENGTH..]
     }
 
     /// Returns the serialized representation of Term.
@@ -250,8 +191,21 @@ where
     /// Do NOT rely on this byte representation in the index.
     /// This value is likely to change in the future.
     #[inline]
+    #[cfg(test)]
     pub fn serialized_term(&self) -> &[u8] {
         self.0.as_ref()
+    }
+
+    /// Returns the field.
+    pub fn field(&self) -> Field {
+        let field_id_bytes: [u8; 4] = (&self.0[..4]).try_into().unwrap();
+        Field::from_field_id(u32::from_be_bytes(field_id_bytes))
+    }
+
+    /// Returns the value of the term.
+    /// address or JSON path + value. (this does not include the field.)
+    pub fn value(&self) -> ValueBytes<&[u8]> {
+        ValueBytes::wrap(&self.0[4..])
     }
 }
 
@@ -268,12 +222,10 @@ where
 /// The nested ValueBytes in JSON is never of type JSON. (there's no recursion)
 #[derive(Clone)]
 pub struct ValueBytes<B>(B)
-where
-    B: AsRef<[u8]>;
+where B: AsRef<[u8]>;
 
 impl<B> ValueBytes<B>
-where
-    B: AsRef<[u8]>,
+where B: AsRef<[u8]>
 {
     /// Wraps a object holding bytes
     pub fn wrap(data: B) -> ValueBytes<B> {
@@ -285,16 +237,8 @@ where
     }
 
     /// Return the type of the term.
-    pub fn typ(&self) -> Type {
+    pub(crate) fn typ(&self) -> Type {
         Type::from_code(self.typ_code()).expect("The term has an invalid type code")
-    }
-
-    /// Returns the `u64` value stored in a term.
-    ///
-    /// Returns `None` if the term is not of the u64 type, or if the term byte representation
-    /// is invalid.
-    pub fn as_u64(&self) -> Option<u64> {
-        self.get_fast_type::<u64>()
     }
 
     fn get_fast_type<T: FastValue>(&self) -> Option<T> {
@@ -304,38 +248,6 @@ where
         let value_bytes = self.value_bytes();
         let value_u64 = u64::from_be_bytes(value_bytes.try_into().ok()?);
         Some(T::from_u64(value_u64))
-    }
-
-    /// Returns the `i64` value stored in a term.
-    ///
-    /// Returns `None` if the term is not of the i64 type, or if the term byte representation
-    /// is invalid.
-    pub fn as_i64(&self) -> Option<i64> {
-        self.get_fast_type::<i64>()
-    }
-
-    /// Returns the `f64` value stored in a term.
-    ///
-    /// Returns `None` if the term is not of the f64 type, or if the term byte representation
-    /// is invalid.
-    pub fn as_f64(&self) -> Option<f64> {
-        self.get_fast_type::<f64>()
-    }
-
-    /// Returns the `bool` value stored in a term.
-    ///
-    /// Returns `None` if the term is not of the bool type, or if the term byte representation
-    /// is invalid.
-    pub fn as_bool(&self) -> Option<bool> {
-        self.get_fast_type::<bool>()
-    }
-
-    /// Returns the `Date` value stored in a term.
-    ///
-    /// Returns `None` if the term is not of the Date type, or if the term byte representation
-    /// is invalid.
-    pub fn as_date(&self) -> Option<DateTime> {
-        self.get_fast_type::<DateTime>()
     }
 
     /// Returns the text associated with the term.
@@ -353,7 +265,7 @@ where
     ///
     /// Returns `None` if the field is not of facet type
     /// or if the bytes are not valid utf-8.
-    pub fn as_facet(&self) -> Option<Facet> {
+    pub(crate) fn as_facet(&self) -> Option<Facet> {
         if self.typ() != Type::Facet {
             return None;
         }
@@ -364,7 +276,7 @@ where
     /// Returns the bytes associated with the term.
     ///
     /// Returns `None` if the field is not of bytes type.
-    pub fn as_bytes(&self) -> Option<&[u8]> {
+    pub(crate) fn as_bytes(&self) -> Option<&[u8]> {
         if self.typ() != Type::Bytes {
             return None;
         }
@@ -372,21 +284,12 @@ where
     }
 
     /// Returns a `Ipv6Addr` value from the term.
-    pub fn as_ip_addr(&self) -> Option<Ipv6Addr> {
+    pub(crate) fn as_ip_addr(&self) -> Option<Ipv6Addr> {
         if self.typ() != Type::IpAddr {
             return None;
         }
         let ip_u128 = u128::from_be_bytes(self.value_bytes().try_into().ok()?);
         Some(Ipv6Addr::from_u128(ip_u128))
-    }
-
-    /// Returns the json path type.
-    ///
-    /// Returns `None` if the value is not JSON.
-    pub fn json_path_type(&self) -> Option<Type> {
-        let json_value_bytes = self.as_json_value_bytes()?;
-
-        Some(json_value_bytes.typ())
     }
 
     /// Returns the json path bytes (including the JSON_END_OF_PATH byte),
@@ -403,18 +306,6 @@ where
         // split at pos + 1, so that json_path_bytes includes the JSON_END_OF_PATH byte.
         let (json_path_bytes, term) = bytes.split_at(pos + 1);
         Some((json_path_bytes, ValueBytes::wrap(term)))
-    }
-
-    /// Returns the encoded ValueBytes after the json path.
-    ///
-    /// Returns `None` if the value is not JSON.
-    pub(crate) fn as_json_value_bytes(&self) -> Option<ValueBytes<&[u8]>> {
-        if self.typ() != Type::Json {
-            return None;
-        }
-        let bytes = self.value_bytes();
-        let pos = bytes.iter().cloned().position(|b| b == JSON_END_OF_PATH)?;
-        Some(ValueBytes::wrap(&bytes[pos + 1..]))
     }
 
     /// Returns the serialized value of ValueBytes without the type.
@@ -439,20 +330,20 @@ where
                 write_opt(f, s)?;
             }
             Type::U64 => {
-                write_opt(f, self.as_u64())?;
+                write_opt(f, self.get_fast_type::<u64>())?;
             }
             Type::I64 => {
-                write_opt(f, self.as_i64())?;
+                write_opt(f, self.get_fast_type::<i64>())?;
             }
             Type::F64 => {
-                write_opt(f, self.as_f64())?;
+                write_opt(f, self.get_fast_type::<f64>())?;
             }
             Type::Bool => {
-                write_opt(f, self.as_bool())?;
+                write_opt(f, self.get_fast_type::<bool>())?;
             }
             // TODO pretty print these types too.
             Type::Date => {
-                write_opt(f, self.as_date())?;
+                write_opt(f, self.get_fast_type::<DateTime>())?;
             }
             Type::Facet => {
                 write_opt(f, self.as_facet())?;
@@ -478,44 +369,6 @@ where
     }
 }
 
-impl<B> Ord for Term<B>
-where
-    B: AsRef<[u8]>,
-{
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.serialized_term().cmp(other.serialized_term())
-    }
-}
-
-impl<B> PartialOrd for Term<B>
-where
-    B: AsRef<[u8]>,
-{
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<B> PartialEq for Term<B>
-where
-    B: AsRef<[u8]>,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.serialized_term() == other.serialized_term()
-    }
-}
-
-impl<B> Eq for Term<B> where B: AsRef<[u8]> {}
-
-impl<B> Hash for Term<B>
-where
-    B: AsRef<[u8]>,
-{
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.as_ref().hash(state)
-    }
-}
-
 fn write_opt<T: std::fmt::Debug>(f: &mut fmt::Formatter, val_opt: Option<T>) -> fmt::Result {
     if let Some(val) = val_opt {
         write!(f, "{val:?}")?;
@@ -523,14 +376,11 @@ fn write_opt<T: std::fmt::Debug>(f: &mut fmt::Formatter, val_opt: Option<T>) -> 
     Ok(())
 }
 
-impl<B> fmt::Debug for Term<B>
-where
-    B: AsRef<[u8]>,
-{
+impl fmt::Debug for Term {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let field_id = self.field().field_id();
         write!(f, "Term(field={field_id}, ")?;
-        let value_bytes = ValueBytes::wrap(&self.0.as_ref()[4..]);
+        let value_bytes = ValueBytes::wrap(&self.0[4..]);
         value_bytes.debug_value_bytes(f)?;
         write!(f, ")",)?;
         Ok(())
@@ -551,39 +401,5 @@ mod tests {
         assert_eq!(term.field(), title_field);
         assert_eq!(term.typ(), Type::Str);
         assert_eq!(term.value().as_str(), Some("test"))
-    }
-
-    /// Size (in bytes) of the buffer of a fast value (u64, i64, f64, or date) term.
-    /// <field> + <type byte> + <value len>
-    ///
-    /// - <field> is a big endian encoded u32 field id
-    /// - <type_byte>'s most significant bit expresses whether the term is a json term or not
-    /// The remaining 7 bits are used to encode the type of the value.
-    /// If this is a JSON term, the type is the type of the leaf of the json.
-    ///
-    /// - <value> is,  if this is not the json term, a binary representation specific to the type.
-    /// If it is a JSON Term, then it is prepended with the path that leads to this leaf value.
-    const FAST_VALUE_TERM_LEN: usize = 4 + 1 + 8;
-
-    #[test]
-    pub fn test_term_u64() {
-        let mut schema_builder = Schema::builder();
-        let count_field = schema_builder.add_u64_field("count", INDEXED);
-        let term = Term::from_field_u64(count_field, 983u64);
-        assert_eq!(term.field(), count_field);
-        assert_eq!(term.typ(), Type::U64);
-        assert_eq!(term.serialized_term().len(), FAST_VALUE_TERM_LEN);
-        assert_eq!(term.value().as_u64(), Some(983u64))
-    }
-
-    #[test]
-    pub fn test_term_bool() {
-        let mut schema_builder = Schema::builder();
-        let bool_field = schema_builder.add_bool_field("bool", INDEXED);
-        let term = Term::from_field_bool(bool_field, true);
-        assert_eq!(term.field(), bool_field);
-        assert_eq!(term.typ(), Type::Bool);
-        assert_eq!(term.serialized_term().len(), FAST_VALUE_TERM_LEN);
-        assert_eq!(term.value().as_bool(), Some(true))
     }
 }

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -20,6 +20,11 @@ use crate::DateTime;
 /// The serialized value `ValueBytes` is considered everything after the 4 first bytes (term id).
 #[derive(Clone, Hash, PartialEq, Ord, PartialOrd, Eq)]
 pub struct Term(Vec<u8>);
+impl Default for Term {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// The number of bytes used as metadata by `Term`.
 const TERM_METADATA_LENGTH: usize = 5;

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -20,7 +20,8 @@ use crate::DateTime;
 /// The serialized value `ValueBytes` is considered everything after the 4 first bytes (term id).
 #[derive(Clone)]
 pub struct Term<B = Vec<u8>>(B)
-where B: AsRef<[u8]>;
+where
+    B: AsRef<[u8]>;
 
 /// The number of bytes used as metadata by `Term`.
 const TERM_METADATA_LENGTH: usize = 5;
@@ -115,12 +116,6 @@ impl Term {
         Term::with_bytes_and_field_and_payload(Type::Bytes, field, bytes)
     }
 
-    /// Removes the value_bytes and set the field and type code.
-    pub(crate) fn clear_with_field_and_type(&mut self, typ: Type, field: Field) {
-        self.truncate_value_bytes(0);
-        self.set_field_and_type(field, typ);
-    }
-
     /// Removes the value_bytes and set the type code.
     pub fn clear_with_type(&mut self, typ: Type) {
         self.truncate_value_bytes(0);
@@ -202,11 +197,6 @@ impl Term {
         self.0.truncate(len + TERM_METADATA_LENGTH);
     }
 
-    /// The length of the bytes.
-    pub fn len_bytes(&self) -> usize {
-        self.0.len() - TERM_METADATA_LENGTH
-    }
-
     /// Appends value bytes to the Term.
     ///
     /// This function returns the segment that has just been added.
@@ -216,27 +206,11 @@ impl Term {
         self.0.extend_from_slice(bytes);
         &mut self.0[len_before..]
     }
-
-    /// Appends json path bytes to the Term.
-    /// If the path contains 0 bytes, they are replaced by a "0" string.
-    /// The 0 byte is used to mark the end of the path.
-    ///
-    /// This function returns the segment that has just been added.
-    #[inline]
-    pub fn append_path(&mut self, bytes: &[u8]) -> &mut [u8] {
-        let len_before = self.0.len();
-        if bytes.contains(&0u8) {
-            self.0
-                .extend(bytes.iter().map(|&b| if b == 0 { b'0' } else { b }));
-        } else {
-            self.0.extend_from_slice(bytes);
-        }
-        &mut self.0[len_before..]
-    }
 }
 
 impl<B> Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     /// Wraps a object holding bytes
     pub fn wrap(data: B) -> Term<B> {
@@ -260,7 +234,7 @@ where B: AsRef<[u8]>
     /// If the term is a string, its value is utf-8 encoded.
     /// If the term is a u64, its value is encoded according
     /// to `byteorder::BigEndian`.
-    pub fn serialized_value_bytes(&self) -> &[u8] {
+    pub(crate) fn serialized_value_bytes(&self) -> &[u8] {
         &self.0.as_ref()[TERM_METADATA_LENGTH..]
     }
 
@@ -294,10 +268,12 @@ where B: AsRef<[u8]>
 /// The nested ValueBytes in JSON is never of type JSON. (there's no recursion)
 #[derive(Clone)]
 pub struct ValueBytes<B>(B)
-where B: AsRef<[u8]>;
+where
+    B: AsRef<[u8]>;
 
 impl<B> ValueBytes<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     /// Wraps a object holding bytes
     pub fn wrap(data: B) -> ValueBytes<B> {
@@ -503,7 +479,8 @@ where B: AsRef<[u8]>
 }
 
 impl<B> Ord for Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.serialized_term().cmp(other.serialized_term())
@@ -511,7 +488,8 @@ where B: AsRef<[u8]>
 }
 
 impl<B> PartialOrd for Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
@@ -519,7 +497,8 @@ where B: AsRef<[u8]>
 }
 
 impl<B> PartialEq for Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     fn eq(&self, other: &Self) -> bool {
         self.serialized_term() == other.serialized_term()
@@ -529,7 +508,8 @@ where B: AsRef<[u8]>
 impl<B> Eq for Term<B> where B: AsRef<[u8]> {}
 
 impl<B> Hash for Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.as_ref().hash(state)
@@ -544,7 +524,8 @@ fn write_opt<T: std::fmt::Debug>(f: &mut fmt::Formatter, val_opt: Option<T>) -> 
 }
 
 impl<B> fmt::Debug for Term<B>
-where B: AsRef<[u8]>
+where
+    B: AsRef<[u8]>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let field_id = self.field().field_id();


### PR DESCRIPTION
- **split term and indexing term**
- **add JsonTermSerializer**
- **cleanup**
- **clippy**

This splits `Term` into `Term` and `IndexingTerm`. `Term` is used for querying, `IndexingTerm` during indexing.
This allows to reduce the complexity of `Term` and a more compact format for `IndexingTerm` by dropping the `type` marker at byte 5. 

Part of: https://github.com/quickwit-oss/tantivy/issues/1795