### PR TITLE
support ff range queries on json fields

### DIFF
--- a/common/src/bounds.rs
+++ b/common/src/bounds.rs
@@ -1,0 +1,130 @@
+use std::io;
+use std::ops::Bound;
+
+#[derive(Clone, Debug)]
+pub struct BoundsRange<T> {
+    pub lower_bound: Bound<T>,
+    pub upper_bound: Bound<T>,
+}
+impl<T> BoundsRange<T> {
+    pub fn new(lower_bound: Bound<T>, upper_bound: Bound<T>) -> Self {
+        BoundsRange {
+            lower_bound,
+            upper_bound,
+        }
+    }
+    pub fn is_unbounded(&self) -> bool {
+        matches!(self.lower_bound, Bound::Unbounded) && matches!(self.upper_bound, Bound::Unbounded)
+    }
+    pub fn map_bound<TTo>(&self, transform: impl Fn(&T) -> TTo) -> BoundsRange<TTo> {
+        BoundsRange {
+            lower_bound: map_bound(&self.lower_bound, &transform),
+            upper_bound: map_bound(&self.upper_bound, &transform),
+        }
+    }
+
+    pub fn map_bound_res<TTo, Err>(
+        &self,
+        transform: impl Fn(&T) -> Result<TTo, Err>,
+    ) -> Result<BoundsRange<TTo>, Err> {
+        Ok(BoundsRange {
+            lower_bound: map_bound_res(&self.lower_bound, &transform)?,
+            upper_bound: map_bound_res(&self.upper_bound, &transform)?,
+        })
+    }
+
+    pub fn transform_inner<TTo>(
+        &self,
+        transform_lower: impl Fn(&T) -> TransformBound<TTo>,
+        transform_upper: impl Fn(&T) -> TransformBound<TTo>,
+    ) -> BoundsRange<TTo> {
+        BoundsRange {
+            lower_bound: transform_bound_inner(&self.lower_bound, &transform_lower),
+            upper_bound: transform_bound_inner(&self.upper_bound, &transform_upper),
+        }
+    }
+
+    /// Returns the first set inner value
+    pub fn get_inner(&self) -> Option<&T> {
+        inner_bound(&self.lower_bound).or(inner_bound(&self.upper_bound))
+    }
+}
+
+pub enum TransformBound<T> {
+    /// Overwrite the bounds
+    NewBound(Bound<T>),
+    /// Use Existing bounds with new value
+    Existing(T),
+}
+
+/// Takes a bound and transforms the inner value into a new bound via a closure.
+/// The bound variant may change by the value returned value from the closure.
+pub fn transform_bound_inner_res<TFrom, TTo>(
+    bound: &Bound<TFrom>,
+    transform: impl Fn(&TFrom) -> io::Result<TransformBound<TTo>>,
+) -> io::Result<Bound<TTo>> {
+    use self::Bound::*;
+    Ok(match bound {
+        Excluded(ref from_val) => match transform(from_val)? {
+            TransformBound::NewBound(new_val) => new_val,
+            TransformBound::Existing(new_val) => Excluded(new_val),
+        },
+        Included(ref from_val) => match transform(from_val)? {
+            TransformBound::NewBound(new_val) => new_val,
+            TransformBound::Existing(new_val) => Included(new_val),
+        },
+        Unbounded => Unbounded,
+    })
+}
+
+/// Takes a bound and transforms the inner value into a new bound via a closure.
+/// The bound variant may change by the value returned value from the closure.
+pub fn transform_bound_inner<TFrom, TTo>(
+    bound: &Bound<TFrom>,
+    transform: impl Fn(&TFrom) -> TransformBound<TTo>,
+) -> Bound<TTo> {
+    use self::Bound::*;
+    match bound {
+        Excluded(ref from_val) => match transform(from_val) {
+            TransformBound::NewBound(new_val) => new_val,
+            TransformBound::Existing(new_val) => Excluded(new_val),
+        },
+        Included(ref from_val) => match transform(from_val) {
+            TransformBound::NewBound(new_val) => new_val,
+            TransformBound::Existing(new_val) => Included(new_val),
+        },
+        Unbounded => Unbounded,
+    }
+}
+
+/// Returns the inner value of a `Bound`
+pub fn inner_bound<T>(val: &Bound<T>) -> Option<&T> {
+    match val {
+        Bound::Included(term) | Bound::Excluded(term) => Some(term),
+        Bound::Unbounded => None,
+    }
+}
+
+pub fn map_bound<TFrom, TTo>(
+    bound: &Bound<TFrom>,
+    transform: impl Fn(&TFrom) -> TTo,
+) -> Bound<TTo> {
+    use self::Bound::*;
+    match bound {
+        Excluded(ref from_val) => Bound::Excluded(transform(from_val)),
+        Included(ref from_val) => Bound::Included(transform(from_val)),
+        Unbounded => Unbounded,
+    }
+}
+
+pub fn map_bound_res<TFrom, TTo, Err>(
+    bound: &Bound<TFrom>,
+    transform: impl Fn(&TFrom) -> Result<TTo, Err>,
+) -> Result<Bound<TTo>, Err> {
+    use self::Bound::*;
+    Ok(match bound {
+        Excluded(ref from_val) => Excluded(transform(from_val)?),
+        Included(ref from_val) => Included(transform(from_val)?),
+        Unbounded => Unbounded,
+    })
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -5,6 +5,7 @@ use std::ops::Deref;
 pub use byteorder::LittleEndian as Endianness;
 
 mod bitset;
+pub mod bounds;
 mod byte_count;
 mod datetime;
 pub mod file_slice;

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -673,7 +673,7 @@ mod tests {
                     ]
                 );
                 assert_eq!(
-                    get_doc_ids(vec![Term::from_field_date(
+                    get_doc_ids(vec![Term::from_field_date_for_search(
                         date_field,
                         DateTime::from_utc(curr_time)
                     )])?,

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -64,9 +64,9 @@ impl SegmentWriter {
     ///
     /// The arguments are defined as follows
     ///
-    /// - memory_budget: most of the segment writer data (terms, and postings lists recorders)
-    /// is stored in a memory arena. This makes it possible for the user to define
-    /// the flushing behavior as a memory limit.
+    /// - memory_budget: most of the segment writer data (terms, and postings lists recorders) is
+    ///   stored in a memory arena. This makes it possible for the user to define the flushing
+    ///   behavior as a memory limit.
     /// - segment: The segment being written
     /// - schema
     pub fn for_segment(memory_budget_in_bytes: usize, segment: Segment) -> crate::Result<Self> {
@@ -431,7 +431,7 @@ mod tests {
     use crate::query::{PhraseQuery, QueryParser};
     use crate::schema::{
         Document, IndexRecordOption, OwnedValue, Schema, TextFieldIndexing, TextOptions, Value,
-        STORED, STRING, TEXT,
+        DATE_TIME_PRECISION_INDEXED, STORED, STRING, TEXT,
     };
     use crate::store::{Compressor, StoreReader, StoreWriter};
     use crate::time::format_description::well_known::Rfc3339;
@@ -651,7 +651,8 @@ mod tests {
             set_fast_val(
                 DateTime::from_utc(
                     OffsetDateTime::parse("1985-04-12T23:20:50.52Z", &Rfc3339).unwrap(),
-                ),
+                )
+                .truncate(DATE_TIME_PRECISION_INDEXED),
                 term
             )
             .serialized_value_bytes()

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -54,7 +54,7 @@ pub use self::phrase_prefix_query::PhrasePrefixQuery;
 pub use self::phrase_query::PhraseQuery;
 pub use self::query::{EnableScoring, Query, QueryClone};
 pub use self::query_parser::{QueryParser, QueryParserError};
-pub use self::range_query::{FastFieldRangeWeight, RangeQuery};
+pub use self::range_query::{FastFieldRangeWeight, RangeQuery, RangeWeight};
 pub use self::regex_query::RegexQuery;
 pub use self::reqopt_scorer::RequiredOptionalScorer;
 pub use self::score_combiner::{

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -54,7 +54,7 @@ pub use self::phrase_prefix_query::PhrasePrefixQuery;
 pub use self::phrase_query::PhraseQuery;
 pub use self::query::{EnableScoring, Query, QueryClone};
 pub use self::query_parser::{QueryParser, QueryParserError};
-pub use self::range_query::{FastFieldRangeWeight, RangeQuery, RangeWeight};
+pub use self::range_query::*;
 pub use self::regex_query::RegexQuery;
 pub use self::reqopt_scorer::RequiredOptionalScorer;
 pub use self::score_combiner::{

--- a/src/query/more_like_this/more_like_this.rs
+++ b/src/query/more_like_this/more_like_this.rs
@@ -241,7 +241,7 @@ impl MoreLikeThis {
                     let timestamp = value.as_datetime().ok_or_else(|| {
                         TantivyError::InvalidArgument("invalid value".to_string())
                     })?;
-                    let term = Term::from_field_date(field, timestamp);
+                    let term = Term::from_field_date_for_search(field, timestamp);
                     *term_frequencies.entry(term).or_insert(0) += 1;
                 }
             }

--- a/src/query/phrase_prefix_query/phrase_prefix_query.rs
+++ b/src/query/phrase_prefix_query/phrase_prefix_query.rs
@@ -1,10 +1,8 @@
 use std::ops::Bound;
 
-use common::bounds::{map_bound, BoundsRange};
-
 use super::{prefix_end, PhrasePrefixWeight};
 use crate::query::bm25::Bm25Weight;
-use crate::query::{EnableScoring, FastFieldRangeWeight, Query, RangeQuery, RangeWeight, Weight};
+use crate::query::{EnableScoring, InvertedIndexRangeWeight, Query, Weight};
 use crate::schema::{Field, IndexRecordOption, Term};
 
 const DEFAULT_MAX_EXPANSIONS: u32 = 50;
@@ -147,14 +145,13 @@ impl Query for PhrasePrefixQuery {
                     Bound::Unbounded
                 };
 
-            let verify_and_unwrap_term = |val: &Term| val.serialized_value_bytes().to_owned();
             let lower_bound = Bound::Included(self.prefix.1.clone());
             let upper_bound = end_term;
 
-            Ok(Box::new(RangeWeight::new(
+            Ok(Box::new(InvertedIndexRangeWeight::new(
                 self.field,
-                map_bound(&lower_bound, verify_and_unwrap_term),
-                map_bound(&upper_bound, verify_and_unwrap_term),
+                &lower_bound,
+                &upper_bound,
                 Some(self.max_expansions as u64),
             )))
         }

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -137,7 +137,7 @@ fn trim_ast(logical_ast: LogicalAst) -> Option<LogicalAst> {
 ///   so-called default fields (as set up in the constructor).
 ///
 ///   Assuming that the default fields are `body` and `title`, and the query parser is set with
-/// conjunction   as a default, our query will be interpreted as.
+///   conjunction as a default, our query will be interpreted as.
 ///   `(body:Barack OR title:Barack) AND (title:Obama OR body:Obama)`.
 ///   By default, all tokenized and indexed fields are default fields.
 ///
@@ -148,8 +148,7 @@ fn trim_ast(logical_ast: LogicalAst) -> Option<LogicalAst> {
 ///   `body:Barack OR (body:Barack OR text:Obama)` .
 ///
 /// * boolean operators `AND`, `OR`. `AND` takes precedence over `OR`, so that `a AND b OR c` is
-///   interpreted
-/// as `(a AND b) OR c`.
+///   interpreted as `(a AND b) OR c`.
 ///
 /// * In addition to the boolean operators, the `-`, `+` can help define. These operators are
 ///   sufficient to express all queries using boolean operators. For instance `x AND y OR z` can be
@@ -272,8 +271,7 @@ impl QueryParser {
 
     /// Creates a `QueryParser`, given
     ///  * an index
-    ///  * a set of default fields used to search if no field is specifically defined
-    ///   in the query.
+    ///  * a set of default fields used to search if no field is specifically defined in the query.
     pub fn for_index(index: &Index, default_fields: Vec<Field>) -> QueryParser {
         QueryParser::new(index.schema(), default_fields, index.tokenizers().clone())
     }
@@ -500,6 +498,7 @@ impl QueryParser {
                     convert_to_fast_value_and_append_to_json_term(
                         get_term_with_path(),
                         phrase,
+                        false,
                     )
                 {
                     Ok(term)
@@ -569,7 +568,7 @@ impl QueryParser {
             }
             FieldType::Date(_) => {
                 let dt = OffsetDateTime::parse(phrase, &Rfc3339)?;
-                let dt_term = Term::from_field_date(field, DateTime::from_utc(dt));
+                let dt_term = Term::from_field_date_for_search(field, DateTime::from_utc(dt));
                 Ok(vec![LogicalLiteral::Term(dt_term)])
             }
             FieldType::Str(ref str_options) => {
@@ -701,8 +700,8 @@ impl QueryParser {
     ///
     /// The terms are identified by a triplet:
     /// - tantivy field
-    /// - field_path: tantivy has JSON fields. It is possible to target a member of a JSON
-    /// object by naturally extending the json field name with a "." separated field_path
+    /// - field_path: tantivy has JSON fields. It is possible to target a member of a JSON object by
+    ///   naturally extending the json field name with a "." separated field_path
     /// - field_phrase: the phrase that is being searched.
     ///
     /// The literal identifies the targeted field by a so-called *full field path*,
@@ -965,7 +964,8 @@ fn generate_literals_for_json_object(
         || Term::from_field_json_path(field, json_path, json_options.is_expand_dots_enabled());
 
     // Try to convert the phrase to a fast value
-    if let Some(term) = convert_to_fast_value_and_append_to_json_term(get_term_with_path(), phrase)
+    if let Some(term) =
+        convert_to_fast_value_and_append_to_json_term(get_term_with_path(), phrase, true)
     {
         logical_literals.push(LogicalLiteral::Term(term));
     }

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -1140,7 +1140,7 @@ mod test {
         assert_eq!(
             format!("{query:?}"),
             "RangeQuery { bounds: BoundsRange { lower_bound: Included(Term(field=0, type=Str, \
-             \"a\")), upper_bound: Included(Term(field=0, type=Str, \"b\")) }, limit: None }"
+             \"a\")), upper_bound: Included(Term(field=0, type=Str, \"b\")) } }"
         );
     }
 

--- a/src/query/range_query/mod.rs
+++ b/src/query/range_query/mod.rs
@@ -4,7 +4,7 @@ mod fast_field_range_doc_set;
 mod range_query;
 mod range_query_u64_fastfield;
 
-pub use self::range_query::{RangeQuery, RangeWeight};
+pub use self::range_query::*;
 pub use self::range_query_u64_fastfield::FastFieldRangeWeight;
 
 // TODO is this correct?

--- a/src/query/range_query/mod.rs
+++ b/src/query/range_query/mod.rs
@@ -1,5 +1,3 @@
-use std::ops::Bound;
-
 use crate::schema::Type;
 
 mod fast_field_range_doc_set;
@@ -12,29 +10,10 @@ pub use self::range_query_u64_fastfield::FastFieldRangeWeight;
 // TODO is this correct?
 pub(crate) fn is_type_valid_for_fastfield_range_query(typ: Type) -> bool {
     match typ {
-        Type::Str | Type::U64 | Type::I64 | Type::F64 | Type::Bool | Type::Date => true,
+        Type::Str | Type::U64 | Type::I64 | Type::F64 | Type::Bool | Type::Date | Type::Json => {
+            true
+        }
         Type::IpAddr => true,
-        Type::Facet | Type::Bytes | Type::Json => false,
+        Type::Facet | Type::Bytes => false,
     }
-}
-
-fn map_bound<TFrom, TTo>(bound: &Bound<TFrom>, transform: impl Fn(&TFrom) -> TTo) -> Bound<TTo> {
-    use self::Bound::*;
-    match bound {
-        Excluded(ref from_val) => Excluded(transform(from_val)),
-        Included(ref from_val) => Included(transform(from_val)),
-        Unbounded => Unbounded,
-    }
-}
-
-fn map_bound_res<TFrom, TTo, Err>(
-    bound: &Bound<TFrom>,
-    transform: impl Fn(&TFrom) -> Result<TTo, Err>,
-) -> Result<Bound<TTo>, Err> {
-    use self::Bound::*;
-    Ok(match bound {
-        Excluded(ref from_val) => Excluded(transform(from_val)?),
-        Included(ref from_val) => Included(transform(from_val)?),
-        Unbounded => Unbounded,
-    })
 }

--- a/src/query/range_query/mod.rs
+++ b/src/query/range_query/mod.rs
@@ -4,7 +4,7 @@ mod fast_field_range_doc_set;
 mod range_query;
 mod range_query_u64_fastfield;
 
-pub use self::range_query::RangeQuery;
+pub use self::range_query::{RangeQuery, RangeWeight};
 pub use self::range_query_u64_fastfield::FastFieldRangeWeight;
 
 // TODO is this correct?

--- a/src/query/range_query/range_query.rs
+++ b/src/query/range_query/range_query.rs
@@ -116,10 +116,7 @@ impl Query for RangeQuery {
         let field_type = schema.get_field_entry(self.field()).field_type();
 
         if field_type.is_fast() && is_type_valid_for_fastfield_range_query(self.value_type()) {
-            Ok(Box::new(FastFieldRangeWeight::new(
-                self.field(),
-                self.bounds.clone(),
-            )))
+            Ok(Box::new(FastFieldRangeWeight::new(self.bounds.clone())))
         } else {
             if field_type.is_json() {
                 return Err(crate::TantivyError::InvalidArgument(

--- a/src/query/range_query/range_query.rs
+++ b/src/query/range_query/range_query.rs
@@ -134,6 +134,7 @@ impl Query for RangeQuery {
     }
 }
 
+/// Range query on the inverted index
 pub struct RangeWeight {
     field: Field,
     lower_bound: Bound<Vec<u8>>,
@@ -142,6 +143,23 @@ pub struct RangeWeight {
 }
 
 impl RangeWeight {
+    /// Creates a new RangeWeight
+    ///
+    /// Note: The limit is only enabled with the quickwit feature flag.
+    pub fn new(
+        field: Field,
+        lower_bound: Bound<Vec<u8>>,
+        upper_bound: Bound<Vec<u8>>,
+        limit: Option<u64>,
+    ) -> Self {
+        Self {
+            field,
+            lower_bound,
+            upper_bound,
+            limit,
+        }
+    }
+
     fn term_range<'a>(&self, term_dict: &'a TermDictionary) -> io::Result<TermStreamer<'a>> {
         use std::ops::Bound::*;
         let mut term_stream_builder = term_dict.range();

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
-use columnar::ColumnType;
+use columnar::{ColumnType, NumericalType};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use thiserror::Error;
@@ -102,6 +102,15 @@ const ALL_TYPES: [Type; 10] = [
 ];
 
 impl Type {
+    pub fn numerical_type(&self) -> Option<NumericalType> {
+        match self {
+            Type::I64 => Some(NumericalType::I64),
+            Type::U64 => Some(NumericalType::U64),
+            Type::F64 => Some(NumericalType::F64),
+            _ => None,
+        }
+    }
+
     /// Returns an iterator over the different values
     /// the Type enum can tape.
     pub fn iter_values() -> impl Iterator<Item = Type> {
@@ -194,6 +203,11 @@ impl FieldType {
             FieldType::JsonObject(_) => Type::Json,
             FieldType::IpAddr(_) => Type::IpAddr,
         }
+    }
+
+    /// returns true if this is an json field
+    pub fn is_json(&self) -> bool {
+        matches!(self, FieldType::JsonObject(_))
     }
 
     /// returns true if this is an ip address field

--- a/src/schema/field_type.rs
+++ b/src/schema/field_type.rs
@@ -102,6 +102,9 @@ const ALL_TYPES: [Type; 10] = [
 ];
 
 impl Type {
+    /// Returns the numerical type if applicable
+    /// It does not do any mapping, e.g. Date is None although it's also stored as I64 in the
+    /// column store
     pub fn numerical_type(&self) -> Option<NumericalType> {
         match self {
             Type::I64 => Some(NumericalType::I64),

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -89,7 +89,7 @@ impl Term {
         term
     }
 
-    fn from_fast_value<T: FastValue>(field: Field, val: &T) -> Term {
+    pub(crate) fn from_fast_value<T: FastValue>(field: Field, val: &T) -> Term {
         let mut term = Self::with_type_and_field(T::to_type(), field);
         term.set_u64(val.to_u64());
         term

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -7,7 +7,7 @@ use common::json_path_writer::{JSON_END_OF_PATH, JSON_PATH_SEGMENT_SEP_STR};
 use common::JsonPathWriter;
 
 use super::date_time_options::DATE_TIME_PRECISION_INDEXED;
-use super::Field;
+use super::{Field, Schema};
 use crate::fastfield::FastValue;
 use crate::json_utils::split_json_path;
 use crate::schema::{Facet, Type};
@@ -55,6 +55,25 @@ impl Term {
         term.append_bytes(json_path.as_str().as_bytes());
 
         term
+    }
+
+    /// Gets the full path of the field name + optional json path.
+    pub fn get_full_path(&self, schema: &Schema) -> String {
+        let field = self.field();
+        let field_type = schema.get_field_entry(field).field_type();
+        let mut field = schema.get_field_name(field).to_string();
+        let field_name = if field_type.is_json() {
+            field.push('.');
+            let value = self.value();
+            let json_path = value.as_json().expect("expected json type in term").0;
+            field.push_str(unsafe {
+                std::str::from_utf8_unchecked(&json_path[..json_path.len() - 1])
+            });
+            field
+        } else {
+            field
+        };
+        field_name
     }
 
     pub(crate) fn with_type_and_field(typ: Type, field: Field) -> Term {
@@ -324,6 +343,11 @@ where B: AsRef<[u8]>
         ValueBytes(data)
     }
 
+    /// Wraps a object holding Vec<u8>
+    pub fn to_owned(&self) -> ValueBytes<Vec<u8>> {
+        ValueBytes(self.0.as_ref().to_vec())
+    }
+
     fn typ_code(&self) -> u8 {
         self.0.as_ref()[0]
     }
@@ -345,7 +369,7 @@ where B: AsRef<[u8]>
         if self.typ() != T::to_type() {
             return None;
         }
-        let value_bytes = self.value_bytes();
+        let value_bytes = self.raw_value_bytes_payload();
         let value_u64 = u64::from_be_bytes(value_bytes.try_into().ok()?);
         Some(T::from_u64(value_u64))
     }
@@ -390,7 +414,7 @@ where B: AsRef<[u8]>
         if self.typ() != Type::Str {
             return None;
         }
-        str::from_utf8(self.value_bytes()).ok()
+        str::from_utf8(self.raw_value_bytes_payload()).ok()
     }
 
     /// Returns the facet associated with the term.
@@ -401,7 +425,7 @@ where B: AsRef<[u8]>
         if self.typ() != Type::Facet {
             return None;
         }
-        let facet_encode_str = str::from_utf8(self.value_bytes()).ok()?;
+        let facet_encode_str = str::from_utf8(self.raw_value_bytes_payload()).ok()?;
         Some(Facet::from_encoded_string(facet_encode_str.to_string()))
     }
 
@@ -412,7 +436,7 @@ where B: AsRef<[u8]>
         if self.typ() != Type::Bytes {
             return None;
         }
-        Some(self.value_bytes())
+        Some(self.raw_value_bytes_payload())
     }
 
     /// Returns a `Ipv6Addr` value from the term.
@@ -420,7 +444,7 @@ where B: AsRef<[u8]>
         if self.typ() != Type::IpAddr {
             return None;
         }
-        let ip_u128 = u128::from_be_bytes(self.value_bytes().try_into().ok()?);
+        let ip_u128 = u128::from_be_bytes(self.raw_value_bytes_payload().try_into().ok()?);
         Some(Ipv6Addr::from_u128(ip_u128))
     }
 
@@ -441,7 +465,7 @@ where B: AsRef<[u8]>
         if self.typ() != Type::Json {
             return None;
         }
-        let bytes = self.value_bytes();
+        let bytes = self.raw_value_bytes_payload();
 
         let pos = bytes.iter().cloned().position(|b| b == JSON_END_OF_PATH)?;
         // split at pos + 1, so that json_path_bytes includes the JSON_END_OF_PATH byte.
@@ -456,14 +480,23 @@ where B: AsRef<[u8]>
         if self.typ() != Type::Json {
             return None;
         }
-        let bytes = self.value_bytes();
+        let bytes = self.raw_value_bytes_payload();
         let pos = bytes.iter().cloned().position(|b| b == JSON_END_OF_PATH)?;
         Some(ValueBytes::wrap(&bytes[pos + 1..]))
     }
 
-    /// Returns the serialized value of ValueBytes without the type.
-    fn value_bytes(&self) -> &[u8] {
+    /// Returns the raw value of ValueBytes payload, without the type tag.
+    pub(crate) fn raw_value_bytes_payload(&self) -> &[u8] {
         &self.0.as_ref()[1..]
+    }
+
+    /// Returns the serialized value of ValueBytes payload, without the type tag.
+    pub(crate) fn value_bytes_payload(&self) -> Vec<u8> {
+        if let Some(value_bytes) = self.as_json_value_bytes() {
+            value_bytes.raw_value_bytes_payload().to_vec()
+        } else {
+            self.raw_value_bytes_payload().to_vec()
+        }
     }
 
     /// Returns the serialized representation of Term.

--- a/src/schema/term.rs
+++ b/src/schema/term.rs
@@ -60,20 +60,24 @@ impl Term {
     /// Gets the full path of the field name + optional json path.
     pub fn get_full_path(&self, schema: &Schema) -> String {
         let field = self.field();
-        let field_type = schema.get_field_entry(field).field_type();
         let mut field = schema.get_field_name(field).to_string();
-        let field_name = if field_type.is_json() {
+        if let Some(json_path) = self.get_json_path() {
             field.push('.');
-            let value = self.value();
-            let json_path = value.as_json().expect("expected json type in term").0;
-            field.push_str(unsafe {
-                std::str::from_utf8_unchecked(&json_path[..json_path.len() - 1])
-            });
-            field
-        } else {
-            field
+            field.push_str(&json_path);
         };
-        field_name
+        field
+    }
+
+    /// Gets the json path if the type is JSON
+    pub fn get_json_path(&self) -> Option<String> {
+        let value = self.value();
+        if let Some((json_path, _)) = value.as_json() {
+            Some(unsafe {
+                std::str::from_utf8_unchecked(&json_path[..json_path.len() - 1]).to_string()
+            })
+        } else {
+            None
+        }
     }
 
     pub(crate) fn with_type_and_field(typ: Type, field: Field) -> Term {


### PR DESCRIPTION
Support ff range queries on json fields. Supported json field types are u64, i64, f64, term and date.

Fixes date truncation issue in Term, where DateTime was truncated to seconds precision unconditionally, but we only want to apply that truncation on the inverted index. 
It's a footgun that date needs to truncated when creating the Term. A proper fix depends on https://github.com/quickwit-oss/tantivy/pull/2366

Changes `PhrasePrefixQuery` to always use the inverted index range query 

TODO:
- Add support for non fast fields