### PR TITLE
lift clauses in LogicalAst

### DIFF
--- a/query-grammar/src/occur.rs
+++ b/query-grammar/src/occur.rs
@@ -6,12 +6,12 @@ use std::fmt::Write;
 #[derive(Debug, Clone, Hash, Copy, Eq, PartialEq)]
 pub enum Occur {
     /// For a given document to be considered for scoring,
-    /// at least one of the terms with the Should or the Must
+    /// at least one of the queries with the Should or the Must
     /// Occur constraint must be within the document.
     Should,
-    /// Document without the term are excluded from the search.
+    /// Document without the queries are excluded from the search.
     Must,
-    /// Document that contain the term are excluded from the
+    /// Document that contain the query are excluded from the
     /// search.
     MustNot,
 }

--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -1,5 +1,5 @@
 use super::boolean_weight::BooleanWeight;
-use crate::query::{EnableScoring, Occur, Query, SumWithCoordsCombiner, TermQuery, Weight};
+use crate::query::{EnableScoring, Occur, Query, SumCombiner, TermQuery, Weight};
 use crate::schema::{IndexRecordOption, Term};
 
 /// The boolean query returns a set of documents
@@ -169,7 +169,7 @@ impl Query for BooleanQuery {
             sub_weights,
             self.minimum_number_should_match,
             enable_scoring.is_scoring_enabled(),
-            Box::new(SumWithCoordsCombiner::default),
+            Box::new(SumCombiner::default),
         )))
     }
 

--- a/src/query/boolean_query/mod.rs
+++ b/src/query/boolean_query/mod.rs
@@ -12,11 +12,10 @@ mod tests {
     use super::*;
     use crate::collector::tests::TEST_COLLECTOR_WITH_SCORE;
     use crate::collector::TopDocs;
-    use crate::query::score_combiner::SumWithCoordsCombiner;
     use crate::query::term_query::TermScorer;
     use crate::query::{
         EnableScoring, Intersection, Occur, Query, QueryParser, RequiredOptionalScorer, Scorer,
-        TermQuery,
+        SumCombiner, TermQuery,
     };
     use crate::schema::*;
     use crate::{assert_nearly_equals, DocAddress, DocId, Index, IndexWriter, Score};
@@ -90,11 +89,8 @@ mod tests {
             let query = query_parser.parse_query("+a b")?;
             let weight = query.weight(EnableScoring::enabled_from_searcher(&searcher))?;
             let scorer = weight.scorer(searcher.segment_reader(0u32), 1.0)?;
-            assert!(scorer.is::<RequiredOptionalScorer<
-                Box<dyn Scorer>,
-                Box<dyn Scorer>,
-                SumWithCoordsCombiner,
-            >>());
+            assert!(scorer
+                .is::<RequiredOptionalScorer<Box<dyn Scorer>, Box<dyn Scorer>, SumCombiner>>());
         }
         {
             let query = query_parser.parse_query("+a b")?;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -57,9 +57,7 @@ pub use self::query_parser::{QueryParser, QueryParserError};
 pub use self::range_query::{FastFieldRangeWeight, IPFastFieldRangeWeight, RangeQuery};
 pub use self::regex_query::RegexQuery;
 pub use self::reqopt_scorer::RequiredOptionalScorer;
-pub use self::score_combiner::{
-    DisjunctionMaxCombiner, ScoreCombiner, SumCombiner, SumWithCoordsCombiner,
-};
+pub use self::score_combiner::{DisjunctionMaxCombiner, ScoreCombiner, SumCombiner};
 pub use self::scorer::Scorer;
 pub use self::set_query::TermSetQuery;
 pub use self::term_query::TermQuery;

--- a/src/query/score_combiner.rs
+++ b/src/query/score_combiner.rs
@@ -54,30 +54,6 @@ impl ScoreCombiner for SumCombiner {
     }
 }
 
-/// Sums the score of different scorers and keeps the count
-/// of scorers which matched.
-#[derive(Default, Clone, Copy)]
-pub struct SumWithCoordsCombiner {
-    num_fields: usize,
-    score: Score,
-}
-
-impl ScoreCombiner for SumWithCoordsCombiner {
-    fn update<TScorer: Scorer>(&mut self, scorer: &mut TScorer) {
-        self.score += scorer.score();
-        self.num_fields += 1;
-    }
-
-    fn clear(&mut self) {
-        self.score = 0.0;
-        self.num_fields = 0;
-    }
-
-    fn score(&self) -> Score {
-        self.score
-    }
-}
-
 /// Take max score of different scorers
 /// and optionally sum it with other matches multiplied by `tie_breaker`
 #[derive(Default, Clone, Copy)]


### PR DESCRIPTION
(a OR b) OR (c OR d) can be simplified to (a OR b OR c OR d)
(a AND b) AND (c AND d) can be simplified to (a AND b AND c AND d)

This directly affects how queries are executed and the performance


Remove `SumWithCoordsCombiner`, it is effectively the same as `SumCombiner`, but with an unused field

![simplify_ast](https://github.com/quickwit-oss/tantivy/assets/1109503/7ffcb3dc-73eb-4b58-ad7f-98b459ad8c7a)



