### PR TITLE
per field size details

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Paul Masurel <paul.masurel@gmail.com>"]
 license = "MIT"
 categories = ["database-implementations", "data-structures"]

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -216,7 +216,7 @@ impl IndexBuilder {
 
     /// Opens or creates a new index in the provided directory
     pub fn open_or_create<T: Into<Box<dyn Directory>>>(self, dir: T) -> crate::Result<Index> {
-        let dir = dir.into();
+        let dir: Box<dyn Directory> = dir.into();
         if !Index::exists(&*dir)? {
             return self.create(dir);
         }
@@ -494,7 +494,7 @@ impl Index {
             .into_iter()
             .map(|segment| SegmentReader::open(&segment)?.fields_metadata())
             .collect::<Result<_, _>>()?;
-        Ok(merge_field_meta_data(fields_metadata, &self.schema()))
+        Ok(merge_field_meta_data(fields_metadata))
     }
 
     /// Creates a new segment_meta (Advanced user only).

--- a/src/index/inverted_index_reader.rs
+++ b/src/index/inverted_index_reader.rs
@@ -1,8 +1,7 @@
 use std::io;
 
 use common::json_path_writer::JSON_END_OF_PATH;
-use common::BinarySerializable;
-use fnv::FnvHashSet;
+use common::{BinarySerializable, ByteCount};
 #[cfg(feature = "quickwit")]
 use futures_util::{FutureExt, StreamExt, TryStreamExt};
 #[cfg(feature = "quickwit")]
@@ -34,6 +33,39 @@ pub struct InvertedIndexReader {
     positions_file_slice: FileSlice,
     record_option: IndexRecordOption,
     total_num_tokens: u64,
+}
+
+/// Object that records the amount of space used by a field in an inverted index.
+pub(crate) struct InvertedIndexFieldSpace {
+    pub field_name: String,
+    pub field_type: Type,
+    pub postings_size: ByteCount,
+    pub positions_size: ByteCount,
+    pub num_terms: u64,
+}
+
+impl InvertedIndexFieldSpace {
+    // Creates an empty FieldSpace object for a given term.
+    fn try_from(term: &[u8]) -> Option<InvertedIndexFieldSpace> {
+        let index = term.iter().position(|&byte| byte == JSON_END_OF_PATH)?;
+        let field_type_code = term.get(index + 1).copied()?;
+        let field_type = Type::from_code(field_type_code)?;
+        // Let's flush the current field.
+        let field_name = String::from_utf8_lossy(&term[..index]).to_string();
+        Some(InvertedIndexFieldSpace {
+            field_name,
+            field_type,
+            postings_size: ByteCount::default(),
+            positions_size: ByteCount::default(),
+            num_terms: 0u64,
+        })
+    }
+
+    fn record(&mut self, term_info: &TermInfo) {
+        self.postings_size += ByteCount::from(term_info.posting_num_bytes() as u64);
+        self.positions_size += ByteCount::from(term_info.positions_num_bytes() as u64);
+        self.num_terms += 1;
+    }
 }
 
 impl InvertedIndexReader {
@@ -81,19 +113,46 @@ impl InvertedIndexReader {
     ///
     /// Notice: This requires a full scan and therefore **very expensive**.
     /// TODO: Move to sstable to use the index.
-    pub fn list_encoded_fields(&self) -> io::Result<Vec<(String, Type)>> {
+    pub(crate) fn list_encoded_json_fields(&self) -> io::Result<Vec<InvertedIndexFieldSpace>> {
         let mut stream = self.termdict.stream()?;
-        let mut fields = Vec::new();
-        let mut fields_set = FnvHashSet::default();
-        while let Some((term, _term_info)) = stream.next() {
-            if let Some(index) = term.iter().position(|&byte| byte == JSON_END_OF_PATH) {
-                if !fields_set.contains(&term[..index + 2]) {
-                    fields_set.insert(term[..index + 2].to_vec());
-                    let typ = Type::from_code(term[index + 1]).unwrap();
-                    fields.push((String::from_utf8_lossy(&term[..index]).to_string(), typ));
+        let mut fields: Vec<InvertedIndexFieldSpace> = Vec::new();
+
+        let mut current_field_opt: Option<InvertedIndexFieldSpace> = None;
+        // Current field bytes, including the JSON_END_OF_PATH.
+        let mut current_field_bytes: Vec<u8> = Vec::new();
+
+        while let Some((term, term_info)) = stream.next() {
+            if let Some(current_field) = &mut current_field_opt {
+                if term.starts_with(&current_field_bytes) {
+                    // We are still in the same field.
+                    current_field.record(term_info);
+                    continue;
                 }
             }
+
+            // This is a new field!
+            // Let's flush the current field.
+            fields.extend(current_field_opt.take());
+            current_field_bytes.clear();
+
+            // And create a new one.
+            let Some(mut field_space) = InvertedIndexFieldSpace::try_from(term) else {
+                error!(
+                    "invalid term bytes encountered {term:?}. this only happens if the term \
+                     dictionary is corrupted. please report"
+                );
+                continue;
+            };
+            field_space.record(&term_info);
+
+            // We include the json type and the json end of path to make sure the prefix check
+            // is meaningful.
+            current_field_bytes.extend_from_slice(&term[..field_space.field_name.len() + 2]);
+            current_field_opt = Some(field_space);
         }
+
+        // We need to flush the last field as well.
+        fields.extend(current_field_opt.take());
 
         Ok(fields)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ mod macros;
 mod future_result;
 
 // Re-exports
-pub use common::DateTime;
+pub use common::{DateTime, ByteCount};
 pub use {columnar, query_grammar, time};
 
 pub use crate::error::TantivyError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ mod macros;
 mod future_result;
 
 // Re-exports
-pub use common::{DateTime, ByteCount};
+pub use common::{ByteCount, DateTime};
 pub use {columnar, query_grammar, time};
 
 pub use crate::error::TantivyError;


### PR DESCRIPTION
Added per-field size details.

This also does a bunch of refactoring.

merging field metadata does not silently asserts that arguments should be sorted.
merging does not set `stored`.

We do not rely on a hashmap to group fields, but instead rely on the fact that
the term dictionary is sorted.

The inverted level method that exposes field metadata is not exposed
as public anymore.