### PR TITLE
Fix compilation stability

### DIFF
--- a/columnar/src/block_accessor.rs
+++ b/columnar/src/block_accessor.rs
@@ -139,7 +139,7 @@ mod tests {
             missing_docs.push(missing_doc);
         });
 
-        assert_eq!(missing_docs, vec![]);
+        assert_eq!(missing_docs, Vec::<u32>::new());
     }
 
     #[test]

--- a/columnar/src/columnar/merge/tests.rs
+++ b/columnar/src/columnar/merge/tests.rs
@@ -403,11 +403,11 @@ fn test_merge_columnar_different_types() {
         panic!()
     };
     assert_eq!(vals.get_cardinality(), Cardinality::Optional);
-    assert_eq!(vals.values_for_doc(0).collect_vec(), vec![]);
-    assert_eq!(vals.values_for_doc(1).collect_vec(), vec![]);
-    assert_eq!(vals.values_for_doc(2).collect_vec(), vec![]);
+    assert_eq!(vals.values_for_doc(0).collect_vec(), Vec::<i64>::new());
+    assert_eq!(vals.values_for_doc(1).collect_vec(), Vec::<i64>::new());
+    assert_eq!(vals.values_for_doc(2).collect_vec(), Vec::<i64>::new());
     assert_eq!(vals.values_for_doc(3).collect_vec(), vec![1]);
-    assert_eq!(vals.values_for_doc(4).collect_vec(), vec![]);
+    assert_eq!(vals.values_for_doc(4).collect_vec(), Vec::<i64>::new());
 
     // text column
     let dynamic_column = cols[1].open().unwrap();

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -942,7 +942,7 @@ mod tests {
 
         let numbers = [100, 200, 300];
         let test_range = |range: RangeInclusive<u64>| {
-            let expected_count = numbers.iter().filter(|num| range.contains(num)).count();
+            let expected_count = numbers.iter().filter(|num| range.contains(*num)).count();
             let mut vec = vec![];
             field.get_row_ids_for_value_range(range, 0..u32::MAX, &mut vec);
             assert_eq!(vec.len(), expected_count);
@@ -1020,7 +1020,7 @@ mod tests {
 
         let numbers = [1000, 1001, 1003];
         let test_range = |range: RangeInclusive<u64>| {
-            let expected_count = numbers.iter().filter(|num| range.contains(num)).count();
+            let expected_count = numbers.iter().filter(|num| range.contains(*num)).count();
             let mut vec = vec![];
             field.get_row_ids_for_value_range(range, 0..u32::MAX, &mut vec);
             assert_eq!(vec.len(), expected_count);

--- a/stacker/src/expull.rs
+++ b/stacker/src/expull.rs
@@ -160,7 +160,7 @@ mod tests {
         {
             let mut buffer = Vec::new();
             stack.read_to_end(&arena, &mut buffer);
-            assert_eq!(&buffer[..], &[]);
+            assert_eq!(&buffer[..], &[] as &[u8]);
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/quickwit-oss/tantivy/issues/2607

Compilation started failing on:

```rust
let numbers = [100, 200, 300];
let expected_count = numbers.iter().filter(|num| range.contains(num)).count();
```

`num` has type `&&u64` and this sometime fails to compile with:

```
no implementation for `&{integer} < u64` and `&{integer} > u64`
```

(see some tests failure in [CI](https://github.com/quickwit-oss/tantivy/pull/2609))

## Root cause

At least some of the errors are due to an update of an indirect dependency:
```
│   ├── tantivy-common v0.7.0 (/Users/remi.dettai/tests/tantivy/common)
│   │   └── time v0.3.41
│   │       ├── deranged v0.4.1
```

```
│   ├── tantivy-common v0.7.0 (/Users/remi.dettai/workspace/tantivy/common)
│   │   └── time v0.3.37
│   │       ├── deranged v0.3.11
```

which leads to erros like:
```
type annotations needed
multiple `impl`s satisfying `u32: PartialEq<_>` found in the following crates: `core`, `deranged`:
- impl PartialEq for u32;
- impl<MIN, MAX> PartialEq<deranged::RangedU32<MIN, MAX>> for u32
  where the constant `MIN` has type `u32`, the constant `MAX` has type `u32`;
required for `Vec<u32>` to implement `PartialEq<Vec<_>>`
```