### PR TITLE
feat(snippet): report range of snippets in original text

### DIFF
--- a/examples/snippet.rs
+++ b/examples/snippet.rs
@@ -59,8 +59,11 @@ fn main() -> tantivy::Result<()> {
         let snippet = snippet_generator.snippet_from_doc(&doc);
         println!("Document score {score}:");
         println!("title: {}", doc.get_first(title).unwrap().as_str().unwrap());
-        println!("snippet: {}", snippet.to_html());
-        println!("custom highlighting: {}", highlight(snippet));
+
+        if let Some(snippet) = snippet {
+            println!("snippet: {}", snippet.to_html());
+            println!("custom highlighting: {}", highlight(snippet));
+        }
     }
 
     Ok(())

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -902,7 +902,8 @@ Survey in 2016, 2017, and 2018."#;
 
     #[test]
     fn test_snippet_absolute_offsets_with_truncation() {
-        let text = "Intro text. The quick brown fox jumps over the lazy dog. The quick brown fox jumps again. End text.";
+        let text = "Intro text. The quick brown fox jumps over the lazy dog. The quick brown fox \
+                    jumps again. End text.";
         let terms = btreemap! {
             String::from("fox") => 1.0,
             String::from("quick") => 0.9

--- a/src/snippet/mod.rs
+++ b/src/snippet/mod.rs
@@ -42,7 +42,7 @@
 //! # let searcher = reader.searcher();
 //! let mut snippet_generator = SnippetGenerator::create(&searcher, &*query, text_field)?;
 //! snippet_generator.set_max_num_chars(100);
-//! let snippet = snippet_generator.snippet_from_doc(&doc);
+//! let snippet = snippet_generator.snippet_from_doc(&doc).unwrap();
 //! let snippet_html: String = snippet.to_html();
 //! assert_eq!(snippet_html, "Comme je descendais des Fleuves impassibles,\n  Je ne me sentis plus guidé par les <b>haleurs</b> :\n Des");
 //! #    Ok(())
@@ -367,7 +367,7 @@ fn is_sorted(mut it: impl Iterator<Item = usize>) -> bool {
 /// # let searcher = reader.searcher();
 /// let mut snippet_generator = SnippetGenerator::create(&searcher, &*query, text_field)?;
 /// snippet_generator.set_max_num_chars(100);
-/// let snippet = snippet_generator.snippet_from_doc(&doc);
+/// let snippet = snippet_generator.snippet_from_doc(&doc).unwrap();
 /// let snippet_html: String = snippet.to_html();
 /// assert_eq!(snippet_html, "Comme je descendais des Fleuves impassibles,\n  Je ne me sentis plus guidé par les <b>haleurs</b> :\n Des");
 /// #    Ok(())


### PR DESCRIPTION
For my own project, I needed a version of `Snippet` that provided absolute offsets within the text. This PR does the following:
- allows the user to retrieve the absolute offset
- changes the return value of `snippet_from_doc` to `Option<Snippet>` and gets rid of "empty snippets"
- adds new methods `snippets_from_doc` and `snippets` which return all of the relevant snippets, not just the best one