### PR TITLE
set root version to be 0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Paul Masurel <paul.masurel@gmail.com>"]
 license = "MIT"
 categories = ["database-implementations", "data-structures"]


### PR DESCRIPTION
I missed updating the cargo root version to 0.24.0 in this [PR](https://github.com/quickwit-oss/tantivy/pull/2606) so it can be published.

I aim to publish the `tantivy` package along with the `tantivy-query-grammar` to `crates.io`, so I can then ask the Python bindings to be updated (tantivy-py).

