### PR TITLE
ci: Switch from actions-rs/toolchain to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/long_running.yml
+++ b/.github/workflows/long_running.yml
@@ -21,12 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
           toolchain: stable
-          profile: minimal
-          override: true
-
     - name: Run indexing_unsorted
       run: cargo test indexing_unsorted -- --ignored
     - name: Run indexing_sorted

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,16 +23,15 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install nightly
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
             toolchain: nightly
-            profile: minimal
             components: rustfmt
+
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
             toolchain: stable
-            profile: minimal
             components: clippy
 
     - uses: Swatinem/rust-cache@v2
@@ -70,11 +69,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
             toolchain: stable
-            profile: minimal
-            override: true
 
     - uses: taiki-e/install-action@nextest
     - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
The `actions-rs` actions haven't been maintained in a very long time.

This leaves the `actions-rs/clippy` usage for a subsequent commit as there is a change in behavior when not using that.