### PR TITLE
refactor: use std AtomicU64 and remove wrapper

### DIFF
--- a/src/indexer/stamper.rs
+++ b/src/indexer/stamper.rs
@@ -1,79 +1,19 @@
 use std::ops::Range;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use crate::Opstamp;
-
-#[cfg(not(target_arch = "arm"))]
-mod atomic_impl {
-
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    use crate::Opstamp;
-
-    #[derive(Default)]
-    pub struct AtomicU64Wrapper(AtomicU64);
-
-    impl AtomicU64Wrapper {
-        pub fn new(first_opstamp: Opstamp) -> AtomicU64Wrapper {
-            AtomicU64Wrapper(AtomicU64::new(first_opstamp))
-        }
-
-        pub fn fetch_add(&self, val: u64, order: Ordering) -> u64 {
-            self.0.fetch_add(val, order)
-        }
-
-        pub fn revert(&self, val: u64, order: Ordering) -> u64 {
-            self.0.store(val, order);
-            val
-        }
-    }
-}
-
-#[cfg(target_arch = "arm")]
-mod atomic_impl {
-
-    /// Under other architecture, we rely on a mutex.
-    use std::sync::atomic::Ordering;
-    use std::sync::RwLock;
-
-    use crate::Opstamp;
-
-    #[derive(Default)]
-    pub struct AtomicU64Wrapper(RwLock<u64>);
-
-    impl AtomicU64Wrapper {
-        pub fn new(first_opstamp: Opstamp) -> AtomicU64Wrapper {
-            AtomicU64Wrapper(RwLock::new(first_opstamp))
-        }
-
-        pub fn fetch_add(&self, incr: u64, _order: Ordering) -> u64 {
-            let mut lock = self.0.write().unwrap();
-            let previous_val = *lock;
-            *lock = previous_val + incr;
-            previous_val
-        }
-
-        pub fn revert(&self, val: u64, _order: Ordering) -> u64 {
-            let mut lock = self.0.write().unwrap();
-            *lock = val;
-            val
-        }
-    }
-}
-
-use self::atomic_impl::AtomicU64Wrapper;
 
 /// Stamper provides Opstamps, which is just an auto-increment id to label
 /// an operation.
 ///
 /// Cloning does not "fork" the stamp generation. The stamper actually wraps an `Arc`.
 #[derive(Clone, Default)]
-pub struct Stamper(Arc<AtomicU64Wrapper>);
+pub struct Stamper(Arc<AtomicU64>);
 
 impl Stamper {
     pub fn new(first_opstamp: Opstamp) -> Stamper {
-        Stamper(Arc::new(AtomicU64Wrapper::new(first_opstamp)))
+        Stamper(Arc::new(AtomicU64::new(first_opstamp)))
     }
 
     pub fn stamp(&self) -> Opstamp {
@@ -92,7 +32,8 @@ impl Stamper {
 
     /// Reverts the stamper to a given `Opstamp` value and returns it
     pub fn revert(&self, to_opstamp: Opstamp) -> Opstamp {
-        self.0.revert(to_opstamp, Ordering::SeqCst)
+        self.0.store(to_opstamp, Ordering::SeqCst);
+        to_opstamp
     }
 }
 


### PR DESCRIPTION
~~Tantivy introduced ([PR1](https://github.com/quickwit-oss/tantivy/pull/745), [PR2](https://github.com/quickwit-oss/tantivy/pull/746)) this `AtomicU64Wrapper` because the lack of support for `AtomicU64` on some platforms, as reported in [this issue](https://github.com/quickwit-oss/tantivy/issues/743).~~

~~This PR replaces it with [`portable_atomic::AtomicU64`](https://docs.rs/portable-atomic/latest/portable_atomic/struct.AtomicU64.html#) so that we won't use `Mutex` for all the `arm` platforms but only the platforms that lack the support.~~

This PR removes the AtomicU64 wrapper and just uses the std AtomicU64 since arm has been supported since Rust 1.59.




