### PR TITLE
allow more JSON values, fix i64 special case

### DIFF
--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -417,7 +417,7 @@ fn test_non_text_json_term_freq() {
     let inv_idx = segment_reader.inverted_index(field).unwrap();
 
     let mut term = Term::from_field_json_path(field, "tenant_id", false);
-    term.append_type_and_fast_value(75u64);
+    term.append_type_and_fast_value(75i64);
 
     let postings = inv_idx
         .read_postings(&term, IndexRecordOption::WithFreqsAndPositions)
@@ -451,7 +451,7 @@ fn test_non_text_json_term_freq_bitpacked() {
     let inv_idx = segment_reader.inverted_index(field).unwrap();
 
     let mut term = Term::from_field_json_path(field, "tenant_id", false);
-    term.append_type_and_fast_value(75u64);
+    term.append_type_and_fast_value(75i64);
 
     let mut postings = inv_idx
         .read_postings(&term, IndexRecordOption::WithFreqsAndPositions)


### PR DESCRIPTION
This changes three things:
- Reuse positions_per_path hashmap instead of allocating one per
  indexed JSON value
- Try to cast u64 values to i64 to streamline with search behaviour
- Allow top level json values to be of any type, instead of limiting it
  to JSON objects. Remove special JSON object handling method.

TODO: We probably should also try to check f64 to i64 and u64 when
indexing, as values may get converted to f64 by the JSON parser
