### PR TITLE
fix field_names in top_hits aggregation

### DIFF
--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -229,6 +229,7 @@ impl TopHitsAggregationReq {
         self.sort
             .iter()
             .map(|KeyOrder { field, .. }| field.as_str())
+            .chain(self.doc_value_fields.iter().map(|s| s.as_str()))
             .collect()
     }
 


### PR DESCRIPTION
required to be used in quickwit