### PR TITLE
add support for str fast field range query

### DIFF
--- a/src/query/range_query/mod.rs
+++ b/src/query/range_query/mod.rs
@@ -12,9 +12,9 @@ pub use self::range_query_u64_fastfield::FastFieldRangeWeight;
 // TODO is this correct?
 pub(crate) fn is_type_valid_for_fastfield_range_query(typ: Type) -> bool {
     match typ {
-        Type::U64 | Type::I64 | Type::F64 | Type::Bool | Type::Date => true,
+        Type::Str | Type::U64 | Type::I64 | Type::F64 | Type::Bool | Type::Date => true,
         Type::IpAddr => true,
-        Type::Str | Type::Facet | Type::Bytes | Type::Json => false,
+        Type::Facet | Type::Bytes | Type::Json => false,
     }
 }
 

--- a/src/query/range_query/range_query_u64_fastfield.rs
+++ b/src/query/range_query/range_query_u64_fastfield.rs
@@ -85,7 +85,7 @@ impl Weight for FastFieldRangeWeight {
             let docset = RangeDocSet::new(value_range, ip_addr_column);
             Ok(Box::new(ConstScorer::new(docset, boost)))
         } else {
-            let (lower_bound, upper_bound) = if field_type.is_term() {
+            let (lower_bound, upper_bound) = if field_type.is_str() {
                 let Some(str_dict_column): Option<StrColumn> =
                     reader.fast_fields().str(field_name)?
                 else {
@@ -259,6 +259,27 @@ pub mod tests {
         test_query("title:[ccc TO ccc]", 0);
         test_query("title:[ccc TO ddd]", 1);
         test_query("title:[ccc TO eee]", 1);
+
+        test_query("title:[aaa TO *}", 2);
+        test_query("title:[bbb TO *]", 2);
+        test_query("title:[bb TO *]", 2);
+        test_query("title:[ccc TO *]", 1);
+        test_query("title:[ddd TO *]", 1);
+        test_query("title:[dddd TO *]", 0);
+
+        test_query("title:{aaa TO *}", 2);
+        test_query("title:{bbb TO *]", 1);
+        test_query("title:{bb TO *]", 2);
+        test_query("title:{ccc TO *]", 1);
+        test_query("title:{ddd TO *]", 0);
+        test_query("title:{dddd TO *]", 0);
+
+        test_query("title:[* TO bb]", 0);
+        test_query("title:[* TO bbb]", 1);
+        test_query("title:[* TO ccc]", 1);
+        test_query("title:[* TO ddd]", 2);
+        test_query("title:[* TO ddd}", 1);
+        test_query("title:[* TO eee]", 2);
 
         Ok(())
     }

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -202,7 +202,7 @@ impl FieldType {
     }
 
     /// returns true if this is an str field
-    pub fn is_term(&self) -> bool {
+    pub fn is_str(&self) -> bool {
         matches!(self, FieldType::Str(_))
     }
 

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -201,6 +201,11 @@ impl FieldType {
         matches!(self, FieldType::IpAddr(_))
     }
 
+    /// returns true if this is an str field
+    pub fn is_term(&self) -> bool {
+        matches!(self, FieldType::Str(_))
+    }
+
     /// returns true if this is an date field
     pub fn is_date(&self) -> bool {
         matches!(self, FieldType::Date(_))

--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -662,6 +662,9 @@ mod tests {
         assert_eq!(dict.term_ord_or_next(b"ddd").unwrap(), TermOrdHit::Exact(1));
         assert_eq!(dict.term_ord_or_next(b"dddd").unwrap(), TermOrdHit::Next(2));
 
+        // This is not u64::MAX because for very small sstables (only one block),
+        // we don't store an index, and the pseudo-index always reply that the
+        // answer lies in block number 0
         assert_eq!(
             dict.term_ord_or_next(b"zzzzzzz").unwrap(),
             TermOrdHit::Next(2)

--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -662,7 +662,6 @@ mod tests {
         assert_eq!(dict.term_ord_or_next(b"ddd").unwrap(), TermOrdHit::Exact(1));
         assert_eq!(dict.term_ord_or_next(b"dddd").unwrap(), TermOrdHit::Next(2));
 
-        // Shouldn't this be u64::MAX?
         assert_eq!(
             dict.term_ord_or_next(b"zzzzzzz").unwrap(),
             TermOrdHit::Next(2)


### PR DESCRIPTION
Add support for range queries on fast fields, by converting term bounds to
term ordinal bounds.

closes https://github.com/quickwit-oss/tantivy/issues/2023
