### PR TITLE
add Key::I64 and Key::U64 variants in aggregation

### DIFF
--- a/columnar/src/value.rs
+++ b/columnar/src/value.rs
@@ -17,6 +17,31 @@ impl NumericalValue {
             NumericalValue::F64(_) => NumericalType::F64,
         }
     }
+
+    /// Tries to normalize the numerical value in the following priorities:
+    /// i64, i64, f64
+    pub fn normalize(self) -> Self {
+        match self {
+            NumericalValue::U64(val) => {
+                if val <= i64::MAX as u64 {
+                    NumericalValue::I64(val as i64)
+                } else {
+                    NumericalValue::F64(val as f64)
+                }
+            }
+            NumericalValue::I64(val) => NumericalValue::I64(val),
+            NumericalValue::F64(val) => {
+                let fract = val.fract();
+                if fract == 0.0 && val >= i64::MIN as f64 && val <= i64::MAX as f64 {
+                    NumericalValue::I64(val as i64)
+                } else if fract == 0.0 && val >= u64::MIN as f64 && val <= u64::MAX as f64 {
+                    NumericalValue::U64(val as u64)
+                } else {
+                    NumericalValue::F64(val)
+                }
+            }
+        }
+    }
 }
 
 impl From<u64> for NumericalValue {

--- a/src/aggregation/bucket/term_missing_agg.rs
+++ b/src/aggregation/bucket/term_missing_agg.rs
@@ -70,7 +70,6 @@ impl SegmentAggregationCollector for TermMissingAgg {
             )?;
             missing_entry.sub_aggregation = res;
         }
-
         entries.insert(missing.into(), missing_entry);
 
         let bucket = IntermediateBucketResult::Terms {

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -51,12 +51,18 @@ pub enum IntermediateKey {
     Str(String),
     /// `f64` key
     F64(f64),
+    /// `i64` key
+    I64(i64),
+    /// `u64` key
+    U64(u64),
 }
 impl From<Key> for IntermediateKey {
     fn from(value: Key) -> Self {
         match value {
             Key::Str(s) => Self::Str(s),
             Key::F64(f) => Self::F64(f),
+            Key::U64(f) => Self::U64(f),
+            Key::I64(f) => Self::I64(f),
         }
     }
 }
@@ -73,7 +79,9 @@ impl From<IntermediateKey> for Key {
                 }
             }
             IntermediateKey::F64(f) => Self::F64(f),
-            IntermediateKey::Bool(f) => Self::F64(f as u64 as f64),
+            IntermediateKey::Bool(f) => Self::U64(f as u64),
+            IntermediateKey::U64(f) => Self::U64(f),
+            IntermediateKey::I64(f) => Self::I64(f),
         }
     }
 }
@@ -86,6 +94,8 @@ impl std::hash::Hash for IntermediateKey {
         match self {
             IntermediateKey::Str(text) => text.hash(state),
             IntermediateKey::F64(val) => val.to_bits().hash(state),
+            IntermediateKey::U64(val) => val.hash(state),
+            IntermediateKey::I64(val) => val.hash(state),
             IntermediateKey::Bool(val) => val.hash(state),
             IntermediateKey::IpAddr(val) => val.hash(state),
         }

--- a/src/aggregation/metric/cardinality.rs
+++ b/src/aggregation/metric/cardinality.rs
@@ -191,6 +191,12 @@ impl SegmentCardinalityCollector {
                         let val = f64_to_u64(*val);
                         self.cardinality.sketch.insert_any(&val);
                     }
+                    Key::U64(val) => {
+                        self.cardinality.sketch.insert_any(&val);
+                    }
+                    Key::I64(val) => {
+                        self.cardinality.sketch.insert_any(&val);
+                    }
                 }
             }
         }

--- a/src/aggregation/metric/cardinality.rs
+++ b/src/aggregation/metric/cardinality.rs
@@ -179,10 +179,11 @@ impl SegmentCardinalityCollector {
                 Ok(())
             })?;
             if has_missing {
+                // Replace missing with the actual value provided
                 let missing_key = self
                     .missing
                     .as_ref()
-                    .expect("Found placeholder term_ord but `missing` is None");
+                    .expect("Found sentinel value u64::MAX for term_ord but `missing` is not set");
                 match missing_key {
                     Key::Str(missing) => {
                         self.cardinality.sketch.insert_any(&missing);

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -336,10 +336,16 @@ pub type SerializedKey = String;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd)]
 /// The key to identify a bucket.
+///
+/// The order is important, with serde untagged, that we try to deserialize into i64 first.
 #[serde(untagged)]
 pub enum Key {
     /// String key
     Str(String),
+    /// `i64` key
+    I64(i64),
+    /// `u64` key
+    U64(u64),
     /// `f64` key
     F64(f64),
 }
@@ -350,6 +356,8 @@ impl std::hash::Hash for Key {
         match self {
             Key::Str(text) => text.hash(state),
             Key::F64(val) => val.to_bits().hash(state),
+            Key::U64(val) => val.hash(state),
+            Key::I64(val) => val.hash(state),
         }
     }
 }
@@ -369,6 +377,8 @@ impl Display for Key {
         match self {
             Key::Str(val) => f.write_str(val),
             Key::F64(val) => f.write_str(&val.to_string()),
+            Key::U64(val) => f.write_str(&val.to_string()),
+            Key::I64(val) => f.write_str(&val.to_string()),
         }
     }
 }


### PR DESCRIPTION
Currently all `Key` numerical values are returned as f64. This causes problems in some
cases with the precision and the way f64 is serialized.

This PR adds `Key::I64` and `Key::U64` variants and uses them in the term
aggregation.

Fixes https://github.com/quickwit-oss/quickwit/issues/5254