### PR TITLE
add access benchmark for columnar

### DIFF
--- a/columnar/Cargo.toml
+++ b/columnar/Cargo.toml
@@ -29,6 +29,10 @@ binggan = "0.8.1"
 name = "bench_merge"
 harness = false
 
+[[bench]]
+name = "bench_access"
+harness = false
+
 
 [features]
 unstable = []

--- a/columnar/benches/bench_access.rs
+++ b/columnar/benches/bench_access.rs
@@ -1,0 +1,120 @@
+use core::fmt;
+use std::fmt::{Display, Formatter};
+
+use binggan::{black_box, InputGroup};
+use tantivy_columnar::*;
+
+enum Card {
+    MultiSparse,
+    Multi,
+    Sparse,
+    Dense,
+    Full,
+}
+impl Display for Card {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Card::MultiSparse => write!(f, "multi sparse 1/13"),
+            Card::Multi => write!(f, "multi 2x"),
+            Card::Sparse => write!(f, "sparse 1/13"),
+            Card::Dense => write!(f, "dense 1/12"),
+            Card::Full => write!(f, "full"),
+        }
+    }
+}
+
+const NUM_DOCS: u32 = 2_000_000;
+
+fn generate_columnar(card: Card, num_docs: u32) -> Column {
+    use tantivy_columnar::ColumnarWriter;
+
+    let mut columnar_writer = ColumnarWriter::default();
+
+    match card {
+        Card::MultiSparse => {
+            columnar_writer.record_numerical(0, "price", 10u64);
+            columnar_writer.record_numerical(0, "price", 10u64);
+        }
+        _ => {}
+    }
+
+    for i in 0..num_docs {
+        match card {
+            Card::MultiSparse | Card::Sparse => {
+                if i % 13 == 0 {
+                    columnar_writer.record_numerical(i, "price", i as u64);
+                }
+            }
+            Card::Dense => {
+                if i % 12 == 0 {
+                    columnar_writer.record_numerical(i, "price", i as u64);
+                }
+            }
+            Card::Full => {
+                columnar_writer.record_numerical(i, "price", i as u64);
+            }
+            Card::Multi => {
+                columnar_writer.record_numerical(i, "price", i as u64);
+                columnar_writer.record_numerical(i, "price", i as u64);
+            }
+        }
+    }
+
+    let mut wrt: Vec<u8> = Vec::new();
+    columnar_writer.serialize(num_docs, None, &mut wrt).unwrap();
+
+    let reader = ColumnarReader::open(wrt).unwrap();
+    reader.read_columns("price").unwrap()[0]
+        .open_u64_lenient()
+        .unwrap()
+        .unwrap()
+}
+fn main() {
+    let mut inputs = Vec::new();
+
+    let mut add_card = |card1: Card| {
+        inputs.push((format!("{card1}"), generate_columnar(card1, NUM_DOCS)));
+    };
+
+    add_card(Card::MultiSparse);
+    add_card(Card::Multi);
+    add_card(Card::Sparse);
+    add_card(Card::Dense);
+    add_card(Card::Full);
+
+    bench_group(InputGroup::new_with_inputs(inputs));
+}
+
+fn bench_group(mut runner: InputGroup<Column>) {
+    runner.register("access_values_for_doc", |column| {
+        let mut sum = 0;
+        for i in 0..NUM_DOCS {
+            for value in column.values_for_doc(i) {
+                sum += value;
+            }
+        }
+        black_box(sum);
+    });
+    runner.register("access_first_vals", |column| {
+        let mut sum = 0;
+        const BLOCK_SIZE: usize = 32;
+        let mut docs = vec![0; BLOCK_SIZE];
+        let mut buffer = vec![None; BLOCK_SIZE];
+        for i in (0..NUM_DOCS).step_by(BLOCK_SIZE) {
+            // fill docs
+            for idx in 0..BLOCK_SIZE {
+                docs[idx] = idx as u32 + i;
+            }
+
+            column.first_vals(&docs, &mut buffer);
+            for val in buffer.iter() {
+                if let Some(val) = val {
+                    sum += *val;
+                }
+            }
+        }
+
+        black_box(sum);
+    });
+    runner.run();
+}

