### PR TITLE
fix union performance regression in tantivy 0.24

### DIFF
--- a/src/query/boolean_query/boolean_query.rs
+++ b/src/query/boolean_query/boolean_query.rs
@@ -180,7 +180,7 @@ impl BooleanQuery {
     pub fn new(subqueries: Vec<(Occur, Box<dyn Query>)>) -> BooleanQuery {
         // If the bool query includes at least one should clause
         // and no Must or MustNot clauses, the default value is 1. Otherwise, the default value is
-        // 0. Keep pace with Elasticsearch.
+        // 0. Keep compatible with Elasticsearch.
         let mut minimum_required = 0;
         for (occur, _) in &subqueries {
             match occur {

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -157,8 +157,7 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
             Ignored,
             // Only contributes to final score.
             Optional(SpecializedScorer),
-            // Must be fitted.
-            Required(Box<dyn Scorer>),
+            Required(SpecializedScorer),
         }
         let mut must_scorers = per_occur_scorers.remove(&Occur::Must);
         let should_opt = if let Some(mut should_scorers) = per_occur_scorers.remove(&Occur::Should)
@@ -169,10 +168,10 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
             }
             match self.minimum_number_should_match {
                 0 => CombinationMethod::Optional(scorer_union(should_scorers, &score_combiner_fn)),
-                1 => CombinationMethod::Required(into_box_scorer(
-                    scorer_union(should_scorers, &score_combiner_fn),
-                    &score_combiner_fn,
-                )),
+                1 => {
+                    let scorer_union = scorer_union(should_scorers, &score_combiner_fn);
+                    CombinationMethod::Required(scorer_union)
+                }
                 n if num_of_should_scorers == n => {
                     // When num_of_should_scorers equals the number of should clauses,
                     // they are no different from must clauses.
@@ -185,11 +184,11 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
                     };
                     CombinationMethod::Ignored
                 }
-                _ => CombinationMethod::Required(scorer_disjunction(
+                _ => CombinationMethod::Required(SpecializedScorer::Other(scorer_disjunction(
                     should_scorers,
                     score_combiner_fn(),
                     self.minimum_number_should_match,
-                )),
+                ))),
             }
         } else {
             // None of should clauses are provided.
@@ -223,15 +222,13 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
                 }
             }
             (CombinationMethod::Required(should_scorer), Some(mut must_scorers)) => {
-                must_scorers.push(should_scorer);
+                must_scorers.push(into_box_scorer(should_scorer, &score_combiner_fn));
                 SpecializedScorer::Other(intersect_scorers(must_scorers))
             }
             (CombinationMethod::Ignored, None) => {
                 return Ok(SpecializedScorer::Other(Box::new(EmptyScorer)))
             }
-            (CombinationMethod::Required(should_scorer), None) => {
-                SpecializedScorer::Other(should_scorer)
-            }
+            (CombinationMethod::Required(should_scorer), None) => should_scorer,
             // Optional options are promoted to required if no must scorers exists.
             (CombinationMethod::Optional(should_scorer), None) => should_scorer,
         };


### PR DESCRIPTION
removes double wrapping by returning `SpecializedScorer` instead of `Box<dyn Scorer>`

closes https://github.com/quickwit-oss/tantivy/issues/2656

<img width="1086" alt="Screenshot 2025-07-01 at 14 44 43" src="https://github.com/user-attachments/assets/960db716-0c95-4df6-bdff-fb11769c5df5" />

