### PR TITLE
Avoid converting BTreeMap to Vec in TantivyDocument::add_object.

### DIFF
--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -489,7 +489,6 @@ fn remap_and_write(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
 
     use tempfile::TempDir;
@@ -799,8 +798,7 @@ mod tests {
         let json_field = schema_builder.add_json_field("json", STORED | TEXT);
         let schema = schema_builder.build();
         let mut doc = TantivyDocument::default();
-        let json_val: BTreeMap<String, crate::schema::OwnedValue> =
-            serde_json::from_str(r#"{"mykey": "repeated token token"}"#).unwrap();
+        let json_val = serde_json::from_str(r#"{"mykey": "repeated token token"}"#).unwrap();
         doc.add_object(json_field, json_val);
         let index = Index::create_in_ram(schema);
         let mut writer = index.writer_for_tests().unwrap();

--- a/src/schema/document/mod.rs
+++ b/src/schema/document/mod.rs
@@ -173,7 +173,8 @@ pub use self::de::{
     ValueDeserialize, ValueDeserializer, ValueType, ValueVisitor,
 };
 pub use self::default_document::{
-    CompactDocArrayIter, CompactDocObjectIter, CompactDocValue, DocParsingError, TantivyDocument,
+    CompactDocArrayIter, CompactDocObjectIter, CompactDocValue, DocParsingError, FlatObject,
+    TantivyDocument,
 };
 pub use self::owned_value::OwnedValue;
 pub(crate) use self::se::BinaryDocumentSerializer;

--- a/src/schema/document/owned_value.rs
+++ b/src/schema/document/owned_value.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::fmt;
 use std::net::Ipv6Addr;
 
@@ -369,10 +368,9 @@ impl From<PreTokenizedString> for OwnedValue {
     }
 }
 
-impl From<BTreeMap<String, OwnedValue>> for OwnedValue {
-    fn from(object: BTreeMap<String, OwnedValue>) -> OwnedValue {
-        let key_values = object.into_iter().collect();
-        OwnedValue::Object(key_values)
+impl From<Vec<(String, OwnedValue)>> for OwnedValue {
+    fn from(object: Vec<(String, OwnedValue)>) -> OwnedValue {
+        OwnedValue::Object(object)
     }
 }
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -130,7 +130,9 @@ use columnar::ColumnType;
 
 pub use self::bytes_options::BytesOptions;
 pub use self::date_time_options::{DateOptions, DateTimePrecision, DATE_TIME_PRECISION_INDEXED};
-pub use self::document::{DocParsingError, Document, OwnedValue, TantivyDocument, Value};
+pub use self::document::{
+    DocParsingError, Document, FlatObject, OwnedValue, TantivyDocument, Value,
+};
 pub(crate) use self::facet::FACET_SEP_BYTE;
 pub use self::facet::{Facet, FacetParseError};
 pub use self::facet_options::FacetOptions;


### PR DESCRIPTION
For the next breaking release when the immediate issues with 0.22.x are resolved.