--- a/columnar/benches/bench_merge.rs
+++ b/columnar/benches/bench_merge.rs
@@ -1,6 +1,3 @@
-#![feature(test)]
-extern crate test;
-
 use core::fmt;
 use std::fmt::{Display, Formatter};
 
@@ -40,12 +37,12 @@ fn generate_columnar(card: Card, num_docs: u32) -> ColumnarReader {
     for i in 0..num_docs {
         match card {
             Card::Multi | Card::Sparse => {
-                if i % 8 == 0 {
+                if i % 13 == 0 {
                     columnar_writer.record_numerical(i, "price", i as u64);
                 }
             }
             Card::Dense => {
-                if i % 6 == 0 {
+                if i % 12 == 0 {
                     columnar_writer.record_numerical(i, "price", i as u64);
                 }
             }
@@ -84,16 +81,12 @@ fn main() {
             input_name,
             columnar_readers,
             move |columnar_readers: &Vec<ColumnarReader>| {
-                let mut out = vec![];
+                let mut out = Vec::new();
                 let columnar_readers = columnar_readers.iter().collect::<Vec<_>>();
                 let merge_row_order = StackMergeOrder::stack(&columnar_readers[..]);
 
-                let _ = black_box(merge_columnar(
-                    &columnar_readers,
-                    &[],
-                    merge_row_order.into(),
-                    &mut out,
-                ));
+                merge_columnar(&columnar_readers, &[], merge_row_order.into(), &mut out).unwrap();
+                black_box(out);
             },
         );
     }


### PR DESCRIPTION
```
multi sparse 1/13
access_values_for_doc        Avg: 12.6985ms (+0.74%)    Median: 12.5761ms (+1.02%)    [12.5325ms .. 15.6811ms]    
access_first_vals            Avg: 8.0852ms (-0.12%)     Median: 8.0347ms (+0.34%)     [7.9755ms .. 9.5182ms]      
multi 2x
access_values_for_doc        Avg: 25.1906ms (+0.89%)    Median: 25.1214ms (+0.75%)    [25.0799ms .. 26.6412ms]    
access_first_vals            Avg: 14.2296ms (-0.44%)    Median: 14.2211ms (+0.20%)    [14.1773ms .. 14.4981ms]    
sparse 1/13
access_values_for_doc        Avg: 40.5447ms (-0.15%)    Median: 40.6281ms (-0.07%)    [40.2593ms .. 40.7071ms]    
access_first_vals            Avg: 43.3743ms (+0.17%)    Median: 43.3775ms (+0.19%)    [43.2441ms .. 43.5812ms]    
dense 1/12
access_values_for_doc        Avg: 7.1800ms (+3.42%)    Median: 7.1789ms (+3.44%)    [7.1678ms .. 7.2023ms]    
access_first_vals            Avg: 6.6070ms (+1.22%)    Median: 6.6100ms (+1.29%)    [6.5745ms .. 6.6463ms]    
full
access_values_for_doc        Avg: 9.5824ms (-27.24%)    Median: 9.5755ms (-27.22%)    [9.4312ms .. 9.6552ms]    
access_first_vals            Avg: 4.4663ms (-0.03%)     Median: 4.4626ms (-0.06%)     [4.4481ms .. 4.5440ms]    


merge_multi_and_multi          Avg: 4.0975ms (+3.37%)    Median: 4.0034ms (+1.12%)    [3.9157ms .. 4.8621ms]     
merge_dense_and_dense          Avg: 0.6811ms (-0.94%)    Median: 0.6706ms (-1.97%)    [0.6584ms .. 0.9537ms]     
merge_sparse_and_sparse        Avg: 0.5703ms (-2.69%)    Median: 0.5667ms (-2.62%)    [0.5568ms .. 0.6408ms]     
merge_sparse_and_dense         Avg: 0.6318ms (+1.09%)    Median: 0.6134ms (-1.95%)    [0.6039ms .. 0.8290ms]     
merge_multi_and_dense          Avg: 5.5281ms (+2.09%)    Median: 5.4526ms (+0.82%)    [5.3714ms .. 6.3027ms]     
merge_multi_and_sparse         Avg: 8.0196ms (+2.09%)    Median: 7.8989ms (+0.85%)    [7.8592ms .. 10.2500ms]    

```