### PR TITLE
modify fastfield range query heuristic

### DIFF
--- a/src/query/range_query/fast_field_range_query.rs
+++ b/src/query/range_query/fast_field_range_query.rs
@@ -174,7 +174,7 @@ impl<T: Send + Sync + PartialOrd + Copy + Debug + 'static> DocSet for RangeDocSe
     }
 
     fn size_hint(&self) -> u32 {
-        0 // heuristic possible by checking number of hits when fetching a block
+        self.column.num_docs()
     }
 }
 


### PR DESCRIPTION
the current heuristic always put such query first inside intersection, but benchmarks indicate putting them last is beneficial. I also tried a "smarter" heuristic assuming uniform distribution of timestamps, but it ended up slower overall