### PR TITLE
Fix Instances of `if` Being Spelt as `iff` in Documentation

### DIFF
--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -153,7 +153,7 @@ pub trait Collector: Sync + Send {
         segment: &SegmentReader,
     ) -> crate::Result<Self::Child>;
 
-    /// Returns true iff the collector requires to compute scores for documents.
+    /// Returns true if the collector requires to compute scores for documents.
     fn requires_scoring(&self) -> bool;
 
     /// Combines the fruit associated with the collection of each segments

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -32,7 +32,7 @@ pub(crate) fn make_io_err(msg: String) -> io::Error {
     io::Error::new(io::ErrorKind::Other, msg)
 }
 
-/// Returns `None` iff the file exists, can be read, but is empty (and hence
+/// Returns `None` if the file exists, can be read, but is empty (and hence
 /// cannot be mmapped)
 fn open_mmap(full_path: &Path) -> Result<Option<Mmap>, OpenReadError> {
     let file = File::open(full_path).map_err(|io_err| {

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -169,7 +169,7 @@ impl SegmentMeta {
             .map(|delete_meta| delete_meta.opstamp)
     }
 
-    /// Returns true iff the segment meta contains
+    /// Returns true if the segment meta contains
     /// delete information.
     pub fn has_deletes(&self) -> bool {
         self.num_deleted_docs() > 0

--- a/src/indexer/index_writer_status.rs
+++ b/src/indexer/index_writer_status.rs
@@ -11,7 +11,7 @@ pub(crate) struct IndexWriterStatus<D: Document = TantivyDocument> {
 }
 
 impl<D: Document> IndexWriterStatus<D> {
-    /// Returns true iff the index writer is alive.
+    /// Returns true if the index writer is alive.
     pub fn is_alive(&self) -> bool {
         self.inner.as_ref().is_alive()
     }

--- a/src/schema/date_time_options.rs
+++ b/src/schema/date_time_options.rs
@@ -24,25 +24,25 @@ pub struct DateOptions {
 }
 
 impl DateOptions {
-    /// Returns true iff the value is stored.
+    /// Returns true if the value is stored.
     #[inline]
     pub fn is_stored(&self) -> bool {
         self.stored
     }
 
-    /// Returns true iff the value is indexed and therefore searchable.
+    /// Returns true if the value is indexed and therefore searchable.
     #[inline]
     pub fn is_indexed(&self) -> bool {
         self.indexed
     }
 
-    /// Returns true iff the field has fieldnorm.
+    /// Returns true if the field has fieldnorms.
     #[inline]
     pub fn fieldnorms(&self) -> bool {
         self.fieldnorms && self.indexed
     }
 
-    /// Returns true iff the value is a fast field.
+    /// Returns true if the value is a fast field.
     #[inline]
     pub fn is_fast(&self) -> bool {
         self.fast

--- a/src/schema/ip_options.rs
+++ b/src/schema/ip_options.rs
@@ -30,7 +30,7 @@ pub struct IpAddrOptions {
 }
 
 impl IpAddrOptions {
-    /// Returns true iff the value is a fast field.
+    /// Returns true if the value is a fast field.
     #[inline]
     pub fn is_fast(&self) -> bool {
         self.fast
@@ -42,7 +42,7 @@ impl IpAddrOptions {
         self.stored
     }
 
-    /// Returns true iff the value is indexed and therefore searchable.
+    /// Returns true if the value is indexed and therefore searchable.
     #[inline]
     pub fn is_indexed(&self) -> bool {
         self.indexed

--- a/src/schema/json_object_options.rs
+++ b/src/schema/json_object_options.rs
@@ -51,7 +51,7 @@ impl JsonObjectOptions {
         self.stored
     }
 
-    /// Returns `true` iff the json object should be indexed.
+    /// Returns `true` if the json object should be indexed.
     #[inline]
     pub fn is_indexed(&self) -> bool {
         self.indexing.is_some()
@@ -79,7 +79,7 @@ impl JsonObjectOptions {
         }
     }
 
-    /// Returns `true` iff dots in json keys should be expanded.
+    /// Returns `true` if dots in json keys should be expanded.
     ///
     /// When expand_dots is enabled, json object like
     /// `{"k8s.node.id": 5}` is processed as if it was

--- a/src/schema/numeric_options.rs
+++ b/src/schema/numeric_options.rs
@@ -52,25 +52,25 @@ impl From<NumericOptionsDeser> for NumericOptions {
 }
 
 impl NumericOptions {
-    /// Returns true iff the value is stored in the doc store.
+    /// Returns true if the value is stored in the doc store.
     #[inline]
     pub fn is_stored(&self) -> bool {
         self.stored
     }
 
-    /// Returns true iff the value is indexed and therefore searchable.
+    /// Returns true if the value is indexed and therefore searchable.
     #[inline]
     pub fn is_indexed(&self) -> bool {
         self.indexed
     }
 
-    /// Returns true iff the field has fieldnorm.
+    /// Returns true if the field has fieldnorms.
     #[inline]
     pub fn fieldnorms(&self) -> bool {
         self.fieldnorms && self.indexed
     }
 
-    /// Returns true iff the value is a fast field.
+    /// Returns true if the value is a fast field.
     #[inline]
     pub fn is_fast(&self) -> bool {
         self.fast


### PR DESCRIPTION
Hi, I used tantivy for a project and noticed `if` being written as `iff` in the NumericOptions docs as I browsed, I doubt these spellings were intentional and a ripgrep later revealed 16 potential locations where this spelling error had occurred.

This PR changes the spelling in all 16 locations that were found through automated means to say `if` instead of `iff`, it also changes `fieldnorm` to `fieldnorms` in 2 areas (that were on the same line as an `iff`) to make the grammar flow better.