### PR TITLE
Fix a typo for the comments of search_with_executor()

### DIFF
--- a/src/core/searcher.rs
+++ b/src/core/searcher.rs
@@ -214,7 +214,7 @@ impl Searcher {
     /// It is powerless at making search faster if your index consists in
     /// one large segment.
     ///
-    /// Also, keep in my multithreading a single query on several
+    /// Also, keep in mind multithreading a single query on several
     /// threads will not improve your throughput. It can actually
     /// hurt it. It will however, decrease the average response time.
     pub fn search_with_executor<C: Collector>(


### PR DESCRIPTION
A simple fix for the typo in comments. Refer the change directly.

No other change and no user impact