### PR TITLE
refactor: change 'wait_merging_threads' to take &self instead of self

### DIFF
--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -330,7 +330,7 @@ impl<D: Document> IndexWriter<D> {
 
     /// If there are some merging threads, blocks until they all finish their work and
     /// then drop the `IndexWriter`.
-    pub fn wait_merging_threads(mut self) -> crate::Result<()> {
+    pub fn wait_merging_threads(&mut self) -> crate::Result<()> {
         // this will stop the indexing thread,
         // dropping the last reference to the segment_updater.
         self.drop_sender();


### PR DESCRIPTION
to avoid the "cannot move out of dereference of self" error in multi-threaded scenarios. 
making it easier to handle ownership properly