### PR TITLE
Improve `IndexWriter` customisation via builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ fastdivide = "0.4.0"
 itertools = "0.13.0"
 measure_time = "0.8.2"
 arc-swap = "1.5.0"
+bon = "3.3.1"
 
 columnar = { version = "0.3", path = "./columnar", package = "tantivy-columnar" }
 sstable = { version = "0.3", path = "./sstable", package = "tantivy-sstable", optional = true }

--- a/examples/index_from_multiple_threads.rs
+++ b/examples/index_from_multiple_threads.rs
@@ -48,8 +48,7 @@ fn main() -> tantivy::Result<()> {
         // we index 100 times the document... for the sake of the example.
         for i in 0..100 {
             let opstamp = index_writer_clone_1
-                .write()
-                .unwrap() //< A read lock is sufficient here.
+                .read().unwrap() //< A read lock is sufficient here.
                 .add_document(
                     doc!(
                         title => "Of Mice and Men",
@@ -75,9 +74,9 @@ fn main() -> tantivy::Result<()> {
     thread::spawn(move || {
         // we index 100 times the document... for the sake of the example.
         for i in 0..100 {
-            // A write lock is required here.
+            // A read lock is sufficient here.
             let opstamp = {
-                let mut index_writer_rlock = index_writer_clone_2.write().unwrap();
+                let index_writer_rlock = index_writer_clone_2.read().unwrap();
                 index_writer_rlock.add_document(doc!(
                     title => "Manufacturing consent",
                     body => "Some great book description..."

--- a/examples/index_from_multiple_threads.rs
+++ b/examples/index_from_multiple_threads.rs
@@ -48,7 +48,8 @@ fn main() -> tantivy::Result<()> {
         // we index 100 times the document... for the sake of the example.
         for i in 0..100 {
             let opstamp = index_writer_clone_1
-                .read().unwrap() //< A read lock is sufficient here.
+                .write()
+                .unwrap() //< A read lock is sufficient here.
                 .add_document(
                     doc!(
                         title => "Of Mice and Men",
@@ -74,9 +75,9 @@ fn main() -> tantivy::Result<()> {
     thread::spawn(move || {
         // we index 100 times the document... for the sake of the example.
         for i in 0..100 {
-            // A read lock is sufficient here.
+            // A write lock is required here.
             let opstamp = {
-                let index_writer_rlock = index_writer_clone_2.read().unwrap();
+                let mut index_writer_rlock = index_writer_clone_2.write().unwrap();
                 index_writer_rlock.add_document(doc!(
                     title => "Manufacturing consent",
                     body => "Some great book description..."

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -15,7 +15,9 @@ use crate::directory::MmapDirectory;
 use crate::directory::{Directory, ManagedDirectory, RamDirectory, INDEX_WRITER_LOCK};
 use crate::error::{DataCorruption, TantivyError};
 use crate::index::{IndexMeta, SegmentId, SegmentMeta, SegmentMetaInventory};
-use crate::indexer::index_writer::{MAX_NUM_THREAD, MEMORY_BUDGET_NUM_BYTES_MIN};
+use crate::indexer::index_writer::{
+    IndexWriterOptions, MAX_NUM_THREAD, MEMORY_BUDGET_NUM_BYTES_MIN,
+};
 use crate::indexer::segment_updater::save_metas;
 use crate::indexer::{IndexWriter, SingleSegmentIndexWriter};
 use crate::reader::{IndexReader, IndexReaderBuilder};
@@ -519,6 +521,43 @@ impl Index {
         load_metas(self.directory(), &self.inventory)
     }
 
+    /// Open a new index writer with the given options. Attempts to acquire a lockfile.
+    ///
+    /// The lockfile should be deleted on drop, but it is possible
+    /// that due to a panic or other error, a stale lockfile will be
+    /// left in the index directory. If you are sure that no other
+    /// `IndexWriter` on the system is accessing the index directory,
+    /// it is safe to manually delete the lockfile.
+    ///
+    /// - `options` defines the writer configuration which includes things like buffer sizes,
+    ///   indexer threads, etc...
+    ///
+    /// # Errors
+    /// If the lockfile already exists, returns `Error::DirectoryLockBusy` or an `Error::IoError`.
+    /// If the memory arena per thread is too small or too big, returns
+    /// `TantivyError::InvalidArgument`
+    pub fn writer_with_options<D: Document>(
+        &self,
+        options: IndexWriterOptions,
+    ) -> crate::Result<IndexWriter<D>> {
+        let directory_lock = self
+            .directory
+            .acquire_lock(&INDEX_WRITER_LOCK)
+            .map_err(|err| {
+                TantivyError::LockFailure(
+                    err,
+                    Some(
+                        "Failed to acquire index lock. If you are using a regular directory, this \
+                         means there is already an `IndexWriter` working on this `Directory`, in \
+                         this process or in a different process."
+                            .to_string(),
+                    ),
+                )
+            })?;
+
+        IndexWriter::new(self, options, directory_lock)
+    }
+
     /// Open a new index writer. Attempts to acquire a lockfile.
     ///
     /// The lockfile should be deleted on drop, but it is possible
@@ -543,27 +582,12 @@ impl Index {
         num_threads: usize,
         overall_memory_budget_in_bytes: usize,
     ) -> crate::Result<IndexWriter<D>> {
-        let directory_lock = self
-            .directory
-            .acquire_lock(&INDEX_WRITER_LOCK)
-            .map_err(|err| {
-                TantivyError::LockFailure(
-                    err,
-                    Some(
-                        "Failed to acquire index lock. If you are using a regular directory, this \
-                         means there is already an `IndexWriter` working on this `Directory`, in \
-                         this process or in a different process."
-                            .to_string(),
-                    ),
-                )
-            })?;
         let memory_arena_in_bytes_per_thread = overall_memory_budget_in_bytes / num_threads;
-        IndexWriter::new(
-            self,
-            num_threads,
-            memory_arena_in_bytes_per_thread,
-            directory_lock,
-        )
+        let options = IndexWriterOptions::builder()
+            .num_worker_threads(num_threads)
+            .memory_budget_per_thread(memory_arena_in_bytes_per_thread)
+            .build();
+        self.writer_with_options(options)
     }
 
     /// Helper to create an index writer for tests.

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -533,7 +533,7 @@ impl Index {
     ///   indexer threads, etc...
     ///
     /// # Errors
-    /// If the lockfile already exists, returns `Error::DirectoryLockBusy` or an `Error::IoError`.
+    /// If the lockfile already exists, returns `TantivyError::LockFailure`.
     /// If the memory arena per thread is too small or too big, returns
     /// `TantivyError::InvalidArgument`
     pub fn writer_with_options<D: Document>(

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -31,7 +31,7 @@ mod stamper;
 use crossbeam_channel as channel;
 use smallvec::SmallVec;
 
-pub use self::index_writer::IndexWriter;
+pub use self::index_writer::{IndexWriter, IndexWriterOptions};
 pub use self::log_merge_policy::LogMergePolicy;
 pub use self::merge_operation::MergeOperation;
 pub use self::merge_policy::{MergeCandidate, MergePolicy, NoMergePolicy};


### PR DESCRIPTION
Recently been hacking the index writer apart to do some mildly questionable thing, as part of that I found myself wanting to customise some more parts of the writer but adding another method with _more_ config options was starting to get unwieldy. Especially since https://github.com/quickwit-oss/tantivy/pull/2535 

This PR adds a builder notibly `IndexWriterOptions` which improves the ergonomics of configuring the writer.

However, I did also make the options _another_ method to avoid making it a huge breaking change, but maybe a breaking change of the create API fine. 

Also sorry, I accidentally wrapped some of the work I did around deferring indexer threads being spawned until required, will remove at a later point.