### PR TITLE
make zstd optional in sstable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@ Tantivy 0.23 - Unreleased
 ================================
 Tantivy 0.23 will be backwards compatible with indices created with v0.22 and v0.21. The new minimum rust version will be 1.75.
 
-> [!WARNING]
-> Users of `sstable` may need to enable the `zstd-compression` to read blocks written by prior versions of `sstable`
-
 #### Bugfixes
 - fix potential endless loop in merge [#2457](https://github.com/quickwit-oss/tantivy/pull/2457)(@PSeitz)
 - fix bug that causes out-of-order sstable key. [#2445](https://github.com/quickwit-oss/tantivy/pull/2445)(@fulmicoton)
@@ -15,7 +12,6 @@ Tantivy 0.23 will be backwards compatible with indices created with v0.22 and v0
 
 #### Breaking API Changes
 - remove index sorting [#2434](https://github.com/quickwit-oss/tantivy/pull/2434)(@PSeitz)
-- make zstd optional in sstable [#2633](https://github.com/quickwit-oss/tantivy/pull/2633)(@parth)
 
 #### Features/Improvements
 - **Aggregation**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Tantivy 0.23 - Unreleased
 ================================
 Tantivy 0.23 will be backwards compatible with indices created with v0.22 and v0.21. The new minimum rust version will be 1.75.
 
+> [!WARNING]
+> Users of `sstable` may need to enable the `zstd-compression` to read blocks written by prior versions of `sstable`
+
 #### Bugfixes
 - fix potential endless loop in merge [#2457](https://github.com/quickwit-oss/tantivy/pull/2457)(@PSeitz)
 - fix bug that causes out-of-order sstable key. [#2445](https://github.com/quickwit-oss/tantivy/pull/2445)(@fulmicoton)
@@ -12,6 +15,7 @@ Tantivy 0.23 will be backwards compatible with indices created with v0.22 and v0
 
 #### Breaking API Changes
 - remove index sorting [#2434](https://github.com/quickwit-oss/tantivy/pull/2434)(@PSeitz)
+- make zstd optional in sstable [#2633](https://github.com/quickwit-oss/tantivy/pull/2633)(@parth)
 
 #### Features/Improvements
 - **Aggregation**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ debug-assertions = true
 overflow-checks = true
 
 [features]
-default = ["mmap", "stopwords", "lz4-compression"]
+default = ["mmap", "stopwords", "lz4-compression", "columnar-zstd-compression"]
 mmap = ["fs4", "tempfile", "memmap2"]
 stopwords = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ mmap = ["fs4", "tempfile", "memmap2"]
 stopwords = []
 
 lz4-compression = ["lz4_flex"]
-zstd-compression = ["zstd"]
+zstd-compression = ["zstd", "columnar/zstd-compression"]
 
 failpoints = ["fail", "fail/failpoints"]
 unstable = []                            # useful for benches.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,10 @@ mmap = ["fs4", "tempfile", "memmap2"]
 stopwords = []
 
 lz4-compression = ["lz4_flex"]
-zstd-compression = ["zstd", "columnar/zstd-compression"]
+zstd-compression = ["zstd"]
+
+# enable zstd-compression in columnar (and sstable)
+columnar-zstd-compression = ["columnar/zstd-compression"]
 
 failpoints = ["fail", "fail/failpoints"]
 unstable = []                            # useful for benches.

--- a/columnar/Cargo.toml
+++ b/columnar/Cargo.toml
@@ -33,6 +33,6 @@ harness = false
 name = "bench_access"
 harness = false
 
-
 [features]
 unstable = []
+zstd-compression = ["sstable/zstd-compression"]

--- a/sstable/Cargo.toml
+++ b/sstable/Cargo.toml
@@ -16,7 +16,10 @@ itertools = "0.14.0"
 tantivy-bitpacker = { version= "0.6", path="../bitpacker" }
 tantivy-fst = "0.5"
 # experimental gives us access to Decompressor::upper_bound
-zstd = { version = "0.13", features = ["experimental"] }
+zstd = { version = "0.13", optional = true, features = ["experimental"] }
+
+[features]
+zstd-compression = ["zstd"]
 
 [dev-dependencies]
 proptest = "1"

--- a/sstable/src/block_reader.rs
+++ b/sstable/src/block_reader.rs
@@ -2,7 +2,6 @@ use std::io::{self, Read};
 use std::ops::Range;
 
 use common::OwnedBytes;
-
 #[cfg(feature = "zstd-compression")]
 use zstd::bulk::Decompressor;
 

--- a/sstable/src/delta.rs
+++ b/sstable/src/delta.rs
@@ -56,7 +56,7 @@ where
 
         let block_len = buffer.len() + self.block.len();
 
-        if block_len > 2048 {
+        if cfg!(feature = "zstd-compression") && block_len > 2048 {
             #[cfg(feature = "zstd-compression")]
             {
                 buffer.extend_from_slice(&self.block);

--- a/sstable/src/delta.rs
+++ b/sstable/src/delta.rs
@@ -2,7 +2,6 @@ use std::io::{self, BufWriter, Write};
 use std::ops::Range;
 
 use common::{CountingWriter, OwnedBytes};
-
 #[cfg(feature = "zstd-compression")]
 use zstd::bulk::Compressor;
 
@@ -14,8 +13,7 @@ const VINT_MODE: u8 = 1u8;
 const BLOCK_LEN: usize = 4_000;
 
 pub struct DeltaWriter<W, TValueWriter>
-where
-    W: io::Write,
+where W: io::Write
 {
     block: Vec<u8>,
     write: CountingWriter<BufWriter<W>>,
@@ -137,8 +135,7 @@ pub struct DeltaReader<TValueReader> {
 }
 
 impl<TValueReader> DeltaReader<TValueReader>
-where
-    TValueReader: value::ValueReader,
+where TValueReader: value::ValueReader
 {
     pub fn new(reader: OwnedBytes) -> Self {
         DeltaReader {

--- a/sstable/src/delta.rs
+++ b/sstable/src/delta.rs
@@ -2,6 +2,8 @@ use std::io::{self, BufWriter, Write};
 use std::ops::Range;
 
 use common::{CountingWriter, OwnedBytes};
+
+#[cfg(feature = "zstd-compression")]
 use zstd::bulk::Compressor;
 
 use super::value::ValueWriter;
@@ -12,7 +14,8 @@ const VINT_MODE: u8 = 1u8;
 const BLOCK_LEN: usize = 4_000;
 
 pub struct DeltaWriter<W, TValueWriter>
-where W: io::Write
+where
+    W: io::Write,
 {
     block: Vec<u8>,
     write: CountingWriter<BufWriter<W>>,
@@ -54,24 +57,27 @@ where
         let block_len = buffer.len() + self.block.len();
 
         if block_len > 2048 {
-            buffer.extend_from_slice(&self.block);
-            self.block.clear();
+            #[cfg(feature = "zstd-compression")]
+            {
+                buffer.extend_from_slice(&self.block);
+                self.block.clear();
 
-            let max_len = zstd::zstd_safe::compress_bound(buffer.len());
-            self.block.reserve(max_len);
-            Compressor::new(3)?.compress_to_buffer(buffer, &mut self.block)?;
+                let max_len = zstd::zstd_safe::compress_bound(buffer.len());
+                self.block.reserve(max_len);
+                Compressor::new(3)?.compress_to_buffer(buffer, &mut self.block)?;
 
-            // verify compression had a positive impact
-            if self.block.len() < buffer.len() {
-                self.write
-                    .write_all(&(self.block.len() as u32 + 1).to_le_bytes())?;
-                self.write.write_all(&[1])?;
-                self.write.write_all(&self.block[..])?;
-            } else {
-                self.write
-                    .write_all(&(block_len as u32 + 1).to_le_bytes())?;
-                self.write.write_all(&[0])?;
-                self.write.write_all(&buffer[..])?;
+                // verify compression had a positive impact
+                if self.block.len() < buffer.len() {
+                    self.write
+                        .write_all(&(self.block.len() as u32 + 1).to_le_bytes())?;
+                    self.write.write_all(&[1])?;
+                    self.write.write_all(&self.block[..])?;
+                } else {
+                    self.write
+                        .write_all(&(block_len as u32 + 1).to_le_bytes())?;
+                    self.write.write_all(&[0])?;
+                    self.write.write_all(&buffer[..])?;
+                }
             }
         } else {
             self.write
@@ -131,7 +137,8 @@ pub struct DeltaReader<TValueReader> {
 }
 
 impl<TValueReader> DeltaReader<TValueReader>
-where TValueReader: value::ValueReader
+where
+    TValueReader: value::ValueReader,
 {
     pub fn new(reader: OwnedBytes) -> Self {
         DeltaReader {


### PR DESCRIPTION
- zstd-compression is optional in tantivy, it was (presumably) inadvertently mandatory in `sstable`. See more info here:
  - https://github.com/quickwit-oss/tantivy/issues/2628
  - https://github.com/gyscos/zstd-rs/issues/337
- This PR makes columnar-zstd-compression optional, but enabled by default due to non-rust components of it's build process.