### PR TITLE
Update MSRV to 1.75

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/quickwit-oss/tantivy"
 readme = "README.md"
 keywords = ["search", "information", "retrieval"]
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.75"
 exclude = ["benches/*.json", "benches/*.txt"]
 
 [dependencies]


### PR DESCRIPTION
This is required by the `fs4` dependency. There are other things that need something later than 1.66.

Both quickwit and the Python binding already require something newer.