### PR TITLE
make find_field_with_default return json fields without path

### DIFF
--- a/src/schema/schema.rs
+++ b/src/schema/schema.rs
@@ -363,7 +363,7 @@ impl Schema {
             .or(default_field_opt.map(|field| (field, full_path)))?;
         let field_entry = self.get_field_entry(field);
         let is_json = field_entry.field_type().value_type() == Type::Json;
-        if is_json == json_path.is_empty() {
+        if !is_json && !json_path.is_empty() {
             return None;
         }
         Some((field, json_path))


### PR DESCRIPTION
this is useful for concatenate fields (they are json under the hood), and possibly json fields if we ever allow value at the root of a json field. We still forbid non-json field with a path