### PR TITLE
make DateHistogramAggregationReq buildable

### DIFF
--- a/src/aggregation/bucket/histogram/date_histogram.rs
+++ b/src/aggregation/bucket/histogram/date_histogram.rs
@@ -34,10 +34,10 @@ use crate::aggregation::*;
 pub struct DateHistogramAggregationReq {
     #[doc(hidden)]
     /// Only for validation
-    interval: Option<String>,
+    pub interval: Option<String>,
     #[doc(hidden)]
     /// Only for validation
-    calendar_interval: Option<String>,
+    pub calendar_interval: Option<String>,
     /// The field to aggregate on.
     pub field: String,
     /// The format to format dates. Unsupported currently.


### PR DESCRIPTION
this options are not supported, so they were left private and hidden. This made the struct impossible to build without going through serde.
This patch makes it possible to build the struct (though the fields are left hidden given they are still not supported)