### PR TITLE
feat: add range (= max - min) into stats

### DIFF
--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -1199,6 +1199,7 @@ mod tests {
                     "count": 0,
                     "min": Value::Null,
                     "max": Value::Null,
+                    "range": Value::Null,
                     "avg": Value::Null,
                 }
             })


### PR DESCRIPTION
I found this is useful when querying something like duration or timespan.