### PR TITLE
Fixes for `TopDocs::order_by_string_fast_field` and `TopNComputer`

### DIFF
--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -1057,6 +1057,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+
     use super::{TopDocs, TopNComputer};
     use crate::collector::top_collector::ComparableDoc;
     use crate::collector::Collector;
@@ -1109,72 +1111,41 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_empty_topn_computer() {
-        let mut computer: TopNComputer<u32, u32> = TopNComputer::new(0);
-
-        computer.push(1u32, 1u32);
-        computer.push(1u32, 2u32);
-        computer.push(1u32, 3u32);
-        assert!(computer.into_sorted_vec().is_empty());
-    }
-    #[test]
-    fn test_topn_computer() {
-        let mut computer: TopNComputer<u32, u32> = TopNComputer::new(2);
-
-        computer.push(1u32, 1u32);
-        computer.push(2u32, 2u32);
-        computer.push(3u32, 3u32);
-        computer.push(2u32, 4u32);
-        computer.push(1u32, 5u32);
-        assert_eq!(
-            computer.into_sorted_vec(),
-            &[
-                ComparableDoc {
-                    feature: 3u32,
-                    doc: 3u32,
-                },
-                ComparableDoc {
-                    feature: 2u32,
-                    doc: 2u32,
-                }
-            ]
-        );
-    }
-    #[test]
-    fn test_topn_computer_asc() {
-        let mut computer: TopNComputer<u32, u32, false> = TopNComputer::new(2);
-
-        computer.push(1u32, 1u32);
-        computer.push(2u32, 2u32);
-        computer.push(3u32, 3u32);
-        computer.push(2u32, 4u32);
-        computer.push(4u32, 5u32);
-        computer.push(1u32, 6u32);
-        assert_eq!(
-            computer.into_sorted_vec(),
-            &[
-                ComparableDoc {
-                    feature: 1u32,
-                    doc: 1u32,
-                },
-                ComparableDoc {
-                    feature: 1u32,
-                    doc: 6u32,
-                }
-            ]
-        );
-    }
-
-    #[test]
-    fn test_topn_computer_no_panic() {
-        for top_n in 0..10 {
-            let mut computer: TopNComputer<u32, u32> = TopNComputer::new(top_n);
-
-            for _ in 0..1 + top_n * 2 {
-                computer.push(1u32, 1u32);
+    proptest! {
+        #[test]
+        fn test_topn_computer_asc(
+          limit in 0..10_usize,
+          docs in proptest::collection::vec((0..100_u64, 0..100_u64), 0..100_usize),
+        ) {
+            let mut computer: TopNComputer<_, _, false> = TopNComputer::new(limit);
+            for (feature, doc) in &docs {
+                computer.push(*feature, *doc);
             }
-            let _vals = computer.into_sorted_vec();
+            let mut comparable_docs = docs.into_iter().map(|(feature, doc)| ComparableDoc { feature, doc }).collect::<Vec<_>>();
+            comparable_docs.sort();
+            comparable_docs.truncate(limit);
+            prop_assert_eq!(
+                computer.into_sorted_vec(),
+                comparable_docs,
+            );
+        }
+
+        #[test]
+        fn test_topn_computer_desc(
+          limit in 0..10_usize,
+          docs in proptest::collection::vec((0..100_u64, 0..100_u64), 0..100_usize),
+        ) {
+            let mut computer: TopNComputer<_, _, true> = TopNComputer::new(limit);
+            for (feature, doc) in &docs {
+                computer.push(*feature, *doc);
+            }
+            let mut comparable_docs = docs.into_iter().map(|(feature, doc)| ComparableDoc { feature, doc }).collect::<Vec<_>>();
+            comparable_docs.sort();
+            comparable_docs.truncate(limit);
+            prop_assert_eq!(
+                computer.into_sorted_vec(),
+                comparable_docs,
+            );
         }
     }
 

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -1111,9 +1111,79 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_empty_topn_computer() {
+        let mut computer: TopNComputer<u32, u32> = TopNComputer::new(0);
+
+        computer.push(1u32, 1u32);
+        computer.push(1u32, 2u32);
+        computer.push(1u32, 3u32);
+        assert!(computer.into_sorted_vec().is_empty());
+    }
+
+    #[test]
+    fn test_topn_computer_asc() {
+        let mut computer: TopNComputer<u32, u32, false> = TopNComputer::new(2);
+
+        computer.push(1u32, 1u32);
+        computer.push(2u32, 2u32);
+        computer.push(3u32, 3u32);
+        computer.push(2u32, 4u32);
+        computer.push(4u32, 5u32);
+        computer.push(1u32, 6u32);
+        assert_eq!(
+            computer.into_sorted_vec(),
+            &[
+                ComparableDoc {
+                    feature: 1u32,
+                    doc: 1u32,
+                },
+                ComparableDoc {
+                    feature: 1u32,
+                    doc: 6u32,
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_topn_computer_desc() {
+        let mut computer: TopNComputer<u32, u32> = TopNComputer::new(2);
+
+        computer.push(1u32, 1u32);
+        computer.push(2u32, 2u32);
+        computer.push(3u32, 3u32);
+        computer.push(2u32, 4u32);
+        computer.push(1u32, 5u32);
+        assert_eq!(
+            computer.into_sorted_vec(),
+            &[
+                ComparableDoc {
+                    feature: 3u32,
+                    doc: 3u32,
+                },
+                ComparableDoc {
+                    feature: 2u32,
+                    doc: 2u32,
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_topn_computer_no_panic() {
+        for top_n in 0..10 {
+            let mut computer: TopNComputer<u32, u32> = TopNComputer::new(top_n);
+            for _ in 0..1 + top_n * 2 {
+                computer.push(1u32, 1u32);
+            }
+            let _vals = computer.into_sorted_vec();
+        }
+    }
+
     proptest! {
         #[test]
-        fn test_topn_computer_asc(
+        fn test_topn_computer_asc_prop(
           limit in 0..10_usize,
           docs in proptest::collection::vec((0..100_u64, 0..100_u64), 0..100_usize),
         ) {
@@ -1131,7 +1201,7 @@ mod tests {
         }
 
         #[test]
-        fn test_topn_computer_desc(
+        fn test_topn_computer_desc_prop(
           limit in 0..10_usize,
           docs in proptest::collection::vec((0..100_u64, 0..100_u64), 0..100_usize),
         ) {

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -1131,6 +1131,30 @@ mod tests {
             ]
         );
     }
+    #[test]
+    fn test_topn_computer_asc() {
+        let mut computer: TopNComputer<u32, u32, false> = TopNComputer::new(2);
+
+        computer.push(1u32, 1u32);
+        computer.push(2u32, 2u32);
+        computer.push(3u32, 3u32);
+        computer.push(2u32, 4u32);
+        computer.push(4u32, 5u32);
+        computer.push(1u32, 6u32);
+        assert_eq!(
+            computer.into_sorted_vec(),
+            &[
+                ComparableDoc {
+                    feature: 1u32,
+                    doc: 1u32,
+                },
+                ComparableDoc {
+                    feature: 1u32,
+                    doc: 6u32,
+                }
+            ]
+        );
+    }
 
     #[test]
     fn test_topn_computer_no_panic() {

--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -517,12 +517,11 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
         let mut current_ordinal = 0;
         let mut prev_ord = None;
         for ord in ord {
-
             // only advance forward if the new ord is different than the one we just processed
             //
             // this allows the input TermOrdinal iterator to contain duplicates, so long as it's
             // still sorted
-            if Some(ord) != prev_ord  {
+            if Some(ord) != prev_ord {
                 assert!(ord >= current_ordinal);
                 // check if block changed for new term_ord
                 let new_block_addr = self.sstable_index.get_block_with_ord(ord);


### PR DESCRIPTION
#2642 added `TopDocs::order_by_string_fast_field`, but the test coverage in that PR did not catch two bugs:

1.  The `TopNComputer` was refactored in https://github.com/quickwit-oss/tantivy/pull/2198 to support both ascending and descending order. But that refactor did not adjust the `TopNComputer::threshold` to include the `ComparableDoc`, which is what provides the relevant `Ord` implementation.
    * The effect of this was that the threshold comparison for `TopNComputer` was still hardcoded for descending order. Unit tests which tested with fewer than `limit * 2` items OR which didn't have an item less than the threshold arrive _after_ the first `limit * 2` items (when the threshold is computed for the first time) would not expose the bug.
2. `sorted_ords_to_term_cb` only supported unique `ords`, likely because its previous consumers in aggregates would always de-dupe ords before lookup.
    * It is much easier for consumers who would like to look up non-unique term ordinals to allow them to be duplicated (as it introduces only two comparisons in a path that is always IO bound).
