### PR TITLE
feat(query): Make `BooleanQuery` supports `minimum_number_should_match`

### DIFF
--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -27,8 +27,7 @@ use crate::schema::{IndexRecordOption, Term};
 /// use tantivy::IndexWriter;
 ///
 /// fn main() -> tantivy::Result<()> {
-///    use tantivy::query::QueryClone;
-/// let mut schema_builder = Schema::builder();
+///    let mut schema_builder = Schema::builder();
 ///    let title = schema_builder.add_text_field("title", TEXT);
 ///    let body = schema_builder.add_text_field("body", TEXT);
 ///    let schema = schema_builder.build();
@@ -126,9 +125,10 @@ use crate::schema::{IndexRecordOption, Term};
 ///         (Occur::Should, girl_term_query.box_clone()),
 ///         (Occur::Should, diary_term_query.box_clone()),
 ///    ], 2);
-///    // Return documents contains 'Diary Cow', 'Diary Girl' or 'Cow Girl'
+///    // Return documents contains "Diary Cow", "Diary Girl" or "Cow Girl"
+///    // Notice: "Diary" isn't "Dairy". ;-)
 ///    let count5 = searcher.search(&minimum_required_query, &Count)?;
-///    assert_eq!(count5, 3);
+///    assert_eq!(count5, 1);
 ///    Ok(())
 /// }
 /// ```
