### PR TITLE
test: Expand boolean query proptest size

### DIFF
--- a/src/query/boolean_query/mod.rs
+++ b/src/query/boolean_query/mod.rs
@@ -375,7 +375,16 @@ mod proptest_boolean_query {
         }
     }
 
-    fn create_index_with_boolean_permutations(num_fields: usize) -> (Index, Vec<Field>) {
+    fn doc_ids(num_docs: usize, num_fields: usize) -> impl Iterator<Item = DocId> {
+        let permutations = 1 << num_fields;
+        let copies = (num_docs as f32 / permutations as f32).ceil() as u32;
+        (0..(permutations * copies)).into_iter()
+    }
+
+    fn create_index_with_boolean_permutations(
+        num_docs: usize,
+        num_fields: usize,
+    ) -> (Index, Vec<Field>) {
         let mut schema_builder = Schema::builder();
         let fields: Vec<Field> = (0..num_fields)
             .map(|i| schema_builder.add_text_field(&format!("field_{}", i), TEXT))
@@ -384,10 +393,10 @@ mod proptest_boolean_query {
         let index = Index::create_in_ram(schema);
         let mut writer = index.writer_for_tests().unwrap();
 
-        for doc_id in 0..(1 << num_fields) {
+        for doc_id in doc_ids(num_docs, num_fields) {
             let mut doc: BTreeMap<_, OwnedValue> = BTreeMap::default();
             for (field_idx, &field) in fields.iter().enumerate() {
-                if (doc_id >> field_idx) & 1 == 1 {
+                if BooleanQueryAST::matches_field(doc_id, field_idx) {
                     doc.insert(field, "true".into());
                 }
             }
@@ -414,14 +423,15 @@ mod proptest_boolean_query {
 
     #[test]
     fn proptest_boolean_query() {
+        let num_docs = 10000;
         let num_fields = 8;
-        let (index, fields) = create_index_with_boolean_permutations(num_fields);
+        let (index, fields) = create_index_with_boolean_permutations(num_docs, num_fields);
         let searcher = index.reader().unwrap().searcher();
         proptest!(|(ast in arb_boolean_query_ast(num_fields))| {
             let query = ast.to_query(&fields);
 
             let mut matching_docs = HashSet::new();
-            for doc_id in 0..(1 << num_fields) {
+            for doc_id in doc_ids(num_docs, num_fields) {
                 if ast.matches(doc_id as DocId) {
                     matching_docs.insert(doc_id as DocId);
                 }


### PR DESCRIPTION
Re-reading https://github.com/quickwit-oss/tantivy/pull/2538, I noticed that the proptest's total document count was not large enough to exercise some of the constants -- for example, the buffered union `HORIZON` value.

Increasing the total document count (by repeating all unique permutations more times to reach a target size) exposes a failure which minimizes to:
```
Intersection(
    [
        Leaf {
            field_idx: 0,
        },
        Union(
            [
                Leaf {
                    field_idx: 2,
                },
                Leaf {
                    field_idx: 2,
                },
            ],
        ),
    ],
)
```

in:
```
   0: __rustc::rust_begin_unwind
             at /rustc/d7ea436a02d5de4033fcf7fd4eb8ed965d0f574c/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/d7ea436a02d5de4033fcf7fd4eb8ed965d0f574c/library/core/src/panicking.rs:75:14
   2: core::panicking::panic_const::panic_const_sub_overflow
             at /rustc/d7ea436a02d5de4033fcf7fd4eb8ed965d0f574c/library/core/src/panicking.rs:178:21
   3: tantivy::query::union::buffered_union::BufferedUnionScorer<TScorer,TScoreCombiner>::is_in_horizon
             at ./src/query/union/buffered_union.rs:128:19
   4: <tantivy::query::union::buffered_union::BufferedUnionScorer<TScorer,TScoreCombiner> as tantivy::docset::DocSet>::seek_into_the_danger_zone
             at ./src/query/union/buffered_union.rs:206:12
   5: <alloc::boxed::Box<TDocSet> as tantivy::docset::DocSet>::seek_into_the_danger_zone
             at ./src/docset.rs:216:9
   6: <tantivy::query::intersection::Intersection<TDocSet,TOtherDocSet> as tantivy::docset::DocSet>::advance
             at ./src/query/intersection.rs:118:20
   7: tantivy::docset::DocSet::fill_buffer
             at ./src/docset.rs:102:16
   8: tantivy::query::weight::for_each_docset_buffered
             at ./src/query/weight.rs:29:25
   9: <tantivy::query::boolean_query::boolean_weight::BooleanWeight<TScoreCombiner> as tantivy::query::weight::Weight>::for_each_no_score
             at ./src/query/boolean_query/boolean_weight.rs:343:17
  10: tantivy::collector::Collector::collect_segment
             at ./src/collector/mod.rs:198:17
  11: tantivy::core::searcher::Searcher::search_with_executor::{{closure}}
             at ./src/core/searcher.rs:231:17
```