### PR TITLE
merge column: small refactors

### DIFF
--- a/columnar/src/column_index/merge/stacked.rs
+++ b/columnar/src/column_index/merge/stacked.rs
@@ -56,7 +56,7 @@ fn get_doc_ids_with_values<'a>(
         ColumnIndex::Full => Box::new(doc_range),
         ColumnIndex::Optional(optional_index) => Box::new(
             optional_index
-                .iter_rows()
+                .iter_docs()
                 .map(move |row| row + doc_range.start),
         ),
         ColumnIndex::Multivalued(multivalued_index) => match multivalued_index {
@@ -73,7 +73,7 @@ fn get_doc_ids_with_values<'a>(
             MultiValueIndex::MultiValueIndexV2(multivalued_index) => Box::new(
                 multivalued_index
                     .optional_index
-                    .iter_rows()
+                    .iter_docs()
                     .map(move |row| row + doc_range.start),
             ),
         },
@@ -177,7 +177,7 @@ impl<'a> Iterable<RowId> for StackedOptionalIndex<'a> {
                         ColumnIndex::Full => Box::new(columnar_row_range),
                         ColumnIndex::Optional(optional_index) => Box::new(
                             optional_index
-                                .iter_rows()
+                                .iter_docs()
                                 .map(move |row_id: RowId| columnar_row_range.start + row_id),
                         ),
                         ColumnIndex::Multivalued(_) => {

--- a/columnar/src/column_index/optional_index/tests.rs
+++ b/columnar/src/column_index/optional_index/tests.rs
@@ -164,7 +164,7 @@ fn test_optional_index_large() {
 fn test_optional_index_iter_aux(row_ids: &[RowId], num_rows: RowId) {
     let optional_index = OptionalIndex::for_test(num_rows, row_ids);
     assert_eq!(optional_index.num_docs(), num_rows);
-    assert!(optional_index.iter_rows().eq(row_ids.iter().copied()));
+    assert!(optional_index.iter_docs().eq(row_ids.iter().copied()));
 }
 
 #[test]

--- a/columnar/src/columnar/merge/merge_dict_column.rs
+++ b/columnar/src/columnar/merge/merge_dict_column.rs
@@ -191,6 +191,7 @@ fn serialize_merged_dict(
 
 #[derive(Default, Debug)]
 struct TermOrdinalMapping {
+    /// Contains the new term ordinals for each segment.
     per_segment_new_term_ordinals: Vec<Vec<TermOrdinal>>,
 }
 

--- a/columnar/src/columnar/merge/merge_dict_column.rs
+++ b/columnar/src/columnar/merge/merge_dict_column.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 use common::{BitSet, CountingWriter, ReadOnlyBitSet};
 use sstable::{SSTable, Streamer, TermOrdinal, VoidSSTable};
 
-use super::term_merger::TermMerger;
+use super::term_merger::{TermMerger, TermsWithSegmentOrd};
 use crate::column::serialize_column_mappable_to_u64;
 use crate::column_index::SerializableColumnIndex;
 use crate::iterable::Iterable;
@@ -126,14 +126,17 @@ fn serialize_merged_dict(
     let mut term_ord_mapping = TermOrdinalMapping::default();
 
     let mut field_term_streams = Vec::new();
-    for column_opt in bytes_columns.iter() {
+    for (segment_ord, column_opt) in bytes_columns.iter().enumerate() {
         if let Some(column) = column_opt {
             term_ord_mapping.add_segment(column.dictionary.num_terms());
             let terms: Streamer<VoidSSTable> = column.dictionary.stream()?;
-            field_term_streams.push(terms);
+            field_term_streams.push(TermsWithSegmentOrd { terms, segment_ord });
         } else {
             term_ord_mapping.add_segment(0);
-            field_term_streams.push(Streamer::empty());
+            field_term_streams.push(TermsWithSegmentOrd {
+                terms: Streamer::empty(),
+                segment_ord,
+            });
         }
     }
 
@@ -206,6 +209,6 @@ impl TermOrdinalMapping {
     }
 
     fn get_segment(&self, segment_ord: u32) -> &[TermOrdinal] {
-        &(self.per_segment_new_term_ordinals[segment_ord as usize])[..]
+        &self.per_segment_new_term_ordinals[segment_ord as usize]
     }
 }

--- a/columnar/src/columnar/merge/merge_mapping.rs
+++ b/columnar/src/columnar/merge/merge_mapping.rs
@@ -26,7 +26,7 @@ impl StackMergeOrder {
         let mut cumulated_row_ids: Vec<RowId> = Vec::with_capacity(columnars.len());
         let mut cumulated_row_id = 0;
         for columnar in columnars {
-            cumulated_row_id += columnar.num_rows();
+            cumulated_row_id += columnar.num_docs();
             cumulated_row_ids.push(cumulated_row_id);
         }
         StackMergeOrder { cumulated_row_ids }

--- a/columnar/src/columnar/reader/mod.rs
+++ b/columnar/src/columnar/reader/mod.rs
@@ -18,13 +18,13 @@ fn io_invalid_data(msg: String) -> io::Error {
 pub struct ColumnarReader {
     column_dictionary: Dictionary<RangeSSTable>,
     column_data: FileSlice,
-    num_rows: RowId,
+    num_docs: RowId,
     format_version: Version,
 }
 
 impl fmt::Debug for ColumnarReader {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let num_rows = self.num_rows();
+        let num_rows = self.num_docs();
         let columns = self.list_columns().unwrap();
         let num_cols = columns.len();
         let mut debug_struct = f.debug_struct("Columnar");
@@ -98,13 +98,13 @@ impl ColumnarReader {
         Ok(ColumnarReader {
             column_dictionary,
             column_data,
-            num_rows,
+            num_docs: num_rows,
             format_version,
         })
     }
 
-    pub fn num_rows(&self) -> RowId {
-        self.num_rows
+    pub fn num_docs(&self) -> RowId {
+        self.num_docs
     }
     // Iterate over the columns in a sorted way
     pub fn iter_columns(

--- a/columnar/src/tests.rs
+++ b/columnar/src/tests.rs
@@ -380,7 +380,7 @@ fn assert_columnar_eq(
     right: &ColumnarReader,
     lenient_on_numerical_value: bool,
 ) {
-    assert_eq!(left.num_rows(), right.num_rows());
+    assert_eq!(left.num_docs(), right.num_docs());
     let left_columns = left.list_columns().unwrap();
     let right_columns = right.list_columns().unwrap();
     assert_eq!(left_columns.len(), right_columns.len());
@@ -588,7 +588,7 @@ proptest! {
     #[test]
     fn test_single_columnar_builder_proptest(docs in columnar_docs_strategy()) {
         let columnar = build_columnar(&docs[..]);
-        assert_eq!(columnar.num_rows() as usize, docs.len());
+        assert_eq!(columnar.num_docs() as usize, docs.len());
         let mut expected_columns: HashMap<(&str, ColumnTypeCategory), HashMap<u32, Vec<&ColumnValue>> > = Default::default();
         for (doc_id, doc_vals) in docs.iter().enumerate() {
             for (col_name, col_val) in doc_vals {
@@ -819,7 +819,7 @@ fn test_columnar_merge_empty() {
     )
     .unwrap();
     let merged_columnar = ColumnarReader::open(output).unwrap();
-    assert_eq!(merged_columnar.num_rows(), 0);
+    assert_eq!(merged_columnar.num_docs(), 0);
     assert_eq!(merged_columnar.num_columns(), 0);
 }
 
@@ -845,7 +845,7 @@ fn test_columnar_merge_single_str_column() {
     )
     .unwrap();
     let merged_columnar = ColumnarReader::open(output).unwrap();
-    assert_eq!(merged_columnar.num_rows(), 1);
+    assert_eq!(merged_columnar.num_docs(), 1);
     assert_eq!(merged_columnar.num_columns(), 1);
 }
 
@@ -877,7 +877,7 @@ fn test_delete_decrease_cardinality() {
     )
     .unwrap();
     let merged_columnar = ColumnarReader::open(output).unwrap();
-    assert_eq!(merged_columnar.num_rows(), 1);
+    assert_eq!(merged_columnar.num_docs(), 1);
     assert_eq!(merged_columnar.num_columns(), 1);
     let cols = merged_columnar.read_columns("c").unwrap();
     assert_eq!(cols.len(), 1);


### PR DESCRIPTION
Some refactors & tests when investigating a crash in `merge_dict_column`

```
Feb 18 09:57:32 quickwit-indexer-13 quickwit-indexer thread 'merge_thread_0' panicked at /usr/local/cargo/git/checkouts/tantivy-f70b7ea03dadae9a/71cf198/columnar/src/columnar/merge/merge_dict_column.rs:70:42:
Feb 18 09:57:32 quickwit-indexer-13 quickwit-indexer index out of bounds: the len is 1034 but the index is 1876
Feb 18 09:57:32 quickwit-indexer-13 quickwit-indexer note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Feb 18 09:57:32 quickwit-indexer-13 quickwit-indexer Rayon: detected unexpected panic; aborting
```