### PR TITLE
Fill `position`s in `NgramTokenizer`

### DIFF
--- a/src/tokenizer/ngram_tokenizer.rs
+++ b/src/tokenizer/ngram_tokenizer.rs
@@ -209,8 +209,7 @@ struct StutteringIterator<T> {
 }
 
 impl<T> StutteringIterator<T>
-where
-    T: Iterator<Item = usize>,
+where T: Iterator<Item = usize>
 {
     pub fn new(underlying: T, min_gram: usize, max_gram: usize) -> StutteringIterator<T> {
         assert!(min_gram > 0);
@@ -241,8 +240,7 @@ where
 }
 
 impl<T> Iterator for StutteringIterator<T>
-where
-    T: Iterator<Item = usize>,
+where T: Iterator<Item = usize>
 {
     type Item = (usize, usize, usize);
 


### PR DESCRIPTION
I am looking into ways to make searches including non-ASCII characters. I want to search all documents that contain the query string as a substring, regardless of the word delimiter position. 

For this purpose, I tried to use `NgramTokenizer` and `PhraseQuery`.  However, it did not work as I expected. The order of the tokens seems to be ignored. I looked into the cause and found that Position was changed to all zeros in commit e75bb1d6a13f22d559072b682f9fcfac0e1ef965.

To be honest, I don't properly understand the reason for this change, but if this change was not necessary for the consistency of the specification or something, why not set the value of `position`?

So, I made a patch to fill "where the token starts, in terms of characters (not bytes)" in `position`s.

There may be a more appropriate way to do this and/or there may be something I've missed, but I would appreciate it if you could take a look.

As a supplement, I've used the following code to check the overall behavior:

```rust
// main.rs

use tantivy::collector::TopDocs;
use tantivy::query::QueryParser;
use tantivy::schema::*;
use tantivy::tokenizer::NgramTokenizer;
use tantivy::{doc, Index, IndexWriter, ReloadPolicy};

fn main() -> tantivy::Result<()> {
    let mut schema_builder = SchemaBuilder::default();

    let text_options = TextOptions::default()
        .set_stored()
        .set_indexing_options(
            TextFieldIndexing::default()
                .set_index_option(IndexRecordOption::WithFreqsAndPositions)
                .set_tokenizer("ngram"),
        )
        .set_stored();

    schema_builder.add_text_field("text", text_options);
    let schema = schema_builder.build();

    let index = Index::create_in_ram(schema.clone());
    let mut index_writer: IndexWriter = index.writer(50_000_000)?;

    let tokenizer = NgramTokenizer::new(1, 1, false)?;
    index.tokenizers().register("ngram", tokenizer.clone());

    let text = schema.get_field("text").unwrap();

    // This is the only document in the index
    index_writer.add_document(doc!(
    text => "本日は晴天なり", // 本日は晴天なり: Today is a fine day
    ))?;
    index_writer.commit()?;

    let reader = index
        .reader_builder()
        .reload_policy(ReloadPolicy::OnCommitWithDelay)
        .try_into()?;
    let searcher = reader.searcher();

    let query_parser = QueryParser::for_index(&index, vec![text]);

    // ✅ Work as expected
    let query = query_parser.parse_query(r#""本日は""#)?; // 本日は: Today is
    println!("Query: {:?}", query);
    let top_docs = searcher.search(&query, &TopDocs::with_limit(10))?;
    for (_score, doc_address) in top_docs {
        let retrieved_doc: TantivyDocument = searcher.doc(doc_address)?;
        println!("Matched (as expected): {}", retrieved_doc.to_json(&schema));
    }

    // ❌ Should not return any results
    println!();
    let query = query_parser.parse_query(r#""日本は""#)?; // 日本は: Japan is
    println!("Query: {:?}", query);
    let top_docs = searcher.search(&query, &TopDocs::with_limit(10))?;
    for (_score, doc_address) in top_docs {
        let retrieved_doc: TantivyDocument = searcher.doc(doc_address)?;
        println!(
            "Matched (but not expeced): {}",
            retrieved_doc.to_json(&schema)
        );
    }

    Ok(())
}
```