### PR TITLE
Refactor aggregation accessors

### DIFF
--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -303,13 +303,15 @@ impl SegmentAggregationCollector for SegmentHistogramCollector {
         let offset = self.offset;
         let get_bucket_pos = |val| (get_bucket_pos_f64(val, interval, offset) as i64);
 
+        let accessor = &bucket_agg_accessor.accessors[0].0;
+
         bucket_agg_accessor
             .column_block_accessor
-            .fetch_block(docs, &bucket_agg_accessor.accessor);
+            .fetch_block(docs, accessor);
 
         for (doc, val) in bucket_agg_accessor
             .column_block_accessor
-            .iter_docid_vals(docs, &bucket_agg_accessor.accessor)
+            .iter_docid_vals(docs, accessor)
         {
             let val = self.f64_from_fastfield_u64(val);
 

--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -231,13 +231,15 @@ impl SegmentAggregationCollector for SegmentRangeCollector {
     ) -> crate::Result<()> {
         let bucket_agg_accessor = &mut agg_with_accessor.aggs.values[self.accessor_idx];
 
+        let accessor = &bucket_agg_accessor.accessors[0].0;
+
         bucket_agg_accessor
             .column_block_accessor
-            .fetch_block(docs, &bucket_agg_accessor.accessor);
+            .fetch_block(docs, accessor);
 
         for (doc, val) in bucket_agg_accessor
             .column_block_accessor
-            .iter_docid_vals(docs, &bucket_agg_accessor.accessor)
+            .iter_docid_vals(docs, accessor)
         {
             let bucket_pos = self.get_bucket_pos(val);
 

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::{CustomOrder, Order, OrderTarget};
 use crate::aggregation::agg_limits::MemoryConsumption;
 use crate::aggregation::agg_req_with_accessor::{
-    AggregationWithAccessor, AggregationsWithAccessor, MissingTermCollection,
+    AggregationWithAccessor, AggregationsWithAccessor, TermMissingStrategy,
 };
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateBucketResult,
@@ -297,13 +297,13 @@ impl SegmentAggregationCollector for SegmentTermCollector {
 
         let accessor = &bucket_agg_accessor.accessors[0].0;
 
-        if let MissingTermCollection::Inline {
-            missing_value_for_accessor,
-        } = bucket_agg_accessor.missing_term_collection
+        if let TermMissingStrategy::Inline {
+            placeholder_fast_representation,
+        } = bucket_agg_accessor.term_missing_strategy
         {
             bucket_agg_accessor
                 .column_block_accessor
-                .fetch_block_with_missing(docs, accessor, missing_value_for_accessor);
+                .fetch_block_with_missing(docs, accessor, placeholder_fast_representation);
         } else {
             bucket_agg_accessor
                 .column_block_accessor

--- a/src/aggregation/bucket/term_missing_agg.rs
+++ b/src/aggregation/bucket/term_missing_agg.rs
@@ -10,13 +10,16 @@ use crate::aggregation::segment_agg_result::{
 };
 
 /// The specialized missing term aggregation.
+///
+/// This is instantited by term aggregations when the missing terms cannot be
+/// injected to the term collector (multiple columns or different type).
 #[derive(Default, Debug, Clone)]
-pub struct TermMissingAgg {
+pub struct SegmentTermMissingCollector {
     missing_count: u32,
     accessor_idx: usize,
     sub_agg: Option<Box<dyn SegmentAggregationCollector>>,
 }
-impl TermMissingAgg {
+impl SegmentTermMissingCollector {
     pub(crate) fn new(
         accessor_idx: usize,
         sub_aggregations: &mut AggregationsWithAccessor,
@@ -37,7 +40,7 @@ impl TermMissingAgg {
     }
 }
 
-impl SegmentAggregationCollector for TermMissingAgg {
+impl SegmentAggregationCollector for SegmentTermMissingCollector {
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
         agg_with_accessor: &AggregationsWithAccessor,

--- a/src/aggregation/metric/cardinality.rs
+++ b/src/aggregation/metric/cardinality.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 
 use crate::aggregation::agg_req_with_accessor::{
-    AggregationWithAccessor, AggregationsWithAccessor, MissingTermCollection,
+    AggregationWithAccessor, AggregationsWithAccessor, TermMissingStrategy,
 };
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
@@ -137,14 +137,14 @@ impl SegmentCardinalityCollector {
         agg_accessor: &mut AggregationWithAccessor,
     ) {
         let accessor = &agg_accessor.accessors[0].0;
-        if let MissingTermCollection::Inline {
-            missing_value_for_accessor,
-        } = agg_accessor.missing_term_collection
+        if let TermMissingStrategy::Inline {
+            placeholder_fast_representation,
+        } = agg_accessor.term_missing_strategy
         {
             agg_accessor.column_block_accessor.fetch_block_with_missing(
                 docs,
                 accessor,
-                missing_value_for_accessor,
+                placeholder_fast_representation,
             );
         } else {
             agg_accessor

--- a/src/aggregation/metric/extended_stats.rs
+++ b/src/aggregation/metric/extended_stats.rs
@@ -350,16 +350,15 @@ impl SegmentExtendedStatsCollector {
         docs: &[DocId],
         agg_accessor: &mut AggregationWithAccessor,
     ) {
+        let accessor = &agg_accessor.accessors[0].0;
         if let Some(missing) = self.missing.as_ref() {
-            agg_accessor.column_block_accessor.fetch_block_with_missing(
-                docs,
-                &agg_accessor.accessor,
-                *missing,
-            );
+            agg_accessor
+                .column_block_accessor
+                .fetch_block_with_missing(docs, accessor, *missing);
         } else {
             agg_accessor
                 .column_block_accessor
-                .fetch_block(docs, &agg_accessor.accessor);
+                .fetch_block(docs, accessor);
         }
         for val in agg_accessor.column_block_accessor.iter_vals() {
             let val1 = f64_from_fastfield_u64(val, &self.field_type);
@@ -392,7 +391,7 @@ impl SegmentAggregationCollector for SegmentExtendedStatsCollector {
         doc: crate::DocId,
         agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()> {
-        let field = &agg_with_accessor.aggs.values[self.accessor_idx].accessor;
+        let field = &agg_with_accessor.aggs.values[self.accessor_idx].accessors[0].0;
         if let Some(missing) = self.missing {
             let mut has_val = false;
             for val in field.values_for_doc(doc) {

--- a/src/aggregation/metric/percentiles.rs
+++ b/src/aggregation/metric/percentiles.rs
@@ -254,16 +254,15 @@ impl SegmentPercentilesCollector {
         docs: &[DocId],
         agg_accessor: &mut AggregationWithAccessor,
     ) {
+        let accessor = &agg_accessor.accessors[0].0;
         if let Some(missing) = self.missing.as_ref() {
-            agg_accessor.column_block_accessor.fetch_block_with_missing(
-                docs,
-                &agg_accessor.accessor,
-                *missing,
-            );
+            agg_accessor
+                .column_block_accessor
+                .fetch_block_with_missing(docs, accessor, *missing);
         } else {
             agg_accessor
                 .column_block_accessor
-                .fetch_block(docs, &agg_accessor.accessor);
+                .fetch_block(docs, accessor);
         }
 
         for val in agg_accessor.column_block_accessor.iter_vals() {
@@ -297,7 +296,7 @@ impl SegmentAggregationCollector for SegmentPercentilesCollector {
         doc: crate::DocId,
         agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()> {
-        let field = &agg_with_accessor.aggs.values[self.accessor_idx].accessor;
+        let field = &agg_with_accessor.aggs.values[self.accessor_idx].accessors[0].0;
 
         if let Some(missing) = self.missing {
             let mut has_val = false;

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -209,16 +209,15 @@ impl SegmentStatsCollector {
         docs: &[DocId],
         agg_accessor: &mut AggregationWithAccessor,
     ) {
+        let accessor = &agg_accessor.accessors[0].0;
         if let Some(missing) = self.missing.as_ref() {
-            agg_accessor.column_block_accessor.fetch_block_with_missing(
-                docs,
-                &agg_accessor.accessor,
-                *missing,
-            );
+            agg_accessor
+                .column_block_accessor
+                .fetch_block_with_missing(docs, accessor, *missing);
         } else {
             agg_accessor
                 .column_block_accessor
-                .fetch_block(docs, &agg_accessor.accessor);
+                .fetch_block(docs, accessor);
         }
         if [
             ColumnType::I64,
@@ -283,7 +282,7 @@ impl SegmentAggregationCollector for SegmentStatsCollector {
         doc: crate::DocId,
         agg_with_accessor: &mut AggregationsWithAccessor,
     ) -> crate::Result<()> {
-        let field = &agg_with_accessor.aggs.values[self.accessor_idx].accessor;
+        let field = &agg_with_accessor.aggs.values[self.accessor_idx].accessors[0].0;
         if let Some(missing) = self.missing {
             let mut has_val = false;
             for val in field.values_for_doc(doc) {

--- a/src/aggregation/segment_agg_result.rs
+++ b/src/aggregation/segment_agg_result.rs
@@ -15,7 +15,7 @@ use super::metric::{
     SegmentPercentilesCollector, SegmentStatsCollector, SegmentStatsType, StatsAggregation,
     SumAggregation,
 };
-use crate::aggregation::agg_req_with_accessor::MissingTermCollection;
+use crate::aggregation::agg_req_with_accessor::TermMissingStrategy;
 use crate::aggregation::bucket::SegmentTermMissingCollector;
 use crate::aggregation::metric::{
     CardinalityAggregationReq, SegmentCardinalityCollector, SegmentExtendedStatsCollector,
@@ -87,7 +87,7 @@ pub(crate) fn build_single_agg_segment_collector(
     use AggregationVariants::*;
     match &req.agg.agg {
         Terms(terms_req) => {
-            if let MissingTermCollection::TermMissingCollector = req.missing_term_collection {
+            if let TermMissingStrategy::ExternalCollector = req.term_missing_strategy {
                 Ok(Box::new(SegmentTermMissingCollector::new(
                     accessor_idx,
                     &mut req.sub_aggregation,


### PR DESCRIPTION
This PR is a refactoring of AggregationWithAccessor to streamline the way accessors are defined and missing values are configured. Some comments were already present in the code about the necessity of this refactoring.

The approach is to make the coupling between AggregationWithAccessor and the collectors more explicit without changing the existing logic.

This refactoring is the first step of a broader effort aiming at adding a new bucket aggregation called composite aggregations (https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-composite-aggregation)