### PR TITLE
reduce top hits memory consumption

### DIFF
--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -203,6 +203,12 @@ impl AggregationVariants {
             _ => None,
         }
     }
+    pub(crate) fn as_top_hits(&self) -> Option<&TopHitsAggregation> {
+        match &self {
+            AggregationVariants::TopHits(top_hits) => Some(top_hits),
+            _ => None,
+        }
+    }
 
     pub(crate) fn as_percentile(&self) -> Option<&PercentilesAggregationReq> {
         match &self {

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -225,7 +225,7 @@ pub(crate) fn empty_from_req(req: &Aggregation) -> IntermediateAggregationResult
             IntermediateMetricResult::Percentiles(PercentilesCollector::default()),
         ),
         TopHits(ref req) => IntermediateAggregationResult::Metric(
-            IntermediateMetricResult::TopHits(TopHitsTopNComputer::new(req.clone())),
+            IntermediateMetricResult::TopHits(TopHitsTopNComputer::new(req)),
         ),
     }
 }

--- a/src/aggregation/metric/extended_stats.rs
+++ b/src/aggregation/metric/extended_stats.rs
@@ -229,8 +229,7 @@ impl IntermediateExtendedStats {
                 * self.intermediate_stats.count as f64
                 * other.intermediate_stats.count as f64
                 / new_count as f64;
-        self.mean = (self.intermediate_stats.sum as f64 + other.intermediate_stats.sum as f64)
-            / new_count as f64;
+        self.mean = (self.intermediate_stats.sum + other.intermediate_stats.sum) / new_count as f64;
         self.sum_of_squares_elastic += other.sum_of_squares_elastic;
         self.delta_sum_for_squares_elastic += other.delta_sum_for_squares_elastic;
         self.intermediate_stats


### PR DESCRIPTION
move request structure out of top hits collector and use from the
passed structure instead

```
full
terms_many_with_top_hits    Memory: 58.2 MB (-43.64%)    Avg: 425.9680ms (-21.38%)    Median: 415.1097ms (-23.56%)    [395.5303ms .. 484.6325ms]
dense
terms_many_with_top_hits    Memory: 58.2 MB (-43.64%)    Avg: 440.0817ms (-19.68%)    Median: 432.2286ms (-21.10%)    [403.5632ms .. 497.7541ms]
sparse
terms_many_with_top_hits    Memory: 13.1 MB (-49.31%)    Avg: 33.3568ms (-32.19%)    Median: 33.0834ms (-31.86%)    [32.5126ms .. 35.7397ms]
multivalue
terms_many_with_top_hits    Memory: 58.2 MB (-43.64%)    Avg: 414.2340ms (-25.44%)    Median: 413.4144ms (-25.64%)    [403.9919ms .. 430.3170ms]
```