### PR TITLE
Add method to take clauses out of boolean query

### DIFF
--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use super::boolean_weight::BooleanWeight;
 use crate::query::{EnableScoring, Occur, Query, SumCombiner, TermQuery, Weight};
 use crate::schema::{IndexRecordOption, Term};
@@ -254,8 +256,13 @@ impl BooleanQuery {
     }
 
     /// Deconstructed view of the clauses making up this query.
-    pub fn clauses(&self) -> &[(Occur, Box<dyn Query>)] {
-        &self.subqueries[..]
+    pub fn clauses(&self) -> impl Iterator<Item = &(Occur, Box<dyn Query>)> {
+        self.subqueries.iter()
+    }
+
+    /// Take the clauses making up this query for reuse.
+    pub fn take_clauses(&mut self) -> impl Iterator<Item = (Occur, Box<dyn Query>)> {
+        mem::take(&mut self.subqueries).into_iter()
     }
 }
 


### PR DESCRIPTION
This helps with rewriting, for example to replace the default score combiner used by boolean queries, insofer it avoids the need to `box_clone` the sub queries.

For us, this replaces #2600 insofar we will keep carrying a `CustomBooleanQuery` to overwrite the default score combiner.