### PR TITLE
perf: deduplicate queries

### DIFF
--- a/query-grammar/Cargo.toml
+++ b/query-grammar/Cargo.toml
@@ -15,3 +15,5 @@ edition = "2024"
 nom = "7"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+ordered-float = "5.0.0"
+fnv = "1.0.7"

--- a/query-grammar/src/lib.rs
+++ b/query-grammar/src/lib.rs
@@ -31,11 +31,11 @@ pub fn parse_query_lenient(query: &str) -> (UserInputAst, Vec<LenientError>) {
 
 #[cfg(test)]
 mod tests {
-    use crate::{parse_query, parse_query_lenient};
+    use crate::{UserInputAst, parse_query, parse_query_lenient};
 
     #[test]
     fn test_deduplication() {
-        let ast = parse_query("a a").unwrap();
+        let ast: UserInputAst = parse_query("a a").unwrap();
         let json = serde_json::to_string(&ast).unwrap();
         assert_eq!(
             json,

--- a/query-grammar/src/lib.rs
+++ b/query-grammar/src/lib.rs
@@ -34,6 +34,16 @@ mod tests {
     use crate::{parse_query, parse_query_lenient};
 
     #[test]
+    fn test_deduplication() {
+        let ast = parse_query("a a").unwrap();
+        let json = serde_json::to_string(&ast).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"bool","clauses":[[null,{"type":"literal","field_name":null,"phrase":"a","delimiter":"none","slop":0,"prefix":false}]]}"#
+        );
+    }
+
+    #[test]
     fn test_parse_query_serialization() {
         let ast = parse_query("title:hello OR title:x").unwrap();
         let json = serde_json::to_string(&ast).unwrap();

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -104,7 +104,7 @@ mod tests {
             let query = query_parser.parse_query("a a a a a").unwrap();
             let mut terms = Vec::new();
             query.query_terms(&mut |term, pos| terms.push((term, pos)));
-            assert_eq!(vec![(&term_a, false); 5], terms);
+            assert_eq!(vec![(&term_a, false); 1], terms);
         }
         {
             let query = query_parser.parse_query("a -b").unwrap();

--- a/src/query/query_parser/logical_ast.rs
+++ b/src/query/query_parser/logical_ast.rs
@@ -45,6 +45,7 @@ impl LogicalAst {
         }
     }
 
+    // TODO: Move to rewrite_ast in query_grammar
     pub fn simplify(self) -> LogicalAst {
         match self {
             LogicalAst::Clause(clauses) => {

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -672,7 +672,7 @@ impl QueryParser {
             }
             UserInputAst::Boost(ast, boost) => {
                 let (ast, errors) = self.compute_logical_ast_with_occur_lenient(*ast);
-                (ast.boost(boost as Score), errors)
+                (ast.boost(boost.into_inner() as Score), errors)
             }
             UserInputAst::Leaf(leaf) => {
                 let (ast, errors) = self.compute_logical_ast_from_leaf_lenient(*leaf);
@@ -2047,6 +2047,16 @@ mod test {
         assert_matches!(
             query_parser.parse_query("abc"),
             Err(QueryParserError::ExpectedInt(_))
+        );
+    }
+
+    #[test]
+    pub fn test_deduplication() {
+        let query = "be be";
+        test_parse_query_to_logical_ast_helper(
+            query,
+            "(Term(field=0, type=Str, \"be\") Term(field=1, type=Str, \"be\"))",
+            false,
         );
     }
 


### PR DESCRIPTION
Currently we may waste performance by executing the same query multiple times. This PR deduplicates duplicate queries in `UserInputAst` after parsing. 

e.g. 
`a a a ` is equal to `a`
`to be or not to be` is equal to `to be or not`

<img width="1003" height="482" alt="Screenshot 2025-09-19 at 11 09 33" src="https://github.com/user-attachments/assets/aaaa097b-12a3-44c2-9da2-31a2d4fe6fee" />
