### PR TITLE
clippy + cleanup

### DIFF
--- a/bitpacker/src/filter_vec/mod.rs
+++ b/bitpacker/src/filter_vec/mod.rs
@@ -35,7 +35,6 @@ const IMPLS: [FilterImplPerInstructionSet; 2] = [
 const IMPLS: [FilterImplPerInstructionSet; 1] = [FilterImplPerInstructionSet::Scalar];
 
 impl FilterImplPerInstructionSet {
-    #[allow(unused_variables)]
     #[inline]
     fn from(code: u8) -> FilterImplPerInstructionSet {
         #[cfg(target_arch = "x86_64")]

--- a/columnar/src/column_index/optional_index/set_block/sparse.rs
+++ b/columnar/src/column_index/optional_index/set_block/sparse.rs
@@ -80,7 +80,7 @@ impl<'a> SparseBlock<'a> {
     }
 
     #[inline]
-    #[allow(clippy::comparison_chain)]
+    #[expect(clippy::comparison_chain)]
     // Looks for the element in the block. Returns the positions if found.
     fn binary_search(&self, target: u16) -> Result<u16, u16> {
         let data = &self.0;

--- a/columnar/src/columnar/writer/column_operation.rs
+++ b/columnar/src/columnar/writer/column_operation.rs
@@ -122,7 +122,7 @@ impl<T> From<T> for ColumnOperation<T> {
 // In order to limit memory usage, and in order
 // to benefit from the stacker, we do this by serialization our data
 // as "Symbols".
-#[allow(clippy::from_over_into)]
+#[expect(clippy::from_over_into)]
 pub(super) trait SymbolValue: Clone + Copy {
     // Serializes the symbol into the given buffer.
     // Returns the number of bytes written into the buffer.

--- a/columnar/src/columnar/writer/mod.rs
+++ b/columnar/src/columnar/writer/mod.rs
@@ -392,7 +392,7 @@ impl ColumnarWriter {
 
 // Serialize [Dictionary, Column, dictionary num bytes U32::LE]
 // Column: [Column Index, Column Values, column index num bytes U32::LE]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn serialize_bytes_or_str_column(
     cardinality: Cardinality,
     num_docs: RowId,

--- a/query-grammar/src/infallible.rs
+++ b/query-grammar/src/infallible.rs
@@ -111,7 +111,6 @@ where F: nom::Parser<I, (O, ErrorList), Infallible> {
         Err(Err::Incomplete(needed)) => Err(Err::Incomplete(needed)),
         // old versions don't understand this is uninhabited and need the empty match to help,
         // newer versions warn because this arm is unreachable (which it is indeed).
-        #[allow(unreachable_patterns)]
         Err(Err::Error(val)) | Err(Err::Failure(val)) => match val {},
     }
 }

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -767,7 +767,7 @@ fn occur_leaf(inp: &str) -> IResult<&str, (Option<Occur>, UserInputAst)> {
     tuple((fallible(occur_symbol), boosted_leaf))(inp)
 }
 
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 fn operand_occur_leaf_infallible(
     inp: &str,
 ) -> JResult<&str, (Option<BinaryOperand>, Option<Occur>, Option<UserInputAst>)> {

--- a/src/aggregation/agg_tests.rs
+++ b/src/aggregation/agg_tests.rs
@@ -585,7 +585,7 @@ fn test_aggregation_invalid_requests() -> crate::Result<()> {
         }
     }));
 
-    assert_eq!(agg_req_1.is_err(), true);
+    assert!(agg_req_1.is_err());
     assert_eq!(agg_req_1.unwrap_err().to_string(), "missing field `field`");
 
     let agg_req_1: Result<Aggregations, serde_json::Error> = serde_json::from_value(json!({
@@ -596,7 +596,7 @@ fn test_aggregation_invalid_requests() -> crate::Result<()> {
         }
     }));
 
-    assert_eq!(agg_req_1.is_err(), true);
+    assert!(agg_req_1.is_err());
     // TODO: This should list valid values
     assert!(agg_req_1
         .unwrap_err()

--- a/src/collector/multi_collector.rs
+++ b/src/collector/multi_collector.rs
@@ -161,7 +161,7 @@ impl<TFruit: Fruit> FruitHandle<TFruit> {
 /// # Ok(())
 /// # }
 /// ```
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 #[derive(Default)]
 pub struct MultiCollector<'a> {
     collector_wrappers: Vec<

--- a/src/core/json_utils.rs
+++ b/src/core/json_utils.rs
@@ -71,7 +71,7 @@ pub fn json_path_sep_to_dot(path: &mut str) {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn index_json_object<'a, V: Value<'a>>(
     doc: DocId,
     json_visitor: V::ObjectIter,
@@ -101,7 +101,7 @@ fn index_json_object<'a, V: Value<'a>>(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn index_json_value<'a, V: Value<'a>>(
     doc: DocId,
     json_value: V,

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -39,7 +39,7 @@ impl RetryPolicy {
 /// The `DirectoryLock` is an object that represents a file lock.
 ///
 /// It is associated with a lock file, that gets deleted on `Drop.`
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub struct DirectoryLock(Box<dyn Send + Sync + 'static>);
 
 struct DirectoryLockGuard {

--- a/src/directory/mmap_directory.rs
+++ b/src/directory/mmap_directory.rs
@@ -244,7 +244,7 @@ impl MmapDirectory {
                 directory_path,
             )));
         }
-        #[allow(clippy::bind_instead_of_map)]
+        #[expect(clippy::bind_instead_of_map)]
         let canonical_path: PathBuf = directory_path.canonicalize().or_else(|io_err| {
             let directory_path = directory_path.to_owned();
 

--- a/src/directory/watch_event_router.rs
+++ b/src/directory/watch_event_router.rs
@@ -32,7 +32,7 @@ pub struct WatchCallbackList {
 /// file change is detected.
 #[must_use = "This `WatchHandle` controls the lifetime of the watch and should therefore be used."]
 #[derive(Clone)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub struct WatchHandle(Arc<WatchCallback>);
 
 impl WatchHandle {

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -839,12 +839,12 @@ mod tests {
             .bool("field_bool")
             .unwrap()
             .first_or_default_col(false);
-        assert_eq!(col.get_val(0), false);
+        assert!(!col.get_val(0));
         let col = fastfield_readers
             .bool("field_bool")
             .unwrap()
             .first_or_default_col(true);
-        assert_eq!(col.get_val(0), true);
+        assert!(col.get_val(0));
     }
 
     fn get_index(docs: &[crate::TantivyDocument], schema: &Schema) -> crate::Result<RamDirectory> {

--- a/src/functional_test.rs
+++ b/src/functional_test.rs
@@ -4,7 +4,6 @@ use rand::{thread_rng, Rng};
 
 use crate::indexer::index_writer::MEMORY_BUDGET_NUM_BYTES_MIN;
 use crate::schema::*;
-#[allow(deprecated)]
 use crate::{doc, schema, Index, IndexWriter, Searcher};
 
 fn check_index_content(searcher: &Searcher, vals: &[u64]) -> crate::Result<()> {

--- a/src/functional_test.rs
+++ b/src/functional_test.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)] // Remove with index sorting
-
 use std::collections::HashSet;
 
 use rand::{thread_rng, Rng};

--- a/src/index/inverted_index_reader.rs
+++ b/src/index/inverted_index_reader.rs
@@ -31,7 +31,6 @@ pub struct InvertedIndexReader {
 }
 
 impl InvertedIndexReader {
-    #[allow(clippy::needless_pass_by_value)] // for symmetry
     pub(crate) fn new(
         termdict: TermDictionary,
         postings_file_slice: FileSlice,

--- a/src/index/segment_reader.rs
+++ b/src/index/segment_reader.rs
@@ -478,7 +478,7 @@ pub fn merge_field_meta_data(
         .into_iter()
         .kmerge_by(|left, right| left < right)
         // TODO: Remove allocation
-        .group_by(|el| (el.field_name.to_string(), el.typ))
+        .chunk_by(|el| (el.field_name.to_string(), el.typ))
     {
         let mut merged: FieldMetadata = group.next().unwrap();
         for el in group {

--- a/src/indexer/delete_queue.rs
+++ b/src/indexer/delete_queue.rs
@@ -187,7 +187,6 @@ impl DeleteCursor {
         }
     }
 
-    #[allow(clippy::wrong_self_convention)]
     fn is_behind_opstamp(&mut self, target_opstamp: Opstamp) -> bool {
         self.get()
             .map(|operation| operation.opstamp < target_opstamp)

--- a/src/indexer/doc_opstamp_mapping.rs
+++ b/src/indexer/doc_opstamp_mapping.rs
@@ -53,10 +53,10 @@ mod tests {
     #[test]
     fn test_doc_to_opstamp_mapping_with_map() {
         let doc_to_opstamp_mapping = DocToOpstampMapping::WithMap(&[5u64, 1u64, 0u64, 4u64, 3u64]);
-        assert_eq!(doc_to_opstamp_mapping.is_deleted(0u32, 2u64), false);
-        assert_eq!(doc_to_opstamp_mapping.is_deleted(1u32, 2u64), true);
-        assert_eq!(doc_to_opstamp_mapping.is_deleted(2u32, 2u64), true);
-        assert_eq!(doc_to_opstamp_mapping.is_deleted(3u32, 2u64), false);
-        assert_eq!(doc_to_opstamp_mapping.is_deleted(4u32, 2u64), false);
+        assert!(!doc_to_opstamp_mapping.is_deleted(0u32, 2u64));
+        assert!(doc_to_opstamp_mapping.is_deleted(1u32, 2u64));
+        assert!(doc_to_opstamp_mapping.is_deleted(2u32, 2u64));
+        assert!(!doc_to_opstamp_mapping.is_deleted(3u32, 2u64));
+        assert!(!doc_to_opstamp_mapping.is_deleted(4u32, 2u64));
     }
 }

--- a/src/indexer/log_merge_policy.rs
+++ b/src/indexer/log_merge_policy.rs
@@ -104,7 +104,7 @@ impl MergePolicy for LogMergePolicy {
 
         let mut current_max_log_size = f64::MAX;
         let mut levels = vec![];
-        for (_, merge_group) in &size_sorted_segments.into_iter().group_by(|segment| {
+        for (_, merge_group) in &size_sorted_segments.into_iter().chunk_by(|segment| {
             let segment_log_size = f64::from(self.clip_min_size(segment.num_docs())).log2();
             if segment_log_size < (current_max_log_size - self.level_log_size) {
                 // update current_max_log_size to create a new group

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -150,7 +150,7 @@ impl SegmentWriter {
         let vals_grouped_by_field = doc
             .iter_fields_and_values()
             .sorted_by_key(|(field, _)| *field)
-            .group_by(|(field, _)| *field);
+            .chunk_by(|(field, _)| *field);
 
         for (field, field_values) in &vals_grouped_by_field {
             let values = field_values.map(|el| el.1);

--- a/src/indexer/stamper.rs
+++ b/src/indexer/stamper.rs
@@ -101,7 +101,7 @@ mod test {
 
     use super::Stamper;
 
-    #[allow(clippy::redundant_clone)]
+    #[expect(clippy::redundant_clone)]
     #[test]
     fn test_stamper() {
         let stamper = Stamper::new(7u64);
@@ -117,7 +117,7 @@ mod test {
         assert_eq!(stamper.stamp(), 15u64);
     }
 
-    #[allow(clippy::redundant_clone)]
+    #[expect(clippy::redundant_clone)]
     #[test]
     fn test_stamper_revert() {
         let stamper = Stamper::new(7u64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,11 @@
 #![cfg_attr(all(feature = "unstable", test), feature(test))]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
 #![warn(missing_docs)]
-#![allow(
+#![expect(
     clippy::len_without_is_empty,
     clippy::derive_partial_eq_without_eq,
     clippy::module_inception,
-    clippy::needless_range_loop,
-    clippy::bool_assert_comparison
+    clippy::needless_range_loop
 )]
 
 //! # `tantivy`
@@ -178,7 +177,6 @@ pub use crate::future_result::FutureResult;
 pub type Result<T> = std::result::Result<T, TantivyError>;
 
 mod core;
-#[allow(deprecated)] // Remove with index sorting
 pub mod indexer;
 
 #[allow(unused_doc_comments)]
@@ -190,7 +188,6 @@ pub mod collector;
 pub mod directory;
 pub mod fastfield;
 pub mod fieldnorm;
-#[allow(deprecated)] // Remove with index sorting
 pub mod index;
 pub mod positions;
 pub mod postings;
@@ -223,7 +220,6 @@ pub use self::docset::{DocSet, COLLECT_BLOCK_BUFFER_LEN, TERMINATED};
 pub use crate::core::json_utils;
 pub use crate::core::{Executor, Searcher, SearcherGeneration};
 pub use crate::directory::Directory;
-#[allow(deprecated)] // Remove with index sorting
 pub use crate::index::{
     Index, IndexBuilder, IndexMeta, IndexSettings, InvertedIndexReader, Order, Segment,
     SegmentMeta, SegmentReader,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ pub type Result<T> = std::result::Result<T, TantivyError>;
 mod core;
 pub mod indexer;
 
-#[allow(unused_doc_comments)]
+#[expect(unused_doc_comments)]
 pub mod error;
 pub mod tokenizer;
 

--- a/src/postings/mod.rs
+++ b/src/postings/mod.rs
@@ -29,7 +29,7 @@ pub use self::serializer::{FieldSerializer, InvertedIndexSerializer};
 pub(crate) use self::skip::{BlockInfo, SkipReader};
 pub use self::term_info::TermInfo;
 
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
 pub(crate) enum FreqReadingOption {
     NoFreq,

--- a/src/query/boolean_query/block_wand.rs
+++ b/src/query/boolean_query/block_wand.rs
@@ -417,7 +417,7 @@ mod tests {
             .boxed()
     }
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn gen_term_scorers(num_scorers: usize) -> BoxedStrategy<(Vec<Vec<(DocId, u32)>>, Vec<u32>)> {
         (1u32..100u32)
             .prop_flat_map(move |max_doc: u32| {

--- a/src/query/phrase_prefix_query/phrase_prefix_scorer.rs
+++ b/src/query/phrase_prefix_query/phrase_prefix_scorer.rs
@@ -8,7 +8,7 @@ use crate::{DocId, Score};
 
 // MultiPrefix is the larger variant, and also the one we expect most often. PhraseScorer is > 1kB
 // though, it would be interesting to slim it down if possible.
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 enum PhraseKind<TPostings: Postings> {
     SinglePrefix {
         position_offset: u32,

--- a/src/query/range_query/range_query_fastfield.rs
+++ b/src/query/range_query/range_query_fastfield.rs
@@ -402,7 +402,7 @@ fn search_on_u64_ff(
     boost: Score,
     bounds: BoundsRange<u64>,
 ) -> crate::Result<Box<dyn Scorer>> {
-    #[allow(clippy::reversed_empty_ranges)]
+    #[expect(clippy::reversed_empty_ranges)]
     let value_range = bound_to_value_range(
         &bounds.lower_bound,
         &bounds.upper_bound,

--- a/src/schema/document/de.rs
+++ b/src/schema/document/de.rs
@@ -381,7 +381,7 @@ where R: Read
             type_codes::NULL_CODE => ValueType::Null,
             type_codes::ARRAY_CODE => ValueType::Array,
             type_codes::OBJECT_CODE => ValueType::Object,
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             type_codes::JSON_OBJ_CODE => ValueType::JSONObject,
             _ => {
                 return Err(DeserializeError::from(io::Error::new(

--- a/src/space_usage/mod.rs
+++ b/src/space_usage/mod.rs
@@ -78,7 +78,7 @@ pub struct SegmentSpaceUsage {
 }
 
 impl SegmentSpaceUsage {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         num_docs: u32,
         termdict: PerFieldSpaceUsage,

--- a/src/store/compression_lz4_block.rs
+++ b/src/store/compression_lz4_block.rs
@@ -4,7 +4,7 @@ use std::mem;
 use lz4_flex::{compress_into, decompress_into};
 
 #[inline]
-#[allow(clippy::uninit_vec)]
+#[expect(clippy::uninit_vec)]
 pub fn compress(uncompressed: &[u8], compressed: &mut Vec<u8>) -> io::Result<()> {
     compressed.clear();
     let maximum_ouput_size =
@@ -24,7 +24,7 @@ pub fn compress(uncompressed: &[u8], compressed: &mut Vec<u8>) -> io::Result<()>
 }
 
 #[inline]
-#[allow(clippy::uninit_vec)]
+#[expect(clippy::uninit_vec)]
 pub fn decompress(compressed: &[u8], decompressed: &mut Vec<u8>) -> io::Result<()> {
     decompressed.clear();
     let uncompressed_size_bytes: &[u8; 4] = compressed

--- a/src/termdict/fst_termdict/streamer.rs
+++ b/src/termdict/fst_termdict/streamer.rs
@@ -136,7 +136,7 @@ where A: Automaton
     }
 
     /// Return the next `(key, value)` pair.
-    #[allow(clippy::should_implement_trait)]
+    #[expect(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<(&[u8], &TermInfo)> {
         if self.advance() {
             Some((self.key(), self.value()))

--- a/src/termdict/mod.rs
+++ b/src/termdict/mod.rs
@@ -49,7 +49,6 @@ use crate::postings::TermInfo;
 
 #[derive(Debug, Eq, PartialEq)]
 #[repr(u32)]
-#[allow(dead_code)]
 enum DictionaryType {
     Fst = 1,
     SSTable = 2,

--- a/src/tokenizer/regex_tokenizer.rs
+++ b/src/tokenizer/regex_tokenizer.rs
@@ -143,7 +143,7 @@ mod tests {
     #[test]
     fn test_regexp_tokenizer_error_on_invalid_regex() {
         let tokenizer = RegexTokenizer::new(r"\@(");
-        assert_eq!(tokenizer.is_err(), true);
+        assert!(tokenizer.is_err());
         assert_eq!(
             tokenizer.err().unwrap().to_string(),
             "An invalid argument was passed: '\\@('"

--- a/sstable/src/lib.rs
+++ b/sstable/src/lib.rs
@@ -85,7 +85,6 @@ pub trait SSTable: Sized {
     }
 }
 
-#[allow(dead_code)]
 pub struct VoidSSTable;
 
 impl SSTable for VoidSSTable {
@@ -100,7 +99,6 @@ impl SSTable for VoidSSTable {
 /// In other words, two keys `k1` and `k2`
 /// such that `k1` <= `k2`, are required to observe
 /// `range_sstable[k1] <= range_sstable[k2]`.
-#[allow(dead_code)]
 pub struct MonotonicU64SSTable;
 
 impl SSTable for MonotonicU64SSTable {

--- a/sstable/src/merge/heap_merge.rs
+++ b/sstable/src/merge/heap_merge.rs
@@ -26,7 +26,6 @@ impl<B: AsRef<[u8]>> PartialEq for HeapItem<B> {
     }
 }
 
-#[allow(dead_code)]
 pub fn merge_sstable<SST: SSTable, W: io::Write, M: ValueMerger<SST::Value>>(
     readers: Vec<Reader<SST::ValueReader>>,
     mut writer: Writer<W, SST::ValueWriter>,

--- a/sstable/src/streamer.rs
+++ b/sstable/src/streamer.rs
@@ -264,7 +264,7 @@ where
     }
 
     /// Return the next `(key, value)` pair.
-    #[allow(clippy::should_implement_trait)]
+    #[expect(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<(&[u8], &TSSTable::Value)> {
         if self.advance() {
             Some((self.key(), self.value()))

--- a/sstable/src/value/range.rs
+++ b/sstable/src/value/range.rs
@@ -78,7 +78,7 @@ impl ValueWriter for RangeValueWriter {
 }
 
 #[cfg(test)]
-#[allow(clippy::single_range_in_vec_init)]
+#[expect(clippy::single_range_in_vec_init)]
 mod tests {
     use super::*;
 

--- a/stacker/src/lib.rs
+++ b/stacker/src/lib.rs
@@ -5,7 +5,6 @@ extern crate test;
 
 mod arena_hashmap;
 mod expull;
-#[allow(dead_code)]
 mod fastcmp;
 mod fastcpy;
 mod memory_arena;

--- a/stacker/src/memory_arena.rs
+++ b/stacker/src/memory_arena.rs
@@ -89,7 +89,6 @@ pub fn load<Item: Copy + 'static>(data: &[u8]) -> Item {
 }
 
 /// The `MemoryArena`
-#[allow(clippy::new_without_default)]
 pub struct MemoryArena {
     pages: Vec<Page>,
 }


### PR DESCRIPTION
use new expect lint in clippy, which works like allow, but errors if the lint is not required anymore

convert clippy allow to clippy expect and remove unused

cleanup
