### PR TITLE
Replace the default score combiner for boolean queries by a boosted variant

### DIFF
--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -1,5 +1,5 @@
 use super::boolean_weight::BooleanWeight;
-use crate::query::{EnableScoring, Occur, Query, SumCombiner, TermQuery, Weight};
+use crate::query::{BoostedSumCombiner, EnableScoring, Occur, Query, TermQuery, Weight};
 use crate::schema::{IndexRecordOption, Term};
 
 /// The boolean query returns a set of documents
@@ -164,7 +164,7 @@ impl Query for BooleanQuery {
             sub_weights,
             self.minimum_number_should_match,
             enable_scoring.is_scoring_enabled(),
-            Box::new(SumCombiner::default),
+            Box::new(BoostedSumCombiner::default),
         )))
     }
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -58,7 +58,7 @@ pub use self::query_parser::{QueryParser, QueryParserError};
 pub use self::range_query::*;
 pub use self::regex_query::RegexQuery;
 pub use self::reqopt_scorer::RequiredOptionalScorer;
-pub use self::score_combiner::{DisjunctionMaxCombiner, ScoreCombiner, SumCombiner};
+pub use self::score_combiner::{DisjunctionMaxCombiner, ScoreCombiner, SumCombiner, BoostedSumCombiner};
 pub use self::scorer::Scorer;
 pub use self::set_query::TermSetQuery;
 pub use self::term_query::TermQuery;


### PR DESCRIPTION
Based on user feedback, and using the default `QueryParser` interpretation, we found this modification of plain BM25 to yield significantly more relevant results and considerably reducing the need for explicit `Must` queries.