### PR TITLE
feat: make `BlockSegmentPostings::open` and `TermInfoStore` public

### DIFF
--- a/src/postings/block_segment_postings.rs
+++ b/src/postings/block_segment_postings.rs
@@ -94,7 +94,7 @@ impl BlockSegmentPostings {
     /// `requested_option` is the amount of data requested by the user.
     /// If for instance, we do not request for term frequencies, this function will not decompress
     /// term frequency blocks.
-    pub(crate) fn open(
+    pub fn open(
         doc_freq: u32,
         data: FileSlice,
         mut record_option: IndexRecordOption,

--- a/src/query/boost_query.rs
+++ b/src/query/boost_query.rs
@@ -20,6 +20,16 @@ impl BoostQuery {
     pub fn new(query: Box<dyn Query>, boost: Score) -> BoostQuery {
         BoostQuery { query, boost }
     }
+
+    /// The wrapped query.
+    pub fn query(&self) -> Box<dyn Query> {
+        self.query.box_clone()
+    }
+
+    /// The boost score.
+    pub fn boost(&self) -> Score {
+        self.boost
+    }
 }
 
 impl Clone for BoostQuery {

--- a/src/query/boost_query.rs
+++ b/src/query/boost_query.rs
@@ -21,13 +21,13 @@ impl BoostQuery {
         BoostQuery { query, boost }
     }
 
-    /// The wrapped query.
-    pub fn query(&self) -> Box<dyn Query> {
+    /// The underlying query.
+    pub fn underlying_query(&self) -> Box<dyn Query> {
         self.query.box_clone()
     }
 
-    /// The boost score.
-    pub fn boost(&self) -> Score {
+    /// Get the boost score.
+    pub fn get_boost(&self) -> Score {
         self.boost
     }
 }

--- a/src/query/const_score_query.rs
+++ b/src/query/const_score_query.rs
@@ -20,13 +20,13 @@ impl ConstScoreQuery {
         ConstScoreQuery { query, score }
     }
 
-    /// The wrapped query.
-    pub fn query(&self) -> Box<dyn Query> {
+    /// The underlying query.
+    pub fn underlying_query(&self) -> Box<dyn Query> {
         self.query.box_clone()
     }
 
-    /// The constant score.
-    pub fn score(&self) -> Score {
+    /// Get the constant score.
+    pub fn get_const_score(&self) -> Score {
         self.score
     }
 }

--- a/src/query/const_score_query.rs
+++ b/src/query/const_score_query.rs
@@ -19,6 +19,16 @@ impl ConstScoreQuery {
     pub fn new(query: Box<dyn Query>, score: Score) -> ConstScoreQuery {
         ConstScoreQuery { query, score }
     }
+
+    /// The wrapped query.
+    pub fn query(&self) -> Box<dyn Query> {
+        self.query.box_clone()
+    }
+
+    /// The constant score.
+    pub fn score(&self) -> Score {
+        self.score
+    }
 }
 
 impl Clone for ConstScoreQuery {

--- a/src/query/fuzzy_query.rs
+++ b/src/query/fuzzy_query.rs
@@ -173,11 +173,20 @@ impl FuzzyTermQuery {
             ))
         }
     }
+
+    /// The `Term` this query is built out of.
+    pub fn term(&self) -> &Term {
+        &self.term
+    }
 }
 
 impl Query for FuzzyTermQuery {
     fn weight(&self, _enable_scoring: EnableScoring<'_>) -> crate::Result<Box<dyn Weight>> {
         Ok(Box::new(self.specialized_weight()?))
+    }
+
+    fn query_terms<'a>(&'a self, visitor: &mut dyn FnMut(&'a Term, bool)) {
+        visitor(&self.term, false);
     }
 }
 

--- a/src/query/phrase_prefix_query/phrase_prefix_query.rs
+++ b/src/query/phrase_prefix_query/phrase_prefix_query.rs
@@ -83,8 +83,8 @@ impl PhrasePrefixQuery {
     }
 
     /// `Term`s in the phrase with the associated offsets.
-    pub fn phrase_terms_with_offsets(&self) -> Vec<(usize, Term)> {
-        self.phrase_terms.clone()
+    pub fn get_phrase_terms_with_offsets(&self) -> &[(usize, Term)] {
+        self.phrase_terms
     }
 
     /// The prefix `Term` in the phrase with the associated offset.

--- a/src/query/phrase_prefix_query/phrase_prefix_query.rs
+++ b/src/query/phrase_prefix_query/phrase_prefix_query.rs
@@ -84,7 +84,7 @@ impl PhrasePrefixQuery {
 
     /// `Term`s in the phrase with the associated offsets.
     pub fn get_phrase_terms_with_offsets(&self) -> &[(usize, Term)] {
-        self.phrase_terms
+        &self.phrase_terms
     }
 
     /// The prefix `Term` in the phrase with the associated offset.

--- a/src/query/phrase_prefix_query/phrase_prefix_query.rs
+++ b/src/query/phrase_prefix_query/phrase_prefix_query.rs
@@ -82,6 +82,16 @@ impl PhrasePrefixQuery {
             .collect::<Vec<Term>>()
     }
 
+    /// `Term`s in the phrase with the associated offsets.
+    pub fn phrase_terms_with_offsets(&self) -> Vec<(usize, Term)> {
+        self.phrase_terms.clone()
+    }
+
+    /// The prefix `Term` in the phrase with the associated offset.
+    pub fn prefix_term_with_offset(&self) -> (usize, Term) {
+        self.prefix.clone()
+    }
+
     /// Returns the [`PhrasePrefixWeight`] for the given phrase query given a specific `searcher`.
     ///
     /// This function is the same as [`Query::weight()`] except it returns

--- a/src/query/phrase_query/phrase_query.rs
+++ b/src/query/phrase_query/phrase_query.rs
@@ -94,6 +94,11 @@ impl PhraseQuery {
             .collect::<Vec<Term>>()
     }
 
+    /// `Term`s in the phrase with the associated offsets.
+    pub fn phrase_terms_with_offsets(&self) -> Vec<(usize, Term)> {
+        self.phrase_terms.clone()
+    }
+
     /// Returns the [`PhraseWeight`] for the given phrase query given a specific `searcher`.
     ///
     /// This function is the same as [`Query::weight()`] except it returns

--- a/src/query/phrase_query/phrase_query.rs
+++ b/src/query/phrase_query/phrase_query.rs
@@ -96,7 +96,7 @@ impl PhraseQuery {
 
     /// `Term`s in the phrase with the associated offsets.
     pub fn get_phrase_terms_with_offsets(&self) -> &[(usize, Term)] {
-        self.phrase_terms
+        &self.phrase_terms
     }
 
     /// Returns the [`PhraseWeight`] for the given phrase query given a specific `searcher`.

--- a/src/query/phrase_query/phrase_query.rs
+++ b/src/query/phrase_query/phrase_query.rs
@@ -95,8 +95,8 @@ impl PhraseQuery {
     }
 
     /// `Term`s in the phrase with the associated offsets.
-    pub fn phrase_terms_with_offsets(&self) -> Vec<(usize, Term)> {
-        self.phrase_terms.clone()
+    pub fn get_phrase_terms_with_offsets(&self) -> &[(usize, Term)] {
+        self.phrase_terms
     }
 
     /// Returns the [`PhraseWeight`] for the given phrase query given a specific `searcher`.

--- a/src/termdict/fst_termdict/mod.rs
+++ b/src/termdict/fst_termdict/mod.rs
@@ -25,4 +25,5 @@ mod termdict;
 
 pub use self::merger::TermMerger;
 pub use self::streamer::{TermStreamer, TermStreamerBuilder};
+pub use self::term_info_store::TermInfoStore;
 pub use self::termdict::{TermDictionary, TermDictionaryBuilder};

--- a/src/termdict/mod.rs
+++ b/src/termdict/mod.rs
@@ -22,6 +22,8 @@
 mod fst_termdict;
 #[cfg(not(feature = "quickwit"))]
 use fst_termdict as termdict;
+#[cfg(not(feature = "quickwit"))]
+pub use fst_termdict::TermInfoStore;
 
 #[cfg(feature = "quickwit")]
 mod sstable_termdict;
@@ -44,7 +46,7 @@ use self::termdict::{
     TermDictionary as InnerTermDict, TermDictionaryBuilder as InnerTermDictBuilder,
     TermStreamerBuilder,
 };
-pub use self::termdict::{TermInfoStore, TermMerger, TermStreamer};
+pub use self::termdict::{TermMerger, TermStreamer};
 use crate::postings::TermInfo;
 
 #[repr(u32)]

--- a/src/termdict/mod.rs
+++ b/src/termdict/mod.rs
@@ -44,7 +44,7 @@ use self::termdict::{
     TermDictionary as InnerTermDict, TermDictionaryBuilder as InnerTermDictBuilder,
     TermStreamerBuilder,
 };
-pub use self::termdict::{TermMerger, TermStreamer};
+pub use self::termdict::{TermInfoStore, TermMerger, TermStreamer};
 use crate::postings::TermInfo;
 
 #[repr(u32)]


### PR DESCRIPTION
Databend uses tantivy to implement inverted index, and tantivy `Searcher` needs to read all the index file data when starting up, which is very large, resulting in poor query performance. To improve performance, we implemented the `Searcher` ourselves to query the matched docs, and improve performance by reading only the `FST` data, `TermInfo` data, and the matched terms related data to reduce the size of data to be read. We need to use `BlockSegmentPostings` and `TermInfoStore`, as well as some fields from the `Query`.