@@ -248,12 +248,13 @@ impl BooleanQuery {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::BooleanQuery;
     use crate::collector::{Count, DocSetCollector};
     use crate::query::{Query, QueryClone, QueryParser, TermQuery};
     use crate::schema::{Field, IndexRecordOption, Schema, TEXT};
     use crate::{DocAddress, DocId, Index, Term};
-    use std::collections::HashSet;
 
     fn create_test_index() -> crate::Result<Index> {
         let mut schema_builder = Schema::builder();

--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -187,17 +187,17 @@ impl BooleanQuery {
         // If the bool query includes at least one should clause
         // and no Must or MustNot clauses, the default value is 1. Otherwise, the default value is
         // 0. Keep pace with Elasticsearch.
-        let mut default_minimum_required = 0;
+        let mut minimum_required = 0;
         for (occur, _) in &subqueries {
             match occur {
-                Occur::Should => default_minimum_required = 1,
+                Occur::Should => minimum_required = 1,
                 Occur::Must | Occur::MustNot => {
-                    default_minimum_required = 0;
+                    minimum_required = 0;
                     break;
                 }
             }
         }
-        Self::with_minimum_required_clauses(subqueries, default_minimum_required)
+        Self::with_minimum_required_clauses(subqueries, minimum_required)
     }
 
     /// Create a new boolean query with minimum number of required should clauses specified.

--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -27,7 +27,8 @@ use crate::schema::{IndexRecordOption, Term};
 /// use tantivy::IndexWriter;
 ///
 /// fn main() -> tantivy::Result<()> {
-///    let mut schema_builder = Schema::builder();
+///    use tantivy::query::QueryClone;
+/// let mut schema_builder = Schema::builder();
 ///    let title = schema_builder.add_text_field("title", TEXT);
 ///    let body = schema_builder.add_text_field("body", TEXT);
 ///    let schema = schema_builder.build();
@@ -66,6 +67,10 @@ use crate::schema::{IndexRecordOption, Term};
 ///        Term::from_field_text(title, "diary"),
 ///        IndexRecordOption::Basic,
 ///    ));
+///    let cow_term_query: Box<dyn Query> = Box::new(TermQuery::new(
+///        Term::from_field_text(title, "cow"),
+///        IndexRecordOption::Basic
+///    ));
 ///    // A TermQuery with "found" in the body
 ///    let body_term_query: Box<dyn Query> = Box::new(TermQuery::new(
 ///        Term::from_field_text(body, "found"),
@@ -74,7 +79,7 @@ use crate::schema::{IndexRecordOption, Term};
 ///    // TermQuery "diary" must and "girl" must not be present
 ///    let queries_with_occurs1 = vec![
 ///        (Occur::Must, diary_term_query.box_clone()),
-///        (Occur::MustNot, girl_term_query),
+///        (Occur::MustNot, girl_term_query.box_clone()),
 ///    ];
 ///    // Make a BooleanQuery equivalent to
 ///    // title:+diary title:-girl
@@ -82,15 +87,10 @@ use crate::schema::{IndexRecordOption, Term};
 ///    let count1 = searcher.search(&diary_must_and_girl_mustnot, &Count)?;
 ///    assert_eq!(count1, 1);
 ///
-///    // TermQuery for "cow" in the title
-///    let cow_term_query: Box<dyn Query> = Box::new(TermQuery::new(
-///        Term::from_field_text(title, "cow"),
-///        IndexRecordOption::Basic,
-///    ));
 ///    // "title:diary OR title:cow"
 ///    let title_diary_or_cow = BooleanQuery::new(vec![
 ///        (Occur::Should, diary_term_query.box_clone()),
-///        (Occur::Should, cow_term_query),
+///        (Occur::Should, cow_term_query.box_clone()),
 ///    ]);
 ///    let count2 = searcher.search(&title_diary_or_cow, &Count)?;
 ///    assert_eq!(count2, 4);
@@ -118,21 +118,38 @@ use crate::schema::{IndexRecordOption, Term};
 ///    ]);
 ///    let count4 = searcher.search(&nested_query, &Count)?;
 ///    assert_eq!(count4, 1);
+///
+///    // You may call `with_minimum_required_clauses` to
+///    // specify the number of should clauses the returned documents must match.
+///    let minimum_required_query = BooleanQuery::with_minimum_required_clauses(vec![
+///         (Occur::Should, cow_term_query.box_clone()),
+///         (Occur::Should, girl_term_query.box_clone()),
+///         (Occur::Should, diary_term_query.box_clone()),
+///    ], 2);
+///    // Return documents contains 'Diary Cow', 'Diary Girl' or 'Cow Girl'
+///    let count5 = searcher.search(&minimum_required_query, &Count)?;
+///    assert_eq!(count5, 3);
 ///    Ok(())
 /// }
 /// ```
 #[derive(Debug)]
 pub struct BooleanQuery {
     subqueries: Vec<(Occur, Box<dyn Query>)>,
+    minimum_number_should_match: usize,
 }
 
 impl Clone for BooleanQuery {
     fn clone(&self) -> Self {
-        self.subqueries
+        let subqueries = self
+            .subqueries
             .iter()
             .map(|(occur, subquery)| (*occur, subquery.box_clone()))
             .collect::<Vec<_>>()
-            .into()
+            .into();
+        Self {
+            subqueries,
+            minimum_number_should_match: self.minimum_number_should_match,
+        }
     }
 }
 
@@ -149,8 +166,9 @@ impl Query for BooleanQuery {
             .iter()
             .map(|(occur, subquery)| Ok((*occur, subquery.weight(enable_scoring)?)))
             .collect::<crate::Result<_>>()?;
-        Ok(Box::new(BooleanWeight::new(
+        Ok(Box::new(BooleanWeight::with_minimum_number_should_match(
             sub_weights,
+            self.minimum_number_should_match,
             enable_scoring.is_scoring_enabled(),
             Box::new(SumWithCoordsCombiner::default),
         )))
@@ -166,7 +184,28 @@ impl Query for BooleanQuery {
 impl BooleanQuery {
     /// Creates a new boolean query.
     pub fn new(subqueries: Vec<(Occur, Box<dyn Query>)>) -> BooleanQuery {
-        BooleanQuery { subqueries }
+        Self::with_minimum_required_clauses(subqueries, 1)
+    }
+
+    /// Create a new boolean query with minimum number of required should clauses specified.
+    pub fn with_minimum_required_clauses(
+        subqueries: Vec<(Occur, Box<dyn Query>)>,
+        minimum_number_should_match: usize,
+    ) -> BooleanQuery {
+        BooleanQuery {
+            subqueries,
+            minimum_number_should_match,
+        }
+    }
+
+    /// Getter for `minimum_number_should_match`
+    pub fn get_minimum_number_should_match(&self) -> usize {
+        self.minimum_number_should_match
+    }
+
+    /// Setter for `minimum_number_should_match`
+    pub fn set_minimum_number_should_match(&mut self, value: usize) {
+        self.minimum_number_should_match = value;
     }
 
     /// Returns the intersection of the queries.
@@ -179,6 +218,12 @@ impl BooleanQuery {
     pub fn union(queries: Vec<Box<dyn Query>>) -> BooleanQuery {
         let subqueries = queries.into_iter().map(|s| (Occur::Should, s)).collect();
         BooleanQuery::new(subqueries)
+    }
+
+    /// Returns the union of the queries with minimum required clause.
+    pub fn union_with_minimum_required(queries: Vec<Box<dyn Query>>, mr: usize) -> BooleanQuery {
+        let subqueries = queries.into_iter().map(|s| (Occur::Should, s)).collect();
+        BooleanQuery::with_minimum_required_clauses(subqueries, mr)
     }
 
     /// Helper method to create a boolean query matching a given list of terms.
@@ -205,9 +250,10 @@ impl BooleanQuery {
 mod tests {
     use super::BooleanQuery;
     use crate::collector::{Count, DocSetCollector};
-    use crate::query::{QueryClone, QueryParser, TermQuery};
-    use crate::schema::{IndexRecordOption, Schema, TEXT};
-    use crate::{DocAddress, Index, Term};
+    use crate::query::{Query, QueryClone, QueryParser, TermQuery};
+    use crate::schema::{Field, IndexRecordOption, Schema, TEXT};
+    use crate::{DocAddress, DocId, Index, Term};
+    use std::collections::HashSet;
 
     fn create_test_index() -> crate::Result<Index> {
         let mut schema_builder = Schema::builder();
@@ -221,6 +267,73 @@ mod tests {
         writer.add_document(doc!(text=>"a d"))?;
         writer.commit()?;
         Ok(index)
+    }
+
+    #[test]
+    fn test_minimum_required() -> crate::Result<()> {
+        fn create_test_index_with<T: IntoIterator<Item = &'static str>>(
+            docs: T,
+        ) -> crate::Result<Index> {
+            let mut schema_builder = Schema::builder();
+            let text = schema_builder.add_text_field("text", TEXT);
+            let schema = schema_builder.build();
+            let index = Index::create_in_ram(schema);
+            let mut writer = index.writer_for_tests()?;
+            for doc in docs {
+                writer.add_document(doc!(text => doc))?;
+            }
+            writer.commit()?;
+            Ok(index)
+        }
+        fn create_boolean_query_with_mr<T: IntoIterator<Item = &'static str>>(
+            queries: T,
+            field: Field,
+            mr: usize,
+        ) -> BooleanQuery {
+            let terms = queries
+                .into_iter()
+                .map(|t| Term::from_field_text(field, t))
+                .map(|t| TermQuery::new(t, IndexRecordOption::Basic))
+                .map(|q| -> Box<dyn Query> { Box::new(q) })
+                .collect();
+            BooleanQuery::union_with_minimum_required(terms, mr)
+        }
+        fn check_doc_id<T: IntoIterator<Item = DocId>>(
+            expected: T,
+            actually: HashSet<DocAddress>,
+            seg: u32,
+        ) {
+            assert_eq!(
+                actually,
+                expected
+                    .into_iter()
+                    .map(|id| DocAddress::new(seg, id))
+                    .collect()
+            );
+        }
+        let index = create_test_index_with(["a b c", "a c e", "d f g", "z z z", "c i b"])?;
+        let searcher = index.reader()?.searcher();
+        let text = index.schema().get_field("text").unwrap();
+        // Documents contains 'a c' 'a z' 'a i' 'c z' 'c i' or 'z i' shall be return.
+        let q1 = create_boolean_query_with_mr(["a", "c", "z", "i"], text, 2);
+        let docs = searcher.search(&q1, &DocSetCollector)?;
+        check_doc_id([0, 1, 4], docs, 0);
+        // Documents contains 'a b c', 'a b e', 'a c e' or 'b c e' shall be return.
+        let q2 = create_boolean_query_with_mr(["a", "b", "c", "e"], text, 3);
+        let docs = searcher.search(&q2, &DocSetCollector)?;
+        check_doc_id([0, 1], docs, 0);
+        // Nothing queried since minimum_required is too large.
+        let q3 = create_boolean_query_with_mr(["a", "b"], text, 3);
+        let docs = searcher.search(&q3, &DocSetCollector)?;
+        assert!(docs.is_empty());
+        // When mr is set to zero or one, there are no difference with `Boolean::Union`.
+        let q4 = create_boolean_query_with_mr(["a", "z"], text, 1);
+        let docs = searcher.search(&q4, &DocSetCollector)?;
+        check_doc_id([0, 1, 3], docs, 0);
+        let q5 = create_boolean_query_with_mr(["a", "b"], text, 0);
+        let docs = searcher.search(&q5, &DocSetCollector)?;
+        check_doc_id([0, 1, 4], docs, 0);
+        Ok(())
     }
 
     #[test]

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -111,6 +111,7 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
         }
     }
 
+    /// Create a new boolean weight with minimum number of required should clauses specified.
     pub fn with_minimum_number_should_match(
         weights: Vec<(Occur, Box<dyn Weight>)>,
         minimum_number_should_match: usize,
@@ -222,18 +223,16 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
             return weight.scorer(reader, boost);
         }
         return if self.scoring_enabled {
-            self
-                .complex_scorer(reader, boost, &self.score_combiner_fn)
+            self.complex_scorer(reader, boost, &self.score_combiner_fn)
                 .map(|specialized_scorer| {
                     into_box_scorer(specialized_scorer, &self.score_combiner_fn)
                 })
         } else {
-            self
-                .complex_scorer(reader, boost, DoNothingCombiner::default)
+            self.complex_scorer(reader, boost, DoNothingCombiner::default)
                 .map(|specialized_scorer| {
                     into_box_scorer(specialized_scorer, DoNothingCombiner::default)
                 })
-        }
+        };
     }
 
     fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation> {

--- a/src/query/disjunction.rs
+++ b/src/query/disjunction.rs
@@ -5,7 +5,7 @@ use crate::query::score_combiner::DoNothingCombiner;
 use crate::query::{ScoreCombiner, Scorer};
 use crate::{DocId, DocSet, Score, TERMINATED};
 
-/// `Disjunction` is responsible for merging `DocSet` from multiply
+/// `Disjunction` is responsible for merging `DocSet` from multiple
 /// source. Specifically, It takes the union of two or more `DocSet`s
 /// then filtering out elements that appear fewer times than a
 /// specified threshold.

--- a/src/query/disjunction.rs
+++ b/src/query/disjunction.rs
@@ -134,11 +134,10 @@ impl<TScorer: Scorer, TScoreCombiner: ScoreCombiner> Scorer
 mod tests {
     use std::collections::BTreeMap;
 
+    use super::DisjunctionScorer;
     use crate::query::score_combiner::DoNothingCombiner;
     use crate::query::{ConstScorer, Scorer, SumCombiner, VecDocSet};
     use crate::{DocId, DocSet, Score, TERMINATED};
-
-    use super::DisjunctionScorer;
 
     fn conjunct<T: Ord + Copy>(arrays: &[Vec<T>], pass_line: usize) -> Vec<T> {
         let mut counts = BTreeMap::new();

--- a/src/query/disjunction.rs
+++ b/src/query/disjunction.rs
@@ -1,0 +1,285 @@
+use std::cmp::{Ordering, Reverse};
+use std::collections::BinaryHeap;
+
+use crate::query::score_combiner::DoNothingCombiner;
+use crate::query::{ScoreCombiner, Scorer};
+use crate::{DocId, DocSet, Score, TERMINATED};
+
+pub struct DisjunctionScorer<TScorer, TScoreCombiner = DoNothingCombiner> {
+    chains: MinHeap<TScorer>,
+    minimum_matches_required: usize,
+    score_combiner: TScoreCombiner,
+
+    doc: DocId,
+    score: Score,
+    is_end: bool,
+}
+
+// TODO: Try reconstruct, it's ugly.
+type MinHeap<T> = BinaryHeap<Reverse<ScorerWrapper<T>>>;
+
+#[repr(transparent)]
+struct ScorerWrapper<T>(T);
+
+impl<T: Scorer> PartialEq for ScorerWrapper<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.doc() == other.0.doc()
+    }
+}
+
+impl<T: Scorer> Eq for ScorerWrapper<T> {}
+
+impl<T: Scorer> PartialOrd for ScorerWrapper<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: Scorer> Ord for ScorerWrapper<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.doc().cmp(&other.0.doc())
+    }
+}
+
+impl<TScorer: Scorer, TScoreCombiner: ScoreCombiner> DisjunctionScorer<TScorer, TScoreCombiner> {
+    pub fn new<T: IntoIterator<Item = TScorer>>(
+        docsets: T,
+        score_combiner: TScoreCombiner,
+        minimum_matches_required: usize,
+    ) -> Self {
+        debug_assert!(
+            minimum_matches_required > 1,
+            "union scorer works better if just one matches required"
+        );
+        let chains: MinHeap<_> = docsets
+            .into_iter()
+            .map(|doc| Reverse(ScorerWrapper(doc)))
+            .collect();
+        let mut disjunction = Self {
+            chains,
+            score_combiner,
+            doc: TERMINATED,
+            minimum_matches_required,
+            score: 0.0,
+            is_end: false,
+        };
+        if minimum_matches_required > disjunction.chains.len() {
+            // Mark it as empty.
+            disjunction.is_end = true;
+            return disjunction;
+        }
+        disjunction.advance();
+        disjunction
+    }
+}
+
+impl<TScorer: Scorer, TScoreCombiner: ScoreCombiner> DocSet
+    for DisjunctionScorer<TScorer, TScoreCombiner>
+{
+    fn advance(&mut self) -> DocId {
+        let mut votes = 0;
+        while let Some(mut candidate) = self.chains.pop() {
+            let next = candidate.0 .0.doc();
+            if next != TERMINATED {
+                // Peek next doc.
+                if self.doc != next {
+                    if votes >= self.minimum_matches_required {
+                        self.chains.push(candidate);
+                        self.score = self.score_combiner.score();
+                        return self.doc;
+                    }
+                    // Reset votes and scores.
+                    votes = 0;
+                    self.doc = next;
+                    self.score_combiner.clear();
+                }
+                votes += 1;
+                self.score_combiner.update(&mut candidate.0 .0);
+                candidate.0 .0.advance();
+                self.chains.push(candidate);
+            }
+        }
+        if votes < self.minimum_matches_required {
+            self.doc = TERMINATED;
+            self.is_end = true;
+        }
+        return self.doc;
+    }
+
+    fn doc(&self) -> DocId {
+        if self.is_end {
+            return TERMINATED;
+        }
+        self.doc
+    }
+
+    fn size_hint(&self) -> u32 {
+        self.chains
+            .iter()
+            .map(|docset| docset.0 .0.size_hint())
+            .max()
+            .unwrap_or(0u32)
+    }
+}
+
+impl<TScorer: Scorer, TScoreCombiner: ScoreCombiner> Scorer
+    for DisjunctionScorer<TScorer, TScoreCombiner>
+{
+    fn score(&mut self) -> Score {
+        self.score
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::query::score_combiner::DoNothingCombiner;
+    use crate::query::{ConstScorer, Scorer, SumCombiner, VecDocSet};
+    use crate::{DocId, DocSet, Score, TERMINATED};
+
+    use super::DisjunctionScorer;
+
+    fn conjunct<T: Ord + Copy>(arrays: &[Vec<T>], pass_line: usize) -> Vec<T> {
+        let mut counts = BTreeMap::new();
+        for array in arrays {
+            for &element in array {
+                *counts.entry(element).or_insert(0) += 1;
+            }
+        }
+        counts
+            .iter()
+            .filter_map(|(&element, &count)| {
+                if count >= pass_line {
+                    Some(element)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn aux_test_conjunction(vals: Vec<Vec<u32>>, min_match: usize) {
+        let mut union_expected = VecDocSet::from(conjunct(&vals, min_match));
+        let make_scorer = || {
+            DisjunctionScorer::new(
+                vals.iter()
+                    .cloned()
+                    .map(VecDocSet::from)
+                    .map(|d| ConstScorer::new(d, 1.0)),
+                DoNothingCombiner::default(),
+                min_match,
+            )
+        };
+        let mut scorer: DisjunctionScorer<_, DoNothingCombiner> = make_scorer();
+        let mut count = 0;
+        while scorer.doc() != TERMINATED {
+            assert_eq!(union_expected.doc(), scorer.doc());
+            assert_eq!(union_expected.advance(), scorer.advance());
+            count += 1;
+        }
+        assert_eq!(union_expected.advance(), TERMINATED);
+        assert_eq!(count, make_scorer().count_including_deleted());
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_arg_check1() {
+        aux_test_conjunction(vec![], 0);
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_arg_check2() {
+        aux_test_conjunction(vec![], 1);
+    }
+
+    #[test]
+    fn test_corner_case() {
+        aux_test_conjunction(vec![], 2);
+        aux_test_conjunction(vec![vec![]; 1000], 2);
+        aux_test_conjunction(vec![vec![]; 100], usize::MAX);
+        aux_test_conjunction(vec![vec![0xC0FFEE]; 10000], usize::MAX);
+        aux_test_conjunction((1..10000u32).map(|i| vec![i]).collect::<Vec<_>>(), 2);
+    }
+
+    #[test]
+    fn test_conjunction() {
+        aux_test_conjunction(
+            vec![
+                vec![1, 3333, 100000000u32],
+                vec![1, 2, 100000000u32],
+                vec![1, 2, 100000000u32],
+            ],
+            2,
+        );
+        aux_test_conjunction(
+            vec![vec![8], vec![3, 4, 0xC0FFEEu32], vec![1, 2, 100000000u32]],
+            2,
+        );
+        aux_test_conjunction(
+            vec![
+                vec![1, 3333, 100000000u32],
+                vec![1, 2, 100000000u32],
+                vec![1, 2, 100000000u32],
+            ],
+            3,
+        )
+    }
+
+    // This dummy scorer does nothing but yield doc id increasingly.
+    // with constant score 1.0
+    #[derive(Clone)]
+    struct DummyScorer {
+        cursor: usize,
+        foo: Vec<(DocId, f32)>,
+    }
+
+    impl DummyScorer {
+        fn new(doc_score: Vec<(DocId, f32)>) -> Self {
+            Self {
+                cursor: 0,
+                foo: doc_score,
+            }
+        }
+    }
+
+    impl DocSet for DummyScorer {
+        fn advance(&mut self) -> DocId {
+            self.cursor += 1;
+            self.doc()
+        }
+
+        fn doc(&self) -> DocId {
+            self.foo.get(self.cursor).map(|x| x.0).unwrap_or(TERMINATED)
+        }
+
+        fn size_hint(&self) -> u32 {
+            self.foo.len() as u32
+        }
+    }
+
+    impl Scorer for DummyScorer {
+        fn score(&mut self) -> Score {
+            self.foo.get(self.cursor).map(|x| x.1).unwrap_or(0.0)
+        }
+    }
+
+    #[test]
+    fn test_score_calculate() {
+        let mut scorer = DisjunctionScorer::new(
+            vec![
+                DummyScorer::new(vec![(1, 1f32), (2, 1f32)]),
+                DummyScorer::new(vec![(1, 1f32), (3, 1f32)]),
+                DummyScorer::new(vec![(1, 1f32), (4, 1f32)]),
+                DummyScorer::new(vec![(1, 1f32), (2, 1f32)]),
+                DummyScorer::new(vec![(1, 1f32), (2, 1f32)]),
+            ],
+            SumCombiner::default(),
+            3,
+        );
+        assert_eq!(scorer.score(), 5.0);
+        assert_eq!(scorer.advance(), 2);
+        assert_eq!(scorer.score(), 3.0);
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -25,6 +25,7 @@ mod set_query;
 mod term_query;
 mod union;
 mod weight;
+mod disjunction;
 
 #[cfg(test)]
 mod vec_docset;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -5,6 +5,7 @@ mod bm25;
 mod boolean_query;
 mod boost_query;
 mod const_score_query;
+mod disjunction;
 mod disjunction_max_query;
 mod empty_query;
 mod exclude;
@@ -25,7 +26,6 @@ mod set_query;
 mod term_query;
 mod union;
 mod weight;
-mod disjunction;
 
 #[cfg(test)]
 mod vec_docset;

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -1821,7 +1821,8 @@ mod test {
              \"bad\"))], prefix: (2, Term(field=0, type=Str, \"wo\")), max_expansions: 50 }), \
              (Should, PhrasePrefixQuery { field: Field(1), phrase_terms: [(0, Term(field=1, \
              type=Str, \"big\")), (1, Term(field=1, type=Str, \"bad\"))], prefix: (2, \
-             Term(field=1, type=Str, \"wo\")), max_expansions: 50 })] }"
+             Term(field=1, type=Str, \"wo\")), max_expansions: 50 })], \
+             minimum_number_should_match: 1 }"
         );
     }
 
@@ -1886,7 +1887,8 @@ mod test {
                 format!("{query:?}"),
                 "BooleanQuery { subqueries: [(Should, FuzzyTermQuery { term: Term(field=0, \
                  type=Str, \"abc\"), distance: 1, transposition_cost_one: true, prefix: false }), \
-                 (Should, TermQuery(Term(field=1, type=Str, \"abc\")))] }"
+                 (Should, TermQuery(Term(field=1, type=Str, \"abc\")))], \
+                 minimum_number_should_match: 1 }"
             );
         }
 
@@ -1903,7 +1905,8 @@ mod test {
                 format!("{query:?}"),
                 "BooleanQuery { subqueries: [(Should, TermQuery(Term(field=0, type=Str, \
                  \"abc\"))), (Should, FuzzyTermQuery { term: Term(field=1, type=Str, \"abc\"), \
-                 distance: 2, transposition_cost_one: false, prefix: true })] }"
+                 distance: 2, transposition_cost_one: false, prefix: true })], \
+                 minimum_number_should_match: 1 }"
             );
         }
     }


### PR DESCRIPTION
see issue #2398

In this commit, a novel scorer named DisjunctionScorer is introduced, which performs the union of inverted chains with the minimal required elements. BTW, it's implemented via a min-heap. Necessary modifications on `BooleanQuery` and `BooleanWeight` are performed as